### PR TITLE
feat(admin-api): full client coverage for redesigned core admin API

### DIFF
--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -18,18 +18,87 @@ import type {
   GetContextIdentitiesResponseData,
   JoinContextResponseData,
   UploadBlobRequest,
+  UploadBlobResponseData,
+  DeleteBlobResponseData,
+  ListBlobsResponseData,
+  GetBlobResponseData,
   CreateAliasRequest,
   ListAliasesResponseData,
+  CreateAliasResponseData,
+  LookupAliasResponseData,
+  DeleteAliasResponseData,
   ListNamespacesResponseData,
+  CreateNamespaceRequest,
+  CreateNamespaceResponseData,
+  DeleteNamespaceRequest,
+  DeleteNamespaceResponseData,
+  CreateNamespaceInvitationRequest,
+  CreateNamespaceInvitationResponseData,
+  JoinNamespaceRequest,
+  JoinNamespaceResponseData,
+  CreateGroupInNamespaceRequest,
+  CreateGroupInNamespaceResponseData,
+  SubgroupEntry,
+  SubscribeNamespaceResponseData,
+  Namespace,
   NamespaceIdentity,
-  CreateGroupRequest,
-  CreateGroupResponseData,
-  ListGroupsResponseData,
   GroupInfoResponseData,
+  DeleteGroupResponseData,
   ListGroupMembersResponseData,
   ListGroupContextsResponseData,
-  CreateGroupInvitationRequest,
-  JoinGroupRequest,
+  AddGroupMembersRequest,
+  AddGroupMembersResponseData,
+  RemoveGroupMembersRequest,
+  RemoveGroupMembersResponseData,
+  UpdateMemberRoleRequest,
+  UpdateMemberRoleResponseData,
+  MemberCapabilities,
+  SetMemberCapabilitiesRequest,
+  SetMemberCapabilitiesResponseData,
+  SetDefaultCapabilitiesRequest,
+  SetDefaultCapabilitiesResponseData,
+  SetDefaultVisibilityRequest,
+  SetDefaultVisibilityResponseData,
+  SetTeeAdmissionPolicyRequest,
+  SetTeeAdmissionPolicyResponseData,
+  UpdateGroupSettingsRequest,
+  UpdateGroupSettingsResponseData,
+  SetGroupAliasRequest,
+  SetGroupAliasResponseData,
+  SetMemberAliasRequest,
+  SetMemberAliasResponseData,
+  SyncGroupRequest,
+  SyncGroupResponseData,
+  RegisterGroupSigningKeyRequest,
+  RegisterGroupSigningKeyResponseData,
+  UpgradeGroupRequest,
+  UpgradeGroupResponseData,
+  GroupUpgradeStatusResponseData,
+  RetryGroupUpgradeRequest,
+  RetryGroupUpgradeResponseData,
+  NestGroupRequest,
+  NestGroupResponseData,
+  UnnestGroupRequest,
+  UnnestGroupResponseData,
+  DetachContextFromGroupRequest,
+  DetachContextFromGroupResponseData,
+  ContextGroupResponseData,
+  ContextStorageResponseData,
+  SyncContextResponseData,
+  InviteSpecializedNodeRequest,
+  InviteSpecializedNodeResponseData,
+  UpdateContextApplicationRequest,
+  UpdateContextApplicationResponseData,
+  ContextsWithExecutorsResponseData,
+  ListContextIdentityAliasesResponseData,
+  CreateContextIdentityAliasResponseData,
+  LookupContextIdentityAliasResponseData,
+  DeleteContextIdentityAliasResponseData,
+  TeeInfoResponseData,
+  TeeAttestRequest,
+  TeeAttestResponseData,
+  TeeVerifyQuoteRequest,
+  TeeVerifyQuoteResponseData,
 } from './admin-types';
 
 /**
@@ -129,47 +198,47 @@ export class AdminApiClient {
 
   // ---- Blob Management ----
 
-  async uploadBlob(data: UploadBlobRequest): Promise<unknown> {
-    return unwrap(await this.httpClient.put<{ data: unknown }>('/admin-api/blobs', data));
+  async uploadBlob(data: UploadBlobRequest): Promise<UploadBlobResponseData> {
+    return unwrap(await this.httpClient.put<{ data: UploadBlobResponseData }>('/admin-api/blobs', data));
   }
 
-  async deleteBlob(blobId: string): Promise<unknown> {
-    return unwrap(await this.httpClient.delete<{ data: unknown }>(`/admin-api/blobs/${blobId}`));
+  async deleteBlob(blobId: string): Promise<DeleteBlobResponseData> {
+    return unwrap(await this.httpClient.delete<{ data: DeleteBlobResponseData }>(`/admin-api/blobs/${blobId}`));
   }
 
-  async listBlobs(): Promise<unknown> {
-    return unwrap(await this.httpClient.get<{ data: unknown }>('/admin-api/blobs'));
+  async listBlobs(): Promise<ListBlobsResponseData> {
+    return unwrap(await this.httpClient.get<{ data: ListBlobsResponseData }>('/admin-api/blobs'));
   }
 
-  async getBlob(blobId: string): Promise<unknown> {
-    return unwrap(await this.httpClient.get<{ data: unknown }>(`/admin-api/blobs/${blobId}`));
+  async getBlob(blobId: string): Promise<GetBlobResponseData> {
+    return unwrap(await this.httpClient.get<{ data: GetBlobResponseData }>(`/admin-api/blobs/${blobId}`));
   }
 
   // ---- Alias Management ----
   // Server uses type-specific alias routes: /admin-api/alias/{create,lookup,delete,list}/{context,application}
 
-  async createContextAlias(request: CreateAliasRequest): Promise<unknown> {
-    return this.httpClient.post('/admin-api/alias/create/context', request);
+  async createContextAlias(request: CreateAliasRequest): Promise<CreateAliasResponseData> {
+    return this.httpClient.post<CreateAliasResponseData>('/admin-api/alias/create/context', request);
   }
 
-  async createApplicationAlias(request: CreateAliasRequest): Promise<unknown> {
-    return this.httpClient.post('/admin-api/alias/create/application', request);
+  async createApplicationAlias(request: CreateAliasRequest): Promise<CreateAliasResponseData> {
+    return this.httpClient.post<CreateAliasResponseData>('/admin-api/alias/create/application', request);
   }
 
-  async lookupContextAlias(name: string): Promise<unknown> {
-    return this.httpClient.post(`/admin-api/alias/lookup/context/${encodeURIComponent(name)}`, {});
+  async lookupContextAlias(name: string): Promise<LookupAliasResponseData> {
+    return this.httpClient.post<LookupAliasResponseData>(`/admin-api/alias/lookup/context/${encodeURIComponent(name)}`, {});
   }
 
-  async lookupApplicationAlias(name: string): Promise<unknown> {
-    return this.httpClient.post(`/admin-api/alias/lookup/application/${encodeURIComponent(name)}`, {});
+  async lookupApplicationAlias(name: string): Promise<LookupAliasResponseData> {
+    return this.httpClient.post<LookupAliasResponseData>(`/admin-api/alias/lookup/application/${encodeURIComponent(name)}`, {});
   }
 
-  async deleteContextAlias(name: string): Promise<unknown> {
-    return this.httpClient.post(`/admin-api/alias/delete/context/${encodeURIComponent(name)}`, {});
+  async deleteContextAlias(name: string): Promise<DeleteAliasResponseData> {
+    return this.httpClient.post<DeleteAliasResponseData>(`/admin-api/alias/delete/context/${encodeURIComponent(name)}`, {});
   }
 
-  async deleteApplicationAlias(name: string): Promise<unknown> {
-    return this.httpClient.post(`/admin-api/alias/delete/application/${encodeURIComponent(name)}`, {});
+  async deleteApplicationAlias(name: string): Promise<DeleteAliasResponseData> {
+    return this.httpClient.post<DeleteAliasResponseData>(`/admin-api/alias/delete/application/${encodeURIComponent(name)}`, {});
   }
 
   async listContextAliases(): Promise<ListAliasesResponseData> {
@@ -187,29 +256,92 @@ export class AdminApiClient {
   }
 
   async getNamespaceIdentity(namespaceId: string): Promise<NamespaceIdentity> {
-    return this.httpClient.get<NamespaceIdentity>(`/admin-api/namespaces/${namespaceId}/identity`);
+    return unwrap(await this.httpClient.get<{ data: NamespaceIdentity }>(`/admin-api/namespaces/${namespaceId}/identity`));
   }
 
   async listNamespacesForApplication(applicationId: string): Promise<ListNamespacesResponseData> {
     return unwrap(await this.httpClient.get<{ data: ListNamespacesResponseData }>(`/admin-api/namespaces/for-application/${applicationId}`));
   }
 
+  async createNamespace(request: CreateNamespaceRequest): Promise<CreateNamespaceResponseData> {
+    return unwrap(await this.httpClient.post<{ data: CreateNamespaceResponseData }>('/admin-api/namespaces', request));
+  }
+
+  async getNamespace(namespaceId: string): Promise<Namespace> {
+    return unwrap(await this.httpClient.get<{ data: Namespace }>(`/admin-api/namespaces/${namespaceId}`));
+  }
+
+  async deleteNamespace(
+    namespaceId: string,
+    request?: DeleteNamespaceRequest,
+  ): Promise<DeleteNamespaceResponseData> {
+    return unwrap(
+      await this.httpClient.request<{ data: DeleteNamespaceResponseData }>(`/admin-api/namespaces/${namespaceId}`, {
+        method: 'DELETE',
+        body: request ? JSON.stringify(request) : undefined,
+        headers: request ? { 'Content-Type': 'application/json' } : undefined,
+      }),
+    );
+  }
+
+  async createNamespaceInvitation(
+    namespaceId: string,
+    request?: CreateNamespaceInvitationRequest,
+  ): Promise<CreateNamespaceInvitationResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: CreateNamespaceInvitationResponseData }>(
+        `/admin-api/namespaces/${namespaceId}/invite`,
+        request ?? {},
+      ),
+    );
+  }
+
+  async joinNamespace(
+    namespaceId: string,
+    request: JoinNamespaceRequest,
+  ): Promise<JoinNamespaceResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: JoinNamespaceResponseData }>(
+        `/admin-api/namespaces/${namespaceId}/join`,
+        request,
+        { timeoutMs: 65000 },
+      ),
+    );
+  }
+
+  async createGroupInNamespace(
+    namespaceId: string,
+    request?: CreateGroupInNamespaceRequest,
+  ): Promise<CreateGroupInNamespaceResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: CreateGroupInNamespaceResponseData }>(
+        `/admin-api/namespaces/${namespaceId}/groups`,
+        request ?? {},
+      ),
+    );
+  }
+
+  async listNamespaceGroups(namespaceId: string): Promise<SubgroupEntry[]> {
+    return unwrap(await this.httpClient.get<{ data: SubgroupEntry[] }>(`/admin-api/namespaces/${namespaceId}/groups`));
+  }
+
+  async subscribeNamespace(namespaceId: string): Promise<SubscribeNamespaceResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: SubscribeNamespaceResponseData }>(
+        `/admin-api/namespaces/${namespaceId}/subscribe`,
+        {},
+      ),
+    );
+  }
+
   // ---- Group Management ----
-
-  async listGroups(): Promise<ListGroupsResponseData> {
-    return unwrap(await this.httpClient.get<{ data: ListGroupsResponseData }>('/admin-api/groups'));
-  }
-
-  async createGroup(request: CreateGroupRequest): Promise<CreateGroupResponseData> {
-    return unwrap(await this.httpClient.post<{ data: CreateGroupResponseData }>('/admin-api/groups', request));
-  }
 
   async getGroupInfo(groupId: string): Promise<GroupInfoResponseData> {
     return unwrap(await this.httpClient.get<{ data: GroupInfoResponseData }>(`/admin-api/groups/${groupId}`));
   }
 
-  async deleteGroup(groupId: string): Promise<unknown> {
-    return unwrap(await this.httpClient.delete<{ data: unknown }>(`/admin-api/groups/${groupId}`));
+  async deleteGroup(groupId: string): Promise<DeleteGroupResponseData> {
+    return unwrap(await this.httpClient.delete<{ data: DeleteGroupResponseData }>(`/admin-api/groups/${groupId}`));
   }
 
   async listGroupMembers(groupId: string): Promise<ListGroupMembersResponseData> {
@@ -220,12 +352,250 @@ export class AdminApiClient {
     return unwrap(await this.httpClient.get<{ data: ListGroupContextsResponseData }>(`/admin-api/groups/${groupId}/contexts`));
   }
 
-  async createGroupInvitation(groupId: string, request?: CreateGroupInvitationRequest): Promise<unknown> {
-    return unwrap(await this.httpClient.post<{ data: unknown }>(`/admin-api/groups/${groupId}/invite`, request ?? {}));
+  async addGroupMembers(groupId: string, request: AddGroupMembersRequest): Promise<AddGroupMembersResponseData> {
+    return this.httpClient.post<AddGroupMembersResponseData>(`/admin-api/groups/${groupId}/members`, request);
   }
 
-  async joinGroup(request: JoinGroupRequest): Promise<unknown> {
-    return unwrap(await this.httpClient.post<{ data: unknown }>('/admin-api/groups/join', request));
+  async removeGroupMembers(groupId: string, request: RemoveGroupMembersRequest): Promise<RemoveGroupMembersResponseData> {
+    return this.httpClient.post<RemoveGroupMembersResponseData>(`/admin-api/groups/${groupId}/members/remove`, request);
+  }
+
+  async updateMemberRole(
+    groupId: string,
+    identity: string,
+    request: UpdateMemberRoleRequest,
+  ): Promise<UpdateMemberRoleResponseData> {
+    return this.httpClient.put<UpdateMemberRoleResponseData>(
+      `/admin-api/groups/${groupId}/members/${identity}/role`,
+      request,
+    );
+  }
+
+  async getMemberCapabilities(groupId: string, identity: string): Promise<MemberCapabilities> {
+    return unwrap(
+      await this.httpClient.get<{ data: MemberCapabilities }>(
+        `/admin-api/groups/${groupId}/members/${identity}/capabilities`,
+      ),
+    );
+  }
+
+  async setMemberCapabilities(
+    groupId: string,
+    identity: string,
+    request: SetMemberCapabilitiesRequest,
+  ): Promise<SetMemberCapabilitiesResponseData> {
+    return this.httpClient.put<SetMemberCapabilitiesResponseData>(
+      `/admin-api/groups/${groupId}/members/${identity}/capabilities`,
+      request,
+    );
+  }
+
+  async setDefaultCapabilities(
+    groupId: string,
+    request: SetDefaultCapabilitiesRequest,
+  ): Promise<SetDefaultCapabilitiesResponseData> {
+    return this.httpClient.put<SetDefaultCapabilitiesResponseData>(
+      `/admin-api/groups/${groupId}/settings/default-capabilities`,
+      request,
+    );
+  }
+
+  async setDefaultVisibility(
+    groupId: string,
+    request: SetDefaultVisibilityRequest,
+  ): Promise<SetDefaultVisibilityResponseData> {
+    return this.httpClient.put<SetDefaultVisibilityResponseData>(
+      `/admin-api/groups/${groupId}/settings/default-visibility`,
+      request,
+    );
+  }
+
+  async setTeeAdmissionPolicy(
+    groupId: string,
+    request: SetTeeAdmissionPolicyRequest,
+  ): Promise<SetTeeAdmissionPolicyResponseData> {
+    return this.httpClient.put<SetTeeAdmissionPolicyResponseData>(
+      `/admin-api/groups/${groupId}/settings/tee-admission-policy`,
+      request,
+    );
+  }
+
+  async updateGroupSettings(
+    groupId: string,
+    request: UpdateGroupSettingsRequest,
+  ): Promise<UpdateGroupSettingsResponseData> {
+    return this.httpClient.patch<UpdateGroupSettingsResponseData>(`/admin-api/groups/${groupId}`, request);
+  }
+
+  async setGroupAlias(groupId: string, request: SetGroupAliasRequest): Promise<SetGroupAliasResponseData> {
+    return this.httpClient.put<SetGroupAliasResponseData>(`/admin-api/groups/${groupId}/alias`, request);
+  }
+
+  async setMemberAlias(
+    groupId: string,
+    identity: string,
+    request: SetMemberAliasRequest,
+  ): Promise<SetMemberAliasResponseData> {
+    return this.httpClient.put<SetMemberAliasResponseData>(
+      `/admin-api/groups/${groupId}/members/${identity}/alias`,
+      request,
+    );
+  }
+
+  async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {
+    return unwrap(await this.httpClient.post<{ data: SyncGroupResponseData }>(`/admin-api/groups/${groupId}/sync`, request ?? {}));
+  }
+
+  async registerGroupSigningKey(
+    groupId: string,
+    request: RegisterGroupSigningKeyRequest,
+  ): Promise<RegisterGroupSigningKeyResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: RegisterGroupSigningKeyResponseData }>(
+        `/admin-api/groups/${groupId}/signing-key`,
+        request,
+      ),
+    );
+  }
+
+  async upgradeGroup(groupId: string, request: UpgradeGroupRequest): Promise<UpgradeGroupResponseData> {
+    return unwrap(await this.httpClient.post<{ data: UpgradeGroupResponseData }>(`/admin-api/groups/${groupId}/upgrade`, request));
+  }
+
+  async getGroupUpgradeStatus(groupId: string): Promise<GroupUpgradeStatusResponseData> {
+    return unwrap(
+      await this.httpClient.get<{ data: GroupUpgradeStatusResponseData }>(`/admin-api/groups/${groupId}/upgrade/status`),
+    );
+  }
+
+  async retryGroupUpgrade(
+    groupId: string,
+    request?: RetryGroupUpgradeRequest,
+  ): Promise<RetryGroupUpgradeResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: RetryGroupUpgradeResponseData }>(
+        `/admin-api/groups/${groupId}/upgrade/retry`,
+        request ?? {},
+      ),
+    );
+  }
+
+  async nestGroup(parentGroupId: string, request: NestGroupRequest): Promise<NestGroupResponseData> {
+    return this.httpClient.post<NestGroupResponseData>(`/admin-api/groups/${parentGroupId}/nest`, request);
+  }
+
+  async unnestGroup(parentGroupId: string, request: UnnestGroupRequest): Promise<UnnestGroupResponseData> {
+    return this.httpClient.post<UnnestGroupResponseData>(`/admin-api/groups/${parentGroupId}/unnest`, request);
+  }
+
+  async listSubgroups(groupId: string): Promise<SubgroupEntry[]> {
+    return unwrap(await this.httpClient.get<{ data: SubgroupEntry[] }>(`/admin-api/groups/${groupId}/subgroups`));
+  }
+
+  async detachContextFromGroup(
+    groupId: string,
+    contextId: string,
+    request?: DetachContextFromGroupRequest,
+  ): Promise<DetachContextFromGroupResponseData> {
+    return this.httpClient.post<DetachContextFromGroupResponseData>(
+      `/admin-api/groups/${groupId}/contexts/${contextId}/remove`,
+      request ?? {},
+    );
+  }
+
+  async getContextGroup(contextId: string): Promise<ContextGroupResponseData> {
+    return unwrap(await this.httpClient.get<{ data: ContextGroupResponseData }>(`/admin-api/contexts/${contextId}/group`));
+  }
+
+  async getContextStorage(contextId: string): Promise<ContextStorageResponseData> {
+    return unwrap(await this.httpClient.get<{ data: ContextStorageResponseData }>(`/admin-api/contexts/${contextId}/storage`));
+  }
+
+  async syncContext(contextId?: string): Promise<SyncContextResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: SyncContextResponseData }>(`/admin-api/contexts/sync/${contextId ?? ''}`, {}),
+    );
+  }
+
+  async inviteSpecializedNode(request: InviteSpecializedNodeRequest): Promise<InviteSpecializedNodeResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: InviteSpecializedNodeResponseData }>(
+        '/admin-api/contexts/invite-specialized-node',
+        request,
+      ),
+    );
+  }
+
+  async updateContextApplication(
+    contextId: string,
+    request: UpdateContextApplicationRequest,
+  ): Promise<UpdateContextApplicationResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: UpdateContextApplicationResponseData }>(
+        `/admin-api/contexts/${contextId}/application`,
+        request,
+      ),
+    );
+  }
+
+  async getContextsWithExecutorsForApplication(applicationId: string): Promise<ContextsWithExecutorsResponseData> {
+    return unwrap(
+      await this.httpClient.get<{ data: ContextsWithExecutorsResponseData }>(
+        `/admin-api/contexts/with-executors/for-application/${applicationId}`,
+      ),
+    );
+  }
+
+  async listContextIdentityAliases(contextId: string): Promise<ListContextIdentityAliasesResponseData> {
+    return unwrap(
+      await this.httpClient.get<{ data: ListContextIdentityAliasesResponseData }>(
+        `/admin-api/alias/list/identity/${contextId}`,
+      ),
+    );
+  }
+
+  async createContextIdentityAlias(
+    contextId: string,
+    request: CreateAliasRequest,
+  ): Promise<CreateContextIdentityAliasResponseData> {
+    return this.httpClient.post<CreateContextIdentityAliasResponseData>(
+      `/admin-api/alias/create/identity/${contextId}`,
+      request,
+    );
+  }
+
+  async lookupContextIdentityAlias(
+    contextId: string,
+    name: string,
+  ): Promise<LookupContextIdentityAliasResponseData> {
+    return this.httpClient.post<LookupContextIdentityAliasResponseData>(
+      `/admin-api/alias/lookup/identity/${contextId}/${encodeURIComponent(name)}`,
+      {},
+    );
+  }
+
+  async deleteContextIdentityAlias(
+    contextId: string,
+    name: string,
+  ): Promise<DeleteContextIdentityAliasResponseData> {
+    return this.httpClient.post<DeleteContextIdentityAliasResponseData>(
+      `/admin-api/alias/delete/identity/${contextId}/${encodeURIComponent(name)}`,
+      {},
+    );
+  }
+
+  async getTeeInfo(): Promise<TeeInfoResponseData> {
+    return unwrap(await this.httpClient.get<{ data: TeeInfoResponseData }>('/admin-api/tee/info'));
+  }
+
+  async teeAttest(request: TeeAttestRequest): Promise<TeeAttestResponseData> {
+    return unwrap(await this.httpClient.post<{ data: TeeAttestResponseData }>('/admin-api/tee/attest', request));
+  }
+
+  async teeVerifyQuote(request: TeeVerifyQuoteRequest): Promise<TeeVerifyQuoteResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: TeeVerifyQuoteResponseData }>('/admin-api/tee/verify-quote', request),
+    );
   }
 
   // ---- Network ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -64,6 +64,7 @@ export interface GetLatestVersionResponseData {
 
 export interface CreateContextRequest {
   applicationId: string;
+  groupId: string;
   serviceName?: string;
   contextSeed?: string;
   initializationParams?: number[];
@@ -114,9 +115,26 @@ export interface UploadBlobRequest {
   data: Uint8Array | ArrayBuffer;
 }
 
+export interface UploadBlobResponseData {
+  blobId?: string;
+  hash?: string;
+  size?: number;
+}
+
 export interface DeleteBlobResponseData {
   success: boolean;
 }
+
+export interface BlobEntry {
+  blobId?: string;
+  hash?: string;
+  size?: number;
+  createdAt?: number;
+}
+
+export type ListBlobsResponseData = BlobEntry[];
+
+export type GetBlobResponseData = BlobEntry;
 
 // ---- Aliases ----
 
@@ -132,6 +150,22 @@ export interface AliasEntry {
 
 export interface ListAliasesResponseData {
   aliases: AliasEntry[];
+}
+
+export interface CreateAliasResponseData {
+  success?: boolean;
+  name?: string;
+  value?: string;
+}
+
+export interface LookupAliasResponseData {
+  name?: string;
+  value?: string;
+}
+
+export interface DeleteAliasResponseData {
+  success?: boolean;
+  name?: string;
 }
 
 // ---- Namespaces ----
@@ -153,6 +187,62 @@ export type ListNamespacesResponseData = Namespace[];
 export interface NamespaceIdentity {
   namespaceId: string;
   publicKey: string;
+}
+
+export interface CreateNamespaceRequest {
+  applicationId: string;
+  namespaceId?: string;
+  appKey?: string;
+  upgradePolicy?: string;
+  alias?: string;
+}
+
+export interface CreateNamespaceResponseData {
+  namespaceId: string;
+}
+
+export interface DeleteNamespaceRequest {
+  force?: boolean;
+}
+
+export interface DeleteNamespaceResponseData {
+  isDeleted: boolean;
+}
+
+export interface CreateNamespaceInvitationRequest {
+  validForSeconds?: number;
+}
+
+export interface CreateNamespaceInvitationResponseData {
+  invitation: string;
+}
+
+export interface JoinNamespaceRequest {
+  invitation: string;
+  namespaceAlias?: string;
+}
+
+export interface JoinNamespaceResponseData {
+  namespaceId: string;
+}
+
+export interface CreateGroupInNamespaceRequest {
+  groupId?: string;
+  alias?: string;
+}
+
+export interface CreateGroupInNamespaceResponseData {
+  groupId: string;
+}
+
+export interface SubgroupEntry {
+  groupId: string;
+  alias?: string;
+}
+
+export interface SubscribeNamespaceResponseData {
+  namespaceId: string;
+  subscribed: boolean;
 }
 
 // ---- Groups ----
@@ -219,6 +309,262 @@ export interface CreateGroupInvitationRequest {
 export interface JoinGroupRequest {
   invitation: unknown;
   groupAlias?: string;
+}
+
+export interface DeleteGroupResponseData {
+  isDeleted: boolean;
+}
+
+// ---- Group Members ----
+
+export interface AddGroupMembersRequest {
+  identities: string[];
+  role?: string;
+}
+
+export interface AddGroupMembersResponseData {
+  added: string[];
+}
+
+export interface RemoveGroupMembersRequest {
+  identities: string[];
+}
+
+export interface RemoveGroupMembersResponseData {
+  removed: string[];
+}
+
+export interface UpdateMemberRoleRequest {
+  role: string;
+}
+
+export interface UpdateMemberRoleResponseData {
+  identity: string;
+  role: string;
+}
+
+// ---- Group Capabilities & Settings ----
+
+export interface MemberCapabilities {
+  identity: string;
+  capabilities: string[];
+}
+
+export interface SetMemberCapabilitiesRequest {
+  capabilities: string[];
+}
+
+export interface SetMemberCapabilitiesResponseData {
+  identity: string;
+  capabilities: string[];
+}
+
+export interface SetDefaultCapabilitiesRequest {
+  capabilities: string[];
+}
+
+export interface SetDefaultCapabilitiesResponseData {
+  capabilities: string[];
+}
+
+export interface SetDefaultVisibilityRequest {
+  visibility: string;
+}
+
+export interface SetDefaultVisibilityResponseData {
+  visibility: string;
+}
+
+export interface SetTeeAdmissionPolicyRequest {
+  policy: string;
+}
+
+export interface SetTeeAdmissionPolicyResponseData {
+  policy: string;
+}
+
+export interface UpdateGroupSettingsRequest {
+  alias?: string;
+  upgradePolicy?: string;
+}
+
+export interface UpdateGroupSettingsResponseData {
+  groupId: string;
+}
+
+export interface SetGroupAliasRequest {
+  alias: string;
+}
+
+export interface SetGroupAliasResponseData {
+  alias: string;
+}
+
+export interface SetMemberAliasRequest {
+  alias: string;
+}
+
+export interface SetMemberAliasResponseData {
+  identity: string;
+  alias: string;
+}
+
+// ---- Group Sync, Signing & Upgrades ----
+
+export interface SyncGroupRequest {
+  force?: boolean;
+}
+
+export interface SyncGroupResponseData {
+  groupId: string;
+  synced: boolean;
+}
+
+export interface RegisterGroupSigningKeyRequest {
+  key: string;
+}
+
+export interface RegisterGroupSigningKeyResponseData {
+  keyId?: string;
+  registered: boolean;
+}
+
+export interface UpgradeGroupRequest {
+  targetVersion?: string;
+}
+
+export interface UpgradeGroupResponseData {
+  operationId?: string;
+  started: boolean;
+}
+
+export interface GroupUpgradeStatusResponseData {
+  status: string;
+  error?: string;
+}
+
+export interface RetryGroupUpgradeRequest {
+  force?: boolean;
+}
+
+export interface RetryGroupUpgradeResponseData {
+  operationId?: string;
+  started: boolean;
+}
+
+// ---- Group Nesting & Context Attachments ----
+
+export interface NestGroupRequest {
+  childGroupId: string;
+}
+
+export interface NestGroupResponseData {
+  parentGroupId: string;
+  childGroupId: string;
+}
+
+export interface UnnestGroupRequest {
+  childGroupId: string;
+}
+
+export interface UnnestGroupResponseData {
+  parentGroupId: string;
+  childGroupId: string;
+}
+
+export interface DetachContextFromGroupRequest {
+  reason?: string;
+}
+
+export interface DetachContextFromGroupResponseData {
+  contextId: string;
+  removed: boolean;
+}
+
+// ---- Additional Context Routes ----
+
+export interface ContextGroupResponseData {
+  groupId: string;
+  alias?: string;
+}
+
+export interface ContextStorageResponseData {
+  usageBytes: number;
+  limitBytes?: number;
+}
+
+export interface SyncContextResponseData {
+  contextId?: string;
+  synced: boolean;
+}
+
+export interface InviteSpecializedNodeRequest {
+  contextId: string;
+  nodePublicKey: string;
+}
+
+export interface InviteSpecializedNodeResponseData {
+  invited: boolean;
+}
+
+export interface UpdateContextApplicationRequest {
+  applicationId: string;
+}
+
+export interface UpdateContextApplicationResponseData {
+  contextId: string;
+  applicationId: string;
+}
+
+export interface ContextWithExecutors {
+  contextId: string;
+  executors: string[];
+}
+
+export type ContextsWithExecutorsResponseData = ContextWithExecutors[];
+
+// ---- Context identity aliases ----
+
+export type ListContextIdentityAliasesResponseData = ListAliasesResponseData;
+
+export interface CreateContextIdentityAliasResponseData {
+  success?: boolean;
+  name?: string;
+  value?: string;
+}
+
+export interface LookupContextIdentityAliasResponseData {
+  name?: string;
+  value?: string;
+}
+
+export interface DeleteContextIdentityAliasResponseData {
+  success?: boolean;
+  name?: string;
+}
+
+// ---- TEE ----
+
+export interface TeeInfoResponseData {
+  enabled: boolean;
+  mode?: string;
+}
+
+export interface TeeAttestRequest {
+  payload: string;
+}
+
+export interface TeeAttestResponseData {
+  quote: string;
+}
+
+export interface TeeVerifyQuoteRequest {
+  quote: string;
+  payload?: string;
+}
+
+export interface TeeVerifyQuoteResponseData {
+  valid: boolean;
 }
 
 // ---- Client Configuration ----


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- align `AdminApiClient` with redesigned admin routes by removing deprecated group-root endpoints and adding full namespace coverage
- add missing group leaf methods (members, capabilities, settings, sync/signing, upgrades, subgroups, context detach)
- add missing context, context-identity-alias, and TEE methods with route-accurate paths and `data` unwrapping where required
- fix `getNamespaceIdentity()` to consistently unwrap `.data`
- update `CreateContextRequest` so `groupId` is required
- expand `admin-types.ts` with interfaces for newly covered request/response payloads and replace unknown return types in the client

## API changes included
- removed: `listGroups()`, `createGroup()`, `createGroupInvitation()`, `joinGroup()`
- added namespace methods:
  - `createNamespace`, `getNamespace`, `deleteNamespace`
  - `createNamespaceInvitation`, `joinNamespace` (65s timeout)
  - `createGroupInNamespace`, `listNamespaceGroups`, `subscribeNamespace`
- added group leaf methods:
  - `addGroupMembers`, `removeGroupMembers`, `updateMemberRole`
  - `getMemberCapabilities`, `setMemberCapabilities`, `setDefaultCapabilities`, `setDefaultVisibility`, `setTeeAdmissionPolicy`
  - `updateGroupSettings`, `setGroupAlias`, `setMemberAlias`
  - `syncGroup`, `registerGroupSigningKey`
  - `upgradeGroup`, `getGroupUpgradeStatus`, `retryGroupUpgrade`
  - `nestGroup`, `unnestGroup`, `listSubgroups`
  - `detachContextFromGroup`
- added context methods:
  - `getContextGroup`, `getContextStorage`, `syncContext`, `inviteSpecializedNode`, `updateContextApplication`, `getContextsWithExecutorsForApplication`
- added context identity alias methods:
  - `listContextIdentityAliases`, `createContextIdentityAlias`, `lookupContextIdentityAlias`, `deleteContextIdentityAlias`
- added TEE methods:
  - `getTeeInfo`, `teeAttest`, `teeVerifyQuote`

## Verification
- [x] `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-477b1100-cdff-40ed-8e5a-4596114ac916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-477b1100-cdff-40ed-8e5a-4596114ac916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

