### PR TITLE
ci: enable E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,62 +68,58 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
 
+  test-e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
 
-  # E2E tests require a running merod node with the X-Auth-Error header fix.
-  # Uncomment after the next core release.
-  #   test-e2e:
-  #     name: E2E Tests
-  #     runs-on: ubuntu-latest
-  #     needs: build
-  #     timeout-minutes: 10
-  #     steps:
-  #       - uses: actions/checkout@v4
-  #       - uses: pnpm/action-setup@v4
-  #       - uses: actions/setup-node@v4
-  #         with:
-  #           node-version: ${{ env.NODE_VERSION }}
-  #           cache: 'pnpm'
-  #       - run: pnpm install --frozen-lockfile
-  #       - run: pnpm build
-  # 
-  #       - name: Start merod node
-  #         run: |
-  #           # Get merod from Docker image
-  #           docker pull ghcr.io/calimero-network/merod:prerelease
-  #           docker create --name merod-bin ghcr.io/calimero-network/merod:prerelease
-  #           docker cp merod-bin:/usr/local/bin/merod ./merod
-  #           docker rm merod-bin
-  #           chmod +x ./merod
-  # 
-  #           # Init + start
-  #           ./merod --home ./e2e-node --node e2e init \
-  #             --server-port 4001 --swarm-port 4002 --auth-mode embedded 2>&1 || true
-  #           RUST_LOG=warn ./merod --home ./e2e-node --node e2e run &
-  #           echo $! > merod.pid
-  # 
-  #           # Wait for ready
-  #           for i in $(seq 1 30); do
-  #             curl -sf http://localhost:4001/admin-api/health >/dev/null 2>&1 && break
-  #             sleep 1
-  #           done
-  #           curl -sf http://localhost:4001/admin-api/health || exit 1
-  # 
-  #           # Install test app bundle (committed in tests/e2e/assets/)
-  #           TOKEN=$(curl -sf http://localhost:4001/auth/token \
-  #             -H "Content-Type: application/json" \
-  #             -d "{\"auth_method\":\"user_password\",\"public_key\":\"dev\",\"client_name\":\"http://localhost:4001\",\"timestamp\":$(date +%s),\"provider_data\":{\"username\":\"dev\",\"password\":\"dev\"}}" \
-  #             | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['access_token'])")
-  #           curl -sf http://localhost:4001/admin-api/install-dev-application \
-  #             -H "Authorization: Bearer $TOKEN" \
-  #             -H "Content-Type: application/json" \
-  #             -d "{\"path\":\"$(pwd)/tests/e2e/assets/kv-store.mpk\",\"metadata\":[]}"
-  #           echo "Node ready with test app"
-  # 
-  #       - name: Run E2E tests
-  #         run: npx vitest run --config vitest.e2e.config.ts tests/e2e/full-api.test.ts
-  #         env:
-  #           NODE_URL: http://localhost:4001
-  # 
-  #       - name: Stop node
-  #         if: always()
-  #         run: kill $(cat merod.pid) 2>/dev/null || true
+      - name: Start merod node
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DOWNLOAD_URL=$(gh release view --repo calimero-network/core --json assets -q '.assets[] | select(.name | test("merod_x86_64.*linux.*tar.gz")) | .browser_download_url' 2>/dev/null)
+          if [ -z "$DOWNLOAD_URL" ]; then
+            DOWNLOAD_URL=$(gh release list --repo calimero-network/core --limit 1 --json tagName -q '.[0].tagName' | xargs -I{} gh release view {} --repo calimero-network/core --json assets -q '.assets[] | select(.name | test("merod_x86_64.*linux.*tar.gz")) | .browser_download_url')
+          fi
+          curl -sL "$DOWNLOAD_URL" | tar xz
+          chmod +x ./merod
+
+          ./merod --home ./e2e-node --node e2e init \
+            --server-port 4001 --swarm-port 4002 --auth-mode embedded 2>&1 || true
+          RUST_LOG=warn ./merod --home ./e2e-node --node e2e run &
+          echo $! > merod.pid
+
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:4001/admin-api/health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          curl -sf http://localhost:4001/admin-api/health || exit 1
+
+          TOKEN=$(curl -sf http://localhost:4001/auth/token \
+            -H "Content-Type: application/json" \
+            -d "{\"auth_method\":\"user_password\",\"public_key\":\"dev\",\"client_name\":\"http://localhost:4001\",\"timestamp\":$(date +%s),\"provider_data\":{\"username\":\"dev\",\"password\":\"dev\"}}" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['data']['access_token'])")
+          curl -sf http://localhost:4001/admin-api/install-dev-application \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"path\":\"$(pwd)/tests/e2e/assets/kv-store.mpk\",\"metadata\":[]}"
+          echo "Node ready with test app"
+
+      - name: Run E2E tests
+        run: npx vitest run --config vitest.e2e.config.ts tests/e2e/full-api.test.ts
+        env:
+          NODE_URL: http://localhost:4001
+
+      - name: Stop node
+        if: always()
+        run: kill $(cat merod.pid) 2>/dev/null || true


### PR DESCRIPTION
## Summary

Uncomments the E2E test job in CI. Requires merod `>= 0.10.1-rc.14` (Docker image `ghcr.io/calimero-network/merod:prerelease`) which includes the `X-Auth-Error: token_expired` header fix.

**Do not merge until rc14 is released.**

## What the E2E job does

1. Pulls merod from Docker image
2. Inits + starts a local node with embedded auth
3. Installs the kv-store test app bundle (committed fixture)
4. Runs 29 E2E tests: auth, applications, contexts, RPC, SSE, token management

## Test coverage

- Authentication (login, bad credentials, providers, health)
- Applications (list, get, package version)
- Contexts (create, list, get, identities, identities-owned)
- JSON-RPC (read, write, remove, error handling)
- SSE (connect, subscribe, event on mutation)
- Auth helpers (parseAuthCallback, buildAuthLoginUrl)
- Token management (get, set, clear)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CI job that downloads and runs an external `merod` binary and executes full E2E tests, which increases CI flakiness risk (network/download/boot timing) and can fail due to upstream release changes.
> 
> **Overview**
> Enables a new **E2E Tests** GitHub Actions job that runs after `build` and executes Vitest E2E coverage against a locally started `merod` node.
> 
> The workflow now downloads the latest `merod` Linux tarball from `calimero-network/core` GitHub Releases, initializes and starts a node, installs the `tests/e2e/assets/kv-store.mpk` fixture app via the admin API, runs `tests/e2e/full-api.test.ts`, and always stops the node afterward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd70af45a3e3a77787dd8c411680188a3729eb94. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->