### PR TITLE
feat: add group admin API parity

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -5,9 +5,14 @@ import { HttpClient } from '../http-client';
 // Mock HttpClient that stores expected responses by "METHOD /path"
 class MockHttpClient implements HttpClient {
   private mockResponses = new Map<string, unknown>();
+  private requestBodies = new Map<string, unknown>();
 
   setMockResponse(method: string, path: string, response: unknown) {
     this.mockResponses.set(`${method} ${path}`, response);
+  }
+
+  getRequestBody(method: string, path: string): unknown {
+    return this.requestBodies.get(`${method} ${path}`);
   }
 
   private getResponse(method: string, path: string): unknown {
@@ -20,14 +25,31 @@ class MockHttpClient implements HttpClient {
   }
 
   async get<T>(path: string): Promise<T> { return this.getResponse('GET', path) as T; }
-  async post<T>(path: string, _body?: unknown): Promise<T> { return this.getResponse('POST', path) as T; }
-  async put<T>(path: string, _body?: unknown): Promise<T> { return this.getResponse('PUT', path) as T; }
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`POST ${path}`, body);
+    return this.getResponse('POST', path) as T;
+  }
+  async put<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`PUT ${path}`, body);
+    return this.getResponse('PUT', path) as T;
+  }
   async delete<T>(path: string): Promise<T> { return this.getResponse('DELETE', path) as T; }
-  async patch<T>(path: string, _body?: unknown): Promise<T> { return this.getResponse('PATCH', path) as T; }
+  async patch<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`PATCH ${path}`, body);
+    return this.getResponse('PATCH', path) as T;
+  }
   async head(_path: string): Promise<{ headers: Record<string, string>; status: number }> {
     return { headers: {}, status: 200 };
   }
-  async request<T>(): Promise<T> { throw new Error('Not implemented'); }
+  async request<T>(path: string, init?: { method?: string; body?: unknown }): Promise<T> {
+    const method = init?.method ?? 'GET';
+    let body = init?.body;
+    if (typeof body === 'string') {
+      body = JSON.parse(body);
+    }
+    this.requestBodies.set(`${method} ${path}`, body);
+    return this.getResponse(method, path) as T;
+  }
 }
 
 describe('AdminApiClient', () => {
@@ -213,6 +235,160 @@ describe('AdminApiClient', () => {
       mock.setMockResponse('GET', '/admin-api/peers', { count: 3 });
       const result = await client.getPeersCount();
       expect(result).toEqual({ count: 3 });
+    });
+  });
+
+  describe('Group Management', () => {
+    it('listGroups unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups', {
+        data: [{ groupId: 'group-1', appKey: 'app-key-1', targetApplicationId: 'app-1', upgradePolicy: 'manual', createdAt: 123 }],
+      });
+      const result = await client.listGroups();
+      expect(result).toEqual([
+        {
+          groupId: 'group-1',
+          appKey: 'app-key-1',
+          targetApplicationId: 'app-1',
+          upgradePolicy: 'manual',
+          createdAt: 123,
+        },
+      ]);
+    });
+
+    it('createGroup posts to correct path and unwraps data', async () => {
+      const request = { applicationId: 'app-1', upgradePolicy: 'manual', alias: 'Lobby' };
+      mock.setMockResponse('POST', '/admin-api/groups', { data: { groupId: 'group-1' } });
+      const result = await client.createGroup(request);
+      expect(result).toEqual({ groupId: 'group-1' });
+      expect(mock.getRequestBody('POST', '/admin-api/groups')).toEqual(request);
+    });
+
+    it('getGroupInfo unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1', {
+        data: {
+          groupId: 'group-1',
+          appKey: 'app-key-1',
+          targetApplicationId: 'app-1',
+          upgradePolicy: 'manual',
+          memberCount: 2,
+          contextCount: 1,
+          defaultCapabilities: 7,
+          defaultVisibility: 'Members',
+        },
+      });
+      const result = await client.getGroupInfo('group-1');
+      expect(result.memberCount).toBe(2);
+    });
+
+    it('deleteGroup sends an empty delete body and unwraps data', async () => {
+      mock.setMockResponse('DELETE', '/admin-api/groups/group-1', { data: { isDeleted: true } });
+      const result = await client.deleteGroup('group-1');
+      expect(result).toEqual({ isDeleted: true });
+      expect(mock.getRequestBody('DELETE', '/admin-api/groups/group-1')).toEqual({});
+    });
+
+    it('listGroupMembers preserves self identity metadata', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/members', {
+        data: [{ identity: 'member-1', role: 'Member' }],
+        selfIdentity: 'self-1',
+      });
+      const result = await client.listGroupMembers('group-1');
+      expect(result).toEqual({
+        data: [{ identity: 'member-1', role: 'Member' }],
+        selfIdentity: 'self-1',
+      });
+    });
+
+    it('addGroupMembers posts members payload', async () => {
+      const request = { members: [{ identity: 'member-1', role: 'Admin' }] };
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/members', { data: null });
+      const result = await client.addGroupMembers('group-1', request);
+      expect(result).toBeNull();
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/members')).toEqual(request);
+    });
+
+    it('removeGroupMembers posts remove payload', async () => {
+      const request = { members: ['member-1'] };
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/members/remove', { data: null });
+      const result = await client.removeGroupMembers('group-1', request);
+      expect(result).toBeNull();
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/members/remove')).toEqual(request);
+    });
+
+    it('listGroupContexts unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/contexts', {
+        data: [{ contextId: 'ctx-1' }],
+      });
+      const result = await client.listGroupContexts('group-1');
+      expect(result).toEqual([{ contextId: 'ctx-1' }]);
+    });
+
+    it('joinGroupContext posts context id and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/join-context', {
+        data: { contextId: 'ctx-1', memberPublicKey: 'pk-1' },
+      });
+      const result = await client.joinGroupContext('group-1', 'ctx-1');
+      expect(result).toEqual({ contextId: 'ctx-1', memberPublicKey: 'pk-1' });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/join-context')).toEqual({
+        contextId: 'ctx-1',
+      });
+    });
+
+    it('createGroupInvitation posts empty body and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/invite', {
+        data: {
+          invitation: {
+            invitation: {
+              inviter_identity: new Array(32).fill(0),
+              group_id: new Array(32).fill(0),
+              expiration_timestamp: 123,
+            },
+            inviter_signature: 'sig-1',
+          },
+        },
+      });
+      const result = await client.createGroupInvitation('group-1');
+      expect(result.invitation.inviter_signature).toBe('sig-1');
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/invite')).toEqual({});
+    });
+
+    it('joinGroup posts invitation payload and unwraps data', async () => {
+      const request = {
+        invitation: {
+          invitation: {
+            inviter_identity: new Array(32).fill(0),
+            group_id: new Array(32).fill(0),
+            expiration_timestamp: 123,
+          },
+          inviter_signature: 'sig-1',
+        },
+        groupAlias: 'Lobby',
+      };
+      mock.setMockResponse('POST', '/admin-api/groups/join', {
+        data: { groupId: 'group-1', memberIdentity: 'member-2' },
+      });
+      const result = await client.joinGroup(request);
+      expect(result).toEqual({ groupId: 'group-1', memberIdentity: 'member-2' });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/join')).toEqual(request);
+    });
+
+    it('setMemberCapabilities puts capabilities payload', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/members/member-1/capabilities', {
+        data: null,
+      });
+      const result = await client.setMemberCapabilities('group-1', 'member-1', 7);
+      expect(result).toBeNull();
+      expect(
+        mock.getRequestBody('PUT', '/admin-api/groups/group-1/members/member-1/capabilities'),
+      ).toEqual({ capabilities: 7 });
+    });
+
+    it('getMemberCapabilities unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/members/member-1/capabilities', {
+        data: { capabilities: 7 },
+      });
+      const result = await client.getMemberCapabilities('group-1', 'member-1');
+      expect(result).toEqual({ capabilities: 7 });
     });
   });
 });

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -171,16 +171,60 @@ describe('AdminApiClient', () => {
   });
 
   describe('Context Invite / Join', () => {
-    it('inviteToContext unwraps data', async () => {
-      mock.setMockResponse('POST', '/admin-api/contexts/invite', { data: { invitation: 'xyz' } });
+    it('inviteToContext returns typed SignedOpenInvitation', async () => {
+      const invitation = {
+        invitation: { inviter_identity: 'id-1', context_id: 'ctx-1', expiration_timestamp: 123, secret_salt: [0] },
+        inviter_signature: 'sig-1',
+      };
+      mock.setMockResponse('POST', '/admin-api/contexts/invite', { data: invitation });
       const result = await client.inviteToContext({ contextId: 'ctx-1', inviterId: 'id-1', validForSeconds: 3600 });
-      expect(result).toEqual({ invitation: 'xyz' });
+      expect(result).toEqual(invitation);
+    });
+
+    it('inviteToContext returns null when no invitation', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/invite', { data: null });
+      const result = await client.inviteToContext({ contextId: 'ctx-1', inviterId: 'id-1', validForSeconds: 3600 });
+      expect(result).toBeNull();
     });
 
     it('joinContext unwraps data', async () => {
+      const invitation = {
+        invitation: { inviter_identity: 'id-1', context_id: 'ctx-1', expiration_timestamp: 123, secret_salt: [0] },
+        inviter_signature: 'sig-1',
+      };
       mock.setMockResponse('POST', '/admin-api/contexts/join', { data: { contextId: 'ctx-1', memberPublicKey: 'pk-1' } });
-      const result = await client.joinContext({ invitation: {}, newMemberPublicKey: 'pk-1' });
+      const result = await client.joinContext({ invitation, newMemberPublicKey: 'pk-1' });
       expect(result).toEqual({ contextId: 'ctx-1', memberPublicKey: 'pk-1' });
+    });
+
+    it('getContextGroup returns group id', async () => {
+      mock.setMockResponse('GET', '/admin-api/contexts/ctx-1/group', { data: 'abcdef0123456789' });
+      const result = await client.getContextGroup('ctx-1');
+      expect(result).toBe('abcdef0123456789');
+    });
+
+    it('getContextGroup returns null when no group', async () => {
+      mock.setMockResponse('GET', '/admin-api/contexts/ctx-1/group', { data: null });
+      const result = await client.getContextGroup('ctx-1');
+      expect(result).toBeNull();
+    });
+
+    it('getContextStorageSize unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/contexts/ctx-1/storage', { data: { sizeInBytes: 1024 } });
+      const result = await client.getContextStorageSize('ctx-1');
+      expect(result).toEqual({ sizeInBytes: 1024 });
+    });
+
+    it('syncContext posts to correct path', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/sync/ctx-1', { data: null });
+      await client.syncContext('ctx-1');
+      expect(mock.getRequestBody('POST', '/admin-api/contexts/sync/ctx-1')).toEqual({});
+    });
+
+    it('syncAllContexts posts to correct path', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/sync', { data: null });
+      await client.syncAllContexts();
+      expect(mock.getRequestBody('POST', '/admin-api/contexts/sync')).toEqual({});
     });
   });
 
@@ -389,6 +433,127 @@ describe('AdminApiClient', () => {
       });
       const result = await client.getMemberCapabilities('group-1', 'member-1');
       expect(result).toEqual({ capabilities: 7 });
+    });
+  });
+
+  describe('Group Governance / Settings', () => {
+    it('setDefaultCapabilities sends PUT with body', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/settings/default-capabilities', { data: null });
+      await client.setDefaultCapabilities('group-1', { defaultCapabilities: 3 });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/settings/default-capabilities')).toEqual({ defaultCapabilities: 3 });
+    });
+
+    it('setDefaultVisibility sends PUT with body', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/settings/default-visibility', { data: null });
+      await client.setDefaultVisibility('group-1', { defaultVisibility: 'open' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/settings/default-visibility')).toEqual({ defaultVisibility: 'open' });
+    });
+
+    it('getContextVisibility unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/contexts/ctx-1/visibility', {
+        data: { mode: 'open', creator: 'member-1' },
+      });
+      const result = await client.getContextVisibility('group-1', 'ctx-1');
+      expect(result).toEqual({ mode: 'open', creator: 'member-1' });
+    });
+
+    it('setContextVisibility sends PUT with body', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/contexts/ctx-1/visibility', { data: null });
+      await client.setContextVisibility('group-1', 'ctx-1', { mode: 'restricted' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/contexts/ctx-1/visibility')).toEqual({ mode: 'restricted' });
+    });
+
+    it('getContextAllowlist unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/contexts/ctx-1/allowlist', {
+        data: ['member-1', 'member-2'],
+      });
+      const result = await client.getContextAllowlist('group-1', 'ctx-1');
+      expect(result).toEqual(['member-1', 'member-2']);
+    });
+
+    it('updateContextAllowlist sends POST with add/remove', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/contexts/ctx-1/allowlist', { data: null });
+      await client.updateContextAllowlist('group-1', 'ctx-1', { add: ['member-3'], remove: ['member-1'] });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/contexts/ctx-1/allowlist')).toEqual({
+        add: ['member-3'],
+        remove: ['member-1'],
+      });
+    });
+
+    it('updateMemberRole sends PUT with role', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/members/member-1/role', { data: null });
+      await client.updateMemberRole('group-1', 'member-1', { role: 'Admin' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/members/member-1/role')).toEqual({ role: 'Admin' });
+    });
+  });
+
+  describe('Group Upgrade', () => {
+    it('upgradeGroup posts request and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/upgrade', {
+        data: { groupId: 'group-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+      });
+      const result = await client.upgradeGroup('group-1', { targetApplicationId: 'app-2' });
+      expect(result.status).toBe('in_progress');
+    });
+
+    it('getGroupUpgradeStatus unwraps data', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/upgrade/status', {
+        data: { groupId: 'group-1', status: 'completed', total: 3, completed: 3, failed: 0 },
+      });
+      const result = await client.getGroupUpgradeStatus('group-1');
+      expect(result?.status).toBe('completed');
+    });
+
+    it('getGroupUpgradeStatus returns null when no upgrade', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/group-1/upgrade/status', { data: null });
+      const result = await client.getGroupUpgradeStatus('group-1');
+      expect(result).toBeNull();
+    });
+
+    it('retryGroupUpgrade posts and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/upgrade/retry', {
+        data: { groupId: 'group-1', status: 'in_progress' },
+      });
+      const result = await client.retryGroupUpgrade('group-1');
+      expect(result.status).toBe('in_progress');
+    });
+  });
+
+  describe('Group / Member Alias', () => {
+    it('setGroupAlias sends PUT with alias', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/alias', { data: null });
+      await client.setGroupAlias('group-1', { alias: 'My Group' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/alias')).toEqual({ alias: 'My Group' });
+    });
+
+    it('setMemberAlias sends PUT with alias', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/group-1/members/member-1/alias', { data: null });
+      await client.setMemberAlias('group-1', 'member-1', { alias: 'Alice' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/group-1/members/member-1/alias')).toEqual({ alias: 'Alice' });
+    });
+  });
+
+  describe('Group Update / Context Removal', () => {
+    it('updateGroup sends PATCH with body', async () => {
+      mock.setMockResponse('PATCH', '/admin-api/groups/group-1', { data: null });
+      await client.updateGroup('group-1', { upgradePolicy: 'automatic' });
+      expect(mock.getRequestBody('PATCH', '/admin-api/groups/group-1')).toEqual({ upgradePolicy: 'automatic' });
+    });
+
+    it('removeContextFromGroup posts to correct path', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/contexts/ctx-1/remove', { data: null });
+      await client.removeContextFromGroup('group-1', 'ctx-1');
+      expect(mock.getRequestBody('POST', '/admin-api/groups/group-1/contexts/ctx-1/remove')).toEqual({});
+    });
+  });
+
+  describe('Signing Key', () => {
+    it('registerSigningKey posts and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/group-1/signing-key', {
+        data: { publicKey: 'pk-123' },
+      });
+      const result = await client.registerSigningKey('group-1', { signingKey: 'sk-123' });
+      expect(result).toEqual({ publicKey: 'pk-123' });
     });
   });
 });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -19,6 +19,21 @@ import type {
   InviteToContextRequest,
   JoinContextRequest,
   JoinContextResponseData,
+  GroupInfo,
+  GroupSummary,
+  CreateGroupRequest,
+  CreateGroupResponseData,
+  DeleteGroupRequest,
+  DeleteGroupResponseData,
+  AddGroupMembersRequest,
+  RemoveGroupMembersRequest,
+  GroupContext,
+  CreateGroupInvitationRequest,
+  CreateGroupInvitationResponseData,
+  JoinGroupRequest,
+  JoinGroupResponseData,
+  MemberCapabilities,
+  ListGroupMembersResponseData,
   UploadBlobRequest,
   CreateAliasRequest,
 
@@ -120,6 +135,90 @@ export class AdminApiClient {
 
   async joinContext(request: JoinContextRequest): Promise<JoinContextResponseData | null> {
     return unwrap(await this.httpClient.post<{ data: JoinContextResponseData | null }>('/admin-api/contexts/join', request));
+  }
+
+  // ---- Group Management ----
+
+  async listGroups(): Promise<GroupSummary[]> {
+    return unwrap(await this.httpClient.get<{ data: GroupSummary[] }>('/admin-api/groups'));
+  }
+
+  async createGroup(request: CreateGroupRequest): Promise<CreateGroupResponseData> {
+    return unwrap(await this.httpClient.post<{ data: CreateGroupResponseData }>('/admin-api/groups', request));
+  }
+
+  async getGroupInfo(groupId: string): Promise<GroupInfo> {
+    return unwrap(await this.httpClient.get<{ data: GroupInfo }>(`/admin-api/groups/${groupId}`));
+  }
+
+  async deleteGroup(groupId: string, request: DeleteGroupRequest = {}): Promise<DeleteGroupResponseData> {
+    return unwrap(
+      await this.httpClient.request<{ data: DeleteGroupResponseData }>(`/admin-api/groups/${groupId}`, {
+        method: 'DELETE',
+        body: JSON.stringify(request),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }),
+    );
+  }
+
+  async listGroupMembers(groupId: string): Promise<ListGroupMembersResponseData> {
+    return this.httpClient.get<ListGroupMembersResponseData>(`/admin-api/groups/${groupId}/members`);
+  }
+
+  async addGroupMembers(groupId: string, request: AddGroupMembersRequest): Promise<void> {
+    return unwrap(await this.httpClient.post<{ data: null }>(`/admin-api/groups/${groupId}/members`, request));
+  }
+
+  async removeGroupMembers(groupId: string, request: RemoveGroupMembersRequest): Promise<void> {
+    return unwrap(await this.httpClient.post<{ data: null }>(`/admin-api/groups/${groupId}/members/remove`, request));
+  }
+
+  async listGroupContexts(groupId: string): Promise<GroupContext[]> {
+    return unwrap(await this.httpClient.get<{ data: GroupContext[] }>(`/admin-api/groups/${groupId}/contexts`));
+  }
+
+  async joinGroupContext(groupId: string, contextId: string): Promise<JoinContextResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: JoinContextResponseData }>(
+        `/admin-api/groups/${groupId}/join-context`,
+        { contextId },
+      ),
+    );
+  }
+
+  async createGroupInvitation(
+    groupId: string,
+    request: CreateGroupInvitationRequest = {},
+  ): Promise<CreateGroupInvitationResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: CreateGroupInvitationResponseData }>(
+        `/admin-api/groups/${groupId}/invite`,
+        request,
+      ),
+    );
+  }
+
+  async joinGroup(request: JoinGroupRequest): Promise<JoinGroupResponseData> {
+    return unwrap(await this.httpClient.post<{ data: JoinGroupResponseData }>('/admin-api/groups/join', request));
+  }
+
+  async setMemberCapabilities(groupId: string, memberId: string, capabilities: number): Promise<void> {
+    return unwrap(
+      await this.httpClient.put<{ data: null }>(
+        `/admin-api/groups/${groupId}/members/${memberId}/capabilities`,
+        { capabilities },
+      ),
+    );
+  }
+
+  async getMemberCapabilities(groupId: string, memberId: string): Promise<MemberCapabilities> {
+    return unwrap(
+      await this.httpClient.get<{ data: MemberCapabilities }>(
+        `/admin-api/groups/${groupId}/members/${memberId}/capabilities`,
+      ),
+    );
   }
 
   // ---- Blob Management ----

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -17,6 +17,7 @@ import type {
   GenerateContextIdentityResponseData,
   GetContextIdentitiesResponseData,
   InviteToContextRequest,
+  SignedOpenInvitation,
   JoinContextRequest,
   JoinContextResponseData,
   GroupInfo,
@@ -33,11 +34,28 @@ import type {
   JoinGroupRequest,
   JoinGroupResponseData,
   MemberCapabilities,
+  SyncGroupRequest,
+  SyncGroupResponseData,
   ListGroupMembersResponseData,
   UploadBlobRequest,
   CreateAliasRequest,
-
   ListAliasesResponseData,
+  SetDefaultCapabilitiesRequest,
+  SetDefaultVisibilityRequest,
+  ContextVisibilityData,
+  SetContextVisibilityRequest,
+  ManageContextAllowlistRequest,
+  UpdateMemberRoleRequest,
+  UpgradeGroupRequest,
+  UpgradeGroupResponseData,
+  RetryGroupUpgradeRequest,
+  SetGroupAliasRequest,
+  SetMemberAliasRequest,
+  UpdateGroupRequest,
+  RemoveContextFromGroupRequest,
+  RegisterSigningKeyRequest,
+  RegisterSigningKeyResponseData,
+  GetContextStorageResponseData,
 } from './admin-types';
 
 /**
@@ -129,12 +147,28 @@ export class AdminApiClient {
 
   // ---- Context Invite / Join ----
 
-  async inviteToContext(request: InviteToContextRequest): Promise<unknown> {
-    return unwrap(await this.httpClient.post<{ data: unknown }>('/admin-api/contexts/invite', request));
+  async inviteToContext(request: InviteToContextRequest): Promise<SignedOpenInvitation | null> {
+    return unwrap(await this.httpClient.post<{ data: SignedOpenInvitation | null }>('/admin-api/contexts/invite', request));
   }
 
   async joinContext(request: JoinContextRequest): Promise<JoinContextResponseData | null> {
     return unwrap(await this.httpClient.post<{ data: JoinContextResponseData | null }>('/admin-api/contexts/join', request));
+  }
+
+  async getContextGroup(contextId: string): Promise<string | null> {
+    return unwrap(await this.httpClient.get<{ data: string | null }>(`/admin-api/contexts/${contextId}/group`));
+  }
+
+  async getContextStorageSize(contextId: string): Promise<GetContextStorageResponseData> {
+    return unwrap(await this.httpClient.get<{ data: GetContextStorageResponseData }>(`/admin-api/contexts/${contextId}/storage`));
+  }
+
+  async syncContext(contextId: string): Promise<void> {
+    unwrap(await this.httpClient.post<{ data: null }>(`/admin-api/contexts/sync/${contextId}`, {}));
+  }
+
+  async syncAllContexts(): Promise<void> {
+    unwrap(await this.httpClient.post<{ data: null }>('/admin-api/contexts/sync', {}));
   }
 
   // ---- Group Management ----
@@ -200,6 +234,15 @@ export class AdminApiClient {
     );
   }
 
+  async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: SyncGroupResponseData }>(
+        `/admin-api/groups/${groupId}/sync`,
+        request ?? {},
+      ),
+    );
+  }
+
   async joinGroup(request: JoinGroupRequest): Promise<JoinGroupResponseData> {
     return unwrap(await this.httpClient.post<{ data: JoinGroupResponseData }>('/admin-api/groups/join', request));
   }
@@ -217,6 +260,120 @@ export class AdminApiClient {
     return unwrap(
       await this.httpClient.get<{ data: MemberCapabilities }>(
         `/admin-api/groups/${groupId}/members/${memberId}/capabilities`,
+      ),
+    );
+  }
+
+  // ---- Group Governance / Settings ----
+
+  async setDefaultCapabilities(groupId: string, request: SetDefaultCapabilitiesRequest): Promise<void> {
+    unwrap(await this.httpClient.put<{ data: null }>(`/admin-api/groups/${groupId}/settings/default-capabilities`, request));
+  }
+
+  async setDefaultVisibility(groupId: string, request: SetDefaultVisibilityRequest): Promise<void> {
+    unwrap(await this.httpClient.put<{ data: null }>(`/admin-api/groups/${groupId}/settings/default-visibility`, request));
+  }
+
+  async getContextVisibility(groupId: string, contextId: string): Promise<ContextVisibilityData> {
+    return unwrap(
+      await this.httpClient.get<{ data: ContextVisibilityData }>(
+        `/admin-api/groups/${groupId}/contexts/${contextId}/visibility`,
+      ),
+    );
+  }
+
+  async setContextVisibility(groupId: string, contextId: string, request: SetContextVisibilityRequest): Promise<void> {
+    unwrap(
+      await this.httpClient.put<{ data: null }>(
+        `/admin-api/groups/${groupId}/contexts/${contextId}/visibility`,
+        request,
+      ),
+    );
+  }
+
+  async getContextAllowlist(groupId: string, contextId: string): Promise<string[]> {
+    return unwrap(
+      await this.httpClient.get<{ data: string[] }>(
+        `/admin-api/groups/${groupId}/contexts/${contextId}/allowlist`,
+      ),
+    );
+  }
+
+  async updateContextAllowlist(groupId: string, contextId: string, request: ManageContextAllowlistRequest): Promise<void> {
+    unwrap(
+      await this.httpClient.post<{ data: null }>(
+        `/admin-api/groups/${groupId}/contexts/${contextId}/allowlist`,
+        request,
+      ),
+    );
+  }
+
+  async updateMemberRole(groupId: string, identity: string, request: UpdateMemberRoleRequest): Promise<void> {
+    unwrap(
+      await this.httpClient.put<{ data: null }>(
+        `/admin-api/groups/${groupId}/members/${identity}/role`,
+        request,
+      ),
+    );
+  }
+
+  // ---- Group Upgrade ----
+
+  async upgradeGroup(groupId: string, request: UpgradeGroupRequest): Promise<UpgradeGroupResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: UpgradeGroupResponseData }>(`/admin-api/groups/${groupId}/upgrade`, request),
+    );
+  }
+
+  async getGroupUpgradeStatus(groupId: string): Promise<UpgradeGroupResponseData | null> {
+    return unwrap(
+      await this.httpClient.get<{ data: UpgradeGroupResponseData | null }>(`/admin-api/groups/${groupId}/upgrade/status`),
+    );
+  }
+
+  async retryGroupUpgrade(groupId: string, request: RetryGroupUpgradeRequest = {}): Promise<UpgradeGroupResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: UpgradeGroupResponseData }>(`/admin-api/groups/${groupId}/upgrade/retry`, request),
+    );
+  }
+
+  // ---- Group / Member Alias ----
+
+  async setGroupAlias(groupId: string, request: SetGroupAliasRequest): Promise<void> {
+    unwrap(await this.httpClient.put<{ data: null }>(`/admin-api/groups/${groupId}/alias`, request));
+  }
+
+  async setMemberAlias(groupId: string, identity: string, request: SetMemberAliasRequest): Promise<void> {
+    unwrap(
+      await this.httpClient.put<{ data: null }>(
+        `/admin-api/groups/${groupId}/members/${identity}/alias`,
+        request,
+      ),
+    );
+  }
+
+  // ---- Group Update / Context Removal ----
+
+  async updateGroup(groupId: string, request: UpdateGroupRequest): Promise<void> {
+    unwrap(await this.httpClient.patch<{ data: null }>(`/admin-api/groups/${groupId}`, request));
+  }
+
+  async removeContextFromGroup(groupId: string, contextId: string, request: RemoveContextFromGroupRequest = {}): Promise<void> {
+    unwrap(
+      await this.httpClient.post<{ data: null }>(
+        `/admin-api/groups/${groupId}/contexts/${contextId}/remove`,
+        request,
+      ),
+    );
+  }
+
+  // ---- Signing Key ----
+
+  async registerSigningKey(groupId: string, request: RegisterSigningKeyRequest): Promise<RegisterSigningKeyResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: RegisterSigningKeyResponseData }>(
+        `/admin-api/groups/${groupId}/signing-key`,
+        request,
       ),
     );
   }

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -67,11 +67,16 @@ export interface CreateContextRequest {
   contextSeed?: string;
   initializationParams?: number[];
   protocol?: string;
+  groupId?: string;
+  identitySecret?: string;
+  alias?: string;
 }
 
 export interface CreateContextResponseData {
   contextId: string;
   memberPublicKey: string;
+  groupId?: string;
+  groupCreated?: boolean;
 }
 
 export interface DeleteContextResponseData {
@@ -101,6 +106,22 @@ export interface GetContextIdentitiesResponseData {
 
 // ---- Context Invite / Join ----
 
+export interface InvitationFromMember {
+  inviter_identity: string;
+  context_id: string;
+  expiration_timestamp: number;
+  secret_salt: number[];
+}
+
+export interface SignedOpenInvitation {
+  invitation: InvitationFromMember;
+  inviter_signature: string;
+  application_id?: number[];
+  blob_id?: number[];
+  source?: string;
+  group_id?: number[];
+}
+
 export interface InviteToContextRequest {
   contextId: string;
   inviterId: string;
@@ -108,7 +129,7 @@ export interface InviteToContextRequest {
 }
 
 export interface JoinContextRequest {
-  invitation: unknown;
+  invitation: SignedOpenInvitation;
   newMemberPublicKey: string;
 }
 
@@ -234,6 +255,18 @@ export interface MemberCapabilities {
   capabilities: number;
 }
 
+export interface SyncGroupRequest {
+  requester?: string;
+}
+
+export interface SyncGroupResponseData {
+  groupId: string;
+  appKey: string;
+  targetApplicationId: string;
+  memberCount: number;
+  contextCount: number;
+}
+
 // ---- Blobs ----
 
 export interface UploadBlobRequest {
@@ -258,6 +291,102 @@ export interface AliasEntry {
 
 export interface ListAliasesResponseData {
   aliases: AliasEntry[];
+}
+
+// ---- Group Governance / Settings ----
+
+export type ContextVisibilityMode = 'open' | 'restricted';
+
+export interface SetDefaultCapabilitiesRequest {
+  defaultCapabilities: number;
+  requester?: string;
+}
+
+export interface SetDefaultVisibilityRequest {
+  defaultVisibility: ContextVisibilityMode;
+  requester?: string;
+}
+
+export interface ContextVisibilityData {
+  mode: string;
+  creator: string;
+}
+
+export interface SetContextVisibilityRequest {
+  mode: ContextVisibilityMode;
+  requester?: string;
+}
+
+export interface ManageContextAllowlistRequest {
+  add?: string[];
+  remove?: string[];
+  requester?: string;
+}
+
+export interface UpdateMemberRoleRequest {
+  role: GroupMemberRole;
+  requester?: string;
+}
+
+// ---- Group Upgrade ----
+
+export interface UpgradeGroupRequest {
+  targetApplicationId: string;
+  requester?: string;
+  migrateMethod?: string;
+}
+
+export interface UpgradeGroupResponseData {
+  groupId: string;
+  status: string;
+  total?: number;
+  completed?: number;
+  failed?: number;
+}
+
+export interface RetryGroupUpgradeRequest {
+  requester?: string;
+}
+
+// ---- Group / Member Alias ----
+
+export interface SetGroupAliasRequest {
+  alias: string;
+  requester?: string;
+}
+
+export interface SetMemberAliasRequest {
+  alias: string;
+  requester?: string;
+}
+
+// ---- Group Update ----
+
+export interface UpdateGroupRequest {
+  requester?: string;
+  upgradePolicy: string;
+}
+
+// ---- Remove Context from Group ----
+
+export interface RemoveContextFromGroupRequest {
+  requester?: string;
+}
+
+// ---- Signing Key ----
+
+export interface RegisterSigningKeyRequest {
+  signingKey: string;
+}
+
+export interface RegisterSigningKeyResponseData {
+  publicKey: string;
+}
+
+// ---- Context Storage ----
+
+export interface GetContextStorageResponseData {
+  sizeInBytes: number;
 }
 
 // ---- Client Configuration ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -117,6 +117,123 @@ export interface JoinContextResponseData {
   memberPublicKey: string;
 }
 
+// ---- Groups ----
+
+export type GroupMemberRole = 'Admin' | 'Member' | 'ReadOnly';
+
+export interface GroupInvitationFromAdmin {
+  inviter_identity: number[] | string;
+  group_id: number[] | string;
+  expiration_timestamp: number;
+  secret_salt?: number[] | Uint8Array;
+}
+
+export interface SignedGroupOpenInvitation {
+  invitation: GroupInvitationFromAdmin;
+  inviter_signature: string;
+}
+
+export interface GroupSummary {
+  groupId: string;
+  appKey: string;
+  targetApplicationId: string;
+  upgradePolicy: string;
+  createdAt: number;
+  alias?: string;
+}
+
+export interface GroupUpgradeStatus {
+  fromVersion: string;
+  toVersion: string;
+  initiatedAt: number;
+  initiatedBy: string;
+  status: string;
+  total?: number;
+  completed?: number;
+  failed?: number;
+  completedAt?: number;
+}
+
+export interface GroupInfo extends Omit<GroupSummary, 'createdAt'> {
+  memberCount: number;
+  contextCount: number;
+  activeUpgrade?: GroupUpgradeStatus;
+  defaultCapabilities: number;
+  defaultVisibility: string;
+  alias?: string;
+}
+
+export interface GroupMember {
+  identity: string;
+  role: GroupMemberRole;
+  alias?: string;
+}
+
+export interface GroupContext {
+  contextId: string;
+  alias?: string;
+}
+
+export interface CreateGroupRequest {
+  groupId?: string;
+  appKey?: string;
+  applicationId: string;
+  upgradePolicy: string;
+  parentGroupId?: string;
+  alias?: string;
+}
+
+export interface CreateGroupResponseData {
+  groupId: string;
+}
+
+export interface DeleteGroupRequest {
+  requester?: string;
+}
+
+export interface DeleteGroupResponseData {
+  isDeleted: boolean;
+}
+
+export interface AddGroupMembersRequest {
+  members: Array<{ identity: string; role: GroupMemberRole }>;
+  requester?: string;
+}
+
+export interface RemoveGroupMembersRequest {
+  members: string[];
+  requester?: string;
+}
+
+export interface ListGroupMembersResponseData {
+  data: GroupMember[];
+  selfIdentity?: string;
+}
+
+export interface CreateGroupInvitationRequest {
+  requester?: string;
+  expirationTimestamp?: number;
+}
+
+export interface CreateGroupInvitationResponseData {
+  invitation: SignedGroupOpenInvitation;
+  groupAlias?: string;
+}
+
+export interface JoinGroupRequest {
+  invitation: SignedGroupOpenInvitation;
+  groupAlias?: string;
+}
+
+export interface JoinGroupResponseData {
+  groupId: string;
+  memberIdentity: string;
+}
+
+export interface MemberCapabilities {
+  capabilities: number;
+}
+
 // ---- Blobs ----
 
 export interface UploadBlobRequest {


### PR DESCRIPTION
Expose the missing group management routes in the admin client so consumers can create, inspect, join, and manage groups with typed request and response models. Add focused unit coverage to lock the new route contracts to the current server behavior.

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the public `AdminApiClient` surface area and tightens types for context invitations and context creation, which may break existing consumers relying on `unknown` payloads. Risk is otherwise limited to client-side request/response contract changes with added unit coverage.
> 
> **Overview**
> **Adds group admin API parity to the TypeScript admin client.** `AdminApiClient` now exposes typed group lifecycle, membership, governance/settings, upgrade, alias, context removal, sync, and signing-key endpoints, plus new context helpers (`getContextGroup`, `getContextStorageSize`, `syncContext`, `syncAllContexts`).
> 
> **Tightens request/response typing.** Context invite/join now uses `SignedOpenInvitation` (and `inviteToContext` returns `SignedOpenInvitation | null`), `CreateContextRequest/Response` gain optional group/identity/alias fields, and a large set of new group-related request/response models were added in `admin-types`.
> 
> **Improves tests and request-body assertions.** The mock `HttpClient` in `admin-client.test.ts` now records bodies (including via `request()` for DELETE-with-body) and adds broad unit coverage to lock down routes and payload shapes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd2f87a4461213dd69f28f09dee2af4e584bd1e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->