### PR TITLE
feat: generic metadata records + capability constants

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -421,12 +421,12 @@ describe('AdminApiClient', () => {
 
     it('createNamespace sends correct fields', async () => {
       mock.setMockResponse('POST', '/admin-api/namespaces', { data: { namespaceId: 'ns-1' } });
-      const result = await client.createNamespace({ applicationId: 'app-1', upgradePolicy: 'manual', alias: 'My NS' });
+      const result = await client.createNamespace({ applicationId: 'app-1', upgradePolicy: 'manual', name: 'My NS' });
       expect(result).toEqual({ namespaceId: 'ns-1' });
       expect(mock.getRequestBody('POST', '/admin-api/namespaces')).toEqual({
         applicationId: 'app-1',
         upgradePolicy: 'manual',
-        alias: 'My NS',
+        name: 'My NS',
       });
     });
 
@@ -442,9 +442,9 @@ describe('AdminApiClient', () => {
         invitation: { inviterIdentity: [1], groupId: [2], expirationTimestamp: 999, secretSalt: [3], invitedRole: 1 },
         inviterSignature: 'sig-1',
       };
-      mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/invite', { data: { invitation, groupAlias: 'NS' } });
+      mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/invite', { data: { invitation, groupName: 'NS' } });
       const result = await client.createNamespaceInvitation('ns-1', { expirationTimestamp: 999 });
-      expect(result).toEqual({ invitation, groupAlias: 'NS' });
+      expect(result).toEqual({ invitation, groupName: 'NS' });
     });
 
     it('joinNamespace sends structured invitation', async () => {
@@ -455,21 +455,21 @@ describe('AdminApiClient', () => {
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
         data: { groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' },
       });
-      const result = await client.joinNamespace('ns-1', { invitation, groupAlias: 'My NS' });
+      const result = await client.joinNamespace('ns-1', { invitation, groupName: 'My NS' });
       expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' });
-      expect(mock.getRequestBody('POST', '/admin-api/namespaces/ns-1/join')).toEqual({ invitation, groupAlias: 'My NS' });
+      expect(mock.getRequestBody('POST', '/admin-api/namespaces/ns-1/join')).toEqual({ invitation, groupName: 'My NS' });
     });
 
     it('createGroupInNamespace sends request', async () => {
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/groups', { data: { groupId: 'g-1' } });
-      const result = await client.createGroupInNamespace('ns-1', { alias: 'Sub' });
+      const result = await client.createGroupInNamespace('ns-1', { name: 'Sub' });
       expect(result).toEqual({ groupId: 'g-1' });
     });
 
     it('listNamespaceGroups unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/groups', { data: [{ groupId: 'g-1', alias: 'Sub' }] });
+      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/groups', { data: [{ groupId: 'g-1', name: 'Sub' }] });
       const result = await client.listNamespaceGroups('ns-1');
-      expect(result).toEqual([{ groupId: 'g-1', alias: 'Sub' }]);
+      expect(result).toEqual([{ groupId: 'g-1', name: 'Sub' }]);
     });
   });
 
@@ -484,7 +484,7 @@ describe('AdminApiClient', () => {
         contextCount: 2,
         defaultCapabilities: 7,
         subgroupVisibility: 'open',
-        alias: 'Lobby',
+        metadata: null,
         activeUpgrade: null,
       };
       mock.setMockResponse('GET', '/admin-api/groups/g-1', { data: info });
@@ -492,6 +492,38 @@ describe('AdminApiClient', () => {
       expect(result.memberCount).toBe(3);
       expect(result.defaultCapabilities).toBe(7);
       expect(result.subgroupVisibility).toBe('open');
+    });
+
+    it('getDefaultCapabilities returns the bitmask from getGroupInfo', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g-1', {
+        data: {
+          groupId: 'g-1',
+          appKey: 'key',
+          targetApplicationId: 'app-1',
+          upgradePolicy: 'manual',
+          memberCount: 1,
+          contextCount: 0,
+          defaultCapabilities: 37,
+          subgroupVisibility: 'open',
+        },
+      });
+      expect(await client.getDefaultCapabilities('g-1')).toBe(37);
+    });
+
+    it('getSubgroupVisibility returns the value from getGroupInfo', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g-1', {
+        data: {
+          groupId: 'g-1',
+          appKey: 'key',
+          targetApplicationId: 'app-1',
+          upgradePolicy: 'manual',
+          memberCount: 1,
+          contextCount: 0,
+          defaultCapabilities: 0,
+          subgroupVisibility: 'open',
+        },
+      });
+      expect(await client.getSubgroupVisibility('g-1')).toBe('open');
     });
 
     it('deleteGroup without requester', async () => {
@@ -633,17 +665,52 @@ describe('AdminApiClient', () => {
       await client.updateGroupSettings('g-1', { upgradePolicy: 'automatic' });
       expect(mock.getRequestBody('PATCH', '/admin-api/groups/g-1')).toEqual({ upgradePolicy: 'automatic' });
     });
+  });
 
-    it('setGroupAlias sends alias', async () => {
-      mock.setMockResponse('PUT', '/admin-api/groups/g-1/alias', {});
-      await client.setGroupAlias('g-1', { alias: 'My Group' });
-      expect(mock.getRequestBody('PUT', '/admin-api/groups/g-1/alias')).toEqual({ alias: 'My Group' });
+  describe('Group / member / context metadata', () => {
+    const record = { name: 'Reports', data: { color: '#f80' }, updatedAt: 123, updatedBy: 'abc' };
+
+    it('setGroupMetadata sends PUT with the request body', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/g1/metadata', {});
+      await client.setGroupMetadata('g1', { name: 'Reports', data: { color: '#f80' } });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/g1/metadata')).toEqual({
+        name: 'Reports',
+        data: { color: '#f80' },
+      });
     });
 
-    it('setMemberAlias sends alias', async () => {
-      mock.setMockResponse('PUT', '/admin-api/groups/g-1/members/pk-1/alias', {});
-      await client.setMemberAlias('g-1', 'pk-1', { alias: 'Alice' });
-      expect(mock.getRequestBody('PUT', '/admin-api/groups/g-1/members/pk-1/alias')).toEqual({ alias: 'Alice' });
+    it('getGroupMetadata returns the inner MetadataRecord', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: { data: record } });
+      expect(await client.getGroupMetadata('g1')).toEqual(record);
+    });
+
+    it('getGroupMetadata returns null when no metadata has been set', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: { data: null } });
+      expect(await client.getGroupMetadata('g1')).toBeNull();
+    });
+
+    it('setMemberMetadata sends PUT to the member path', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/g1/members/pk-1/metadata', {});
+      await client.setMemberMetadata('g1', 'pk-1', { name: 'Alice' });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/g1/members/pk-1/metadata')).toEqual({ name: 'Alice' });
+    });
+
+    it('getMemberMetadata returns the inner MetadataRecord', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', { data: { data: record } });
+      expect(await client.getMemberMetadata('g1', 'pk-1')).toEqual(record);
+    });
+
+    it('setContextMetadata sends PUT to the context path', async () => {
+      mock.setMockResponse('PUT', '/admin-api/groups/g1/contexts/ctx-1/metadata', {});
+      await client.setContextMetadata('g1', 'ctx-1', { data: { region: 'eu' } });
+      expect(mock.getRequestBody('PUT', '/admin-api/groups/g1/contexts/ctx-1/metadata')).toEqual({
+        data: { region: 'eu' },
+      });
+    });
+
+    it('getContextMetadata returns the inner MetadataRecord', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: { data: record } });
+      expect(await client.getContextMetadata('g1', 'ctx-1')).toEqual(record);
     });
   });
 
@@ -738,15 +805,15 @@ describe('AdminApiClient', () => {
 
     it('createGroupInvitation returns structured invitation', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/invite', {
-        data: { invitation: mockInvitation, groupAlias: 'Lobby' },
+        data: { invitation: mockInvitation, groupName: 'Lobby' },
       });
       const result = await client.createGroupInvitation('g-1', { expirationTimestamp: 999 });
-      expect(result).toEqual({ invitation: mockInvitation, groupAlias: 'Lobby' });
+      expect(result).toEqual({ invitation: mockInvitation, groupName: 'Lobby' });
     });
 
     it('createGroupInvitation with recursive returns list', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/invite', {
-        data: { invitations: [{ groupId: 'g-1', invitation: mockInvitation, groupAlias: 'Lobby' }] },
+        data: { invitations: [{ groupId: 'g-1', invitation: mockInvitation, groupName: 'Lobby' }] },
       });
       const result = await client.createGroupInvitation('g-1', { recursive: true });
       expect('invitations' in result).toBe(true);
@@ -756,11 +823,11 @@ describe('AdminApiClient', () => {
       mock.setMockResponse('POST', '/admin-api/groups/join', {
         data: { groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' },
       });
-      const result = await client.joinGroup({ invitation: mockInvitation, groupAlias: 'Lobby' });
+      const result = await client.joinGroup({ invitation: mockInvitation, groupName: 'Lobby' });
       expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' });
       expect(mock.getRequestBody('POST', '/admin-api/groups/join')).toEqual({
         invitation: mockInvitation,
-        groupAlias: 'Lobby',
+        groupName: 'Lobby',
       });
     });
   });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -69,8 +69,11 @@ import type {
   SetSubgroupVisibilityRequest,
   SetTeeAdmissionPolicyRequest,
   UpdateGroupSettingsRequest,
-  SetGroupAliasRequest,
-  SetMemberAliasRequest,
+  SetGroupMetadataRequest,
+  SetMemberMetadataRequest,
+  SetContextMetadataRequest,
+  MetadataRecord,
+  GetMetadataResponseData,
   SyncGroupRequest,
   SyncGroupResponseData,
   RegisterGroupSigningKeyRequest,
@@ -449,6 +452,16 @@ export class AdminApiClient {
     return unwrap(await this.httpClient.get<{ data: GroupInfoResponseData }>(`/admin-api/groups/${groupId}`));
   }
 
+  /** Thin wrapper over {@link getGroupInfo}: returns the group's `defaultCapabilities` bitmask. */
+  async getDefaultCapabilities(groupId: string): Promise<number> {
+    return (await this.getGroupInfo(groupId)).defaultCapabilities;
+  }
+
+  /** Thin wrapper over {@link getGroupInfo}: returns the group's `subgroupVisibility`. */
+  async getSubgroupVisibility(groupId: string): Promise<string> {
+    return (await this.getGroupInfo(groupId)).subgroupVisibility;
+  }
+
   async deleteGroup(groupId: string, request?: DeleteGroupRequest): Promise<DeleteGroupResponseData> {
     if (request) {
       return unwrap(
@@ -547,16 +560,42 @@ export class AdminApiClient {
     await this.httpClient.patch(`/admin-api/groups/${groupId}`, request);
   }
 
-  async setGroupAlias(groupId: string, request: SetGroupAliasRequest): Promise<void> {
-    await this.httpClient.put(`/admin-api/groups/${groupId}/alias`, request);
+  // ---- Group / member / context metadata ----
+
+  async setGroupMetadata(groupId: string, request: SetGroupMetadataRequest): Promise<void> {
+    await this.httpClient.put(`/admin-api/groups/${groupId}/metadata`, request);
   }
 
-  async setMemberAlias(
+  async getGroupMetadata(groupId: string): Promise<MetadataRecord | null> {
+    return unwrap(await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/metadata`)).data;
+  }
+
+  async setMemberMetadata(
     groupId: string,
     identity: string,
-    request: SetMemberAliasRequest,
+    request: SetMemberMetadataRequest,
   ): Promise<void> {
-    await this.httpClient.put(`/admin-api/groups/${groupId}/members/${identity}/alias`, request);
+    await this.httpClient.put(`/admin-api/groups/${groupId}/members/${identity}/metadata`, request);
+  }
+
+  async getMemberMetadata(groupId: string, identity: string): Promise<MetadataRecord | null> {
+    return unwrap(
+      await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/members/${identity}/metadata`),
+    ).data;
+  }
+
+  async setContextMetadata(
+    groupId: string,
+    contextId: string,
+    request: SetContextMetadataRequest,
+  ): Promise<void> {
+    await this.httpClient.put(`/admin-api/groups/${groupId}/contexts/${contextId}/metadata`, request);
+  }
+
+  async getContextMetadata(groupId: string, contextId: string): Promise<MetadataRecord | null> {
+    return unwrap(
+      await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/contexts/${contextId}/metadata`),
+    ).data;
   }
 
   async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -82,7 +82,9 @@ export interface CreateContextRequest {
   contextSeed?: string;
   initializationParams?: number[];
   identitySecret?: string;
-  alias?: string;
+  // Renamed from `alias` in core (`context create --alias` -> `--group-name`)
+  // because `--name` was already the node-local alias flag.
+  groupName?: string;
 }
 
 export interface CreateContextResponseData {
@@ -252,7 +254,7 @@ export interface SignedGroupOpenInvitation {
 export interface RecursiveInvitationEntry {
   groupId: string;
   invitation: SignedGroupOpenInvitation;
-  groupAlias?: string;
+  groupName?: string;
 }
 
 // ---- Namespaces ----
@@ -263,7 +265,7 @@ export interface Namespace {
   targetApplicationId: string;
   upgradePolicy: string;
   createdAt: number;
-  alias?: string;
+  name?: string;
   memberCount: number;
   contextCount: number;
   subgroupCount: number;
@@ -279,7 +281,7 @@ export interface NamespaceIdentity {
 export interface CreateNamespaceRequest {
   applicationId: string;
   upgradePolicy: string;
-  alias?: string;
+  name?: string;
 }
 
 export interface CreateNamespaceResponseData {
@@ -302,7 +304,7 @@ export interface CreateNamespaceInvitationRequest {
 
 export interface CreateNamespaceInvitationResponseData {
   invitation: SignedGroupOpenInvitation;
-  groupAlias?: string;
+  groupName?: string;
 }
 
 export interface CreateRecursiveInvitationResponseData {
@@ -311,7 +313,7 @@ export interface CreateRecursiveInvitationResponseData {
 
 export interface JoinNamespaceRequest {
   invitation: SignedGroupOpenInvitation;
-  groupAlias?: string;
+  groupName?: string;
 }
 
 export interface JoinNamespaceResponseData {
@@ -322,7 +324,7 @@ export interface JoinNamespaceResponseData {
 
 export interface CreateGroupInNamespaceRequest {
   groupId?: string;
-  alias?: string;
+  name?: string;
 }
 
 export interface CreateGroupInNamespaceResponseData {
@@ -331,7 +333,7 @@ export interface CreateGroupInNamespaceResponseData {
 
 export interface SubgroupEntry {
   groupId: string;
-  alias?: string;
+  name?: string;
 }
 
 // ---- Groups ----
@@ -341,7 +343,7 @@ export interface CreateGroupRequest {
   upgradePolicy: string;
   groupId?: string;
   appKey?: string;
-  alias?: string;
+  name?: string;
   parentGroupId?: string;
 }
 
@@ -371,7 +373,11 @@ export interface GroupInfo {
   activeUpgrade?: GroupUpgradeStatus;
   defaultCapabilities: number;
   subgroupVisibility: string;
-  alias?: string;
+  /**
+   * The group's generic metadata record (replaces the old `alias` field).
+   * `null` if no metadata has ever been set for this group.
+   */
+  metadata?: MetadataRecord | null;
 }
 
 export type GroupInfoResponseData = GroupInfo;
@@ -379,7 +385,7 @@ export type GroupInfoResponseData = GroupInfo;
 export interface GroupMember {
   identity: string;
   role: string;
-  alias?: string;
+  name?: string;
 }
 
 export interface ListGroupMembersResponseData {
@@ -396,7 +402,7 @@ export interface ListGroupMembersResponseData {
 
 export interface GroupContextEntry {
   contextId: string;
-  alias?: string;
+  name?: string;
 }
 
 export type ListGroupContextsResponseData = GroupContextEntry[];
@@ -492,21 +498,51 @@ export interface UpdateGroupSettingsRequest {
 // Returns empty
 export type UpdateGroupSettingsResponseData = Record<string, never>;
 
-export interface SetGroupAliasRequest {
-  alias: string;
+// ---- Group / member / context metadata ----
+
+/**
+ * Generic metadata record attached to a group, group member, or
+ * context-registered-in-a-group (core `calimero_primitives::metadata::MetadataRecord`).
+ *
+ * `data` is application-defined and opaque to core — it is stored verbatim.
+ * Server-enforced size limits: `name` <= 64 bytes; at most 64 entries in
+ * `data`; each key <= 64 bytes; each value <= 4096 bytes. Clients do not need
+ * to enforce these — the server validates.
+ */
+export interface MetadataRecord {
+  name: string | null;
+  data: Record<string, string>;
+  updatedAt: number;
+  /** Public key (hex) of the member that last updated the record. */
+  updatedBy: string;
+}
+
+/**
+ * Request body for setting a metadata record. **This wholly replaces the
+ * record**: `data` defaults to `{}` server-side and replaces the stored map,
+ * while omitting `name` keeps the current name. To change `name` while
+ * preserving existing `data`, GET the record first and pass its `data` back.
+ */
+export interface SetMetadataRequest {
+  name?: string;
+  data?: Record<string, string>;
   requester?: string;
 }
 
-// Returns empty
-export type SetGroupAliasResponseData = Record<string, never>;
+export type SetGroupMetadataRequest = SetMetadataRequest;
+export type SetMemberMetadataRequest = SetMetadataRequest;
+export type SetContextMetadataRequest = SetMetadataRequest;
 
-export interface SetMemberAliasRequest {
-  alias: string;
-  requester?: string;
+// Set-metadata returns empty
+export type SetMetadataResponseData = Record<string, never>;
+
+/**
+ * Inner payload of a GET metadata response. `data` is `null` if no metadata
+ * has ever been set for the target group/member/context.
+ */
+export interface GetMetadataResponseData {
+  data: MetadataRecord | null;
 }
-
-// Returns empty
-export type SetMemberAliasResponseData = Record<string, never>;
 
 // ---- Group Sync, Signing & Upgrades ----
 
@@ -588,7 +624,7 @@ export interface CreateGroupInvitationRequest {
 
 export interface CreateGroupInvitationResponseData {
   invitation: SignedGroupOpenInvitation;
-  groupAlias?: string;
+  groupName?: string;
 }
 
 export interface CreateRecursiveGroupInvitationResponseData {
@@ -597,7 +633,7 @@ export interface CreateRecursiveGroupInvitationResponseData {
 
 export interface JoinGroupRequest {
   invitation: SignedGroupOpenInvitation;
-  groupAlias?: string;
+  groupName?: string;
 }
 
 export interface JoinGroupResponseData {

--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { CAPABILITIES, hasCap, withCap, withoutCap } from './capabilities';
+
+describe('capabilities', () => {
+  it('exposes the expected capability bits as powers of two', () => {
+    expect(CAPABILITIES).toEqual({
+      CAN_CREATE_CONTEXT: 1,
+      CAN_INVITE_MEMBERS: 2,
+      CAN_JOIN_OPEN_SUBGROUPS: 4,
+      MANAGE_MEMBERS: 8,
+      MANAGE_APPLICATION: 16,
+      CAN_CREATE_SUBGROUP: 32,
+      CAN_DELETE_SUBGROUP: 64,
+      CAN_MANAGE_VISIBILITY: 128,
+      CAN_MANAGE_METADATA: 256,
+    });
+    expect(Object.keys(CAPABILITIES)).toHaveLength(9);
+    for (const value of Object.values(CAPABILITIES)) {
+      expect(value & (value - 1)).toBe(0); // exactly one bit set
+    }
+  });
+
+  it('hasCap checks every bit of the requested mask is present', () => {
+    expect(hasCap(0b101, 0b100)).toBe(true);
+    expect(hasCap(0b101, 0b010)).toBe(false);
+    expect(hasCap(0b101, 0b101)).toBe(true);
+    expect(hasCap(0, CAPABILITIES.CAN_CREATE_CONTEXT)).toBe(false);
+  });
+
+  it('hasCap handles high bits like 1 << 31 (signed-int safety)', () => {
+    const appBit = withCap(0, 1 << 31); // u32-normalized => 0x80000000
+    expect(hasCap(appBit, 1 << 31)).toBe(true);
+    expect(hasCap(appBit, appBit)).toBe(true);
+    expect(hasCap(withCap(appBit, CAPABILITIES.CAN_CREATE_CONTEXT), 1 << 31)).toBe(true);
+    expect(hasCap(CAPABILITIES.CAN_CREATE_CONTEXT, 1 << 31)).toBe(false);
+  });
+
+  it('withCap sets bits', () => {
+    expect(withCap(0, CAPABILITIES.CAN_CREATE_SUBGROUP)).toBe(32);
+    expect(withCap(0b001, 0b100)).toBe(0b101);
+  });
+
+  it('withoutCap clears bits', () => {
+    expect(withoutCap(0b111, 0b010)).toBe(0b101);
+    expect(withoutCap(0, CAPABILITIES.CAN_MANAGE_METADATA)).toBe(0);
+  });
+
+  it('withCap / withoutCap return u32-normalized non-negative numbers', () => {
+    const a = withCap(-1, CAPABILITIES.CAN_CREATE_CONTEXT);
+    const b = withoutCap(-1, CAPABILITIES.CAN_CREATE_CONTEXT);
+    expect(a).toBeGreaterThanOrEqual(0);
+    expect(b).toBeGreaterThanOrEqual(0);
+    expect(a).toBe(0xffffffff);
+    expect(b).toBe(0xfffffffe);
+  });
+});

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,48 @@
+// Member capability bitmask constants — mirrors core's `MemberCapabilities`
+// (crates/context/config/src/lib.rs). The value stored per-member is a u32
+// bitmask. Core currently assigns bits 0..=8; bits 9 and above are unassigned
+// and may be claimed by future core versions, so an application MUST NOT
+// assume any particular bit is safe for its own use unless core documents it
+// as reserved for applications.
+
+/**
+ * Capability bits as defined by core's `MemberCapabilities`.
+ *
+ * The per-member value is a u32 bitmask. Core currently assigns bits 0..=8
+ * (the entries below); bits 9 and above are unassigned — do not repurpose
+ * them for application data, as a future core release may claim them.
+ */
+export const CAPABILITIES = {
+  CAN_CREATE_CONTEXT: 1 << 0,
+  CAN_INVITE_MEMBERS: 1 << 1,
+  CAN_JOIN_OPEN_SUBGROUPS: 1 << 2,
+  MANAGE_MEMBERS: 1 << 3,
+  MANAGE_APPLICATION: 1 << 4,
+  CAN_CREATE_SUBGROUP: 1 << 5,
+  CAN_DELETE_SUBGROUP: 1 << 6,
+  CAN_MANAGE_VISIBILITY: 1 << 7,
+  CAN_MANAGE_METADATA: 1 << 8,
+} as const;
+
+export type CapabilityName = keyof typeof CAPABILITIES;
+export type CapabilityBit = (typeof CAPABILITIES)[CapabilityName];
+
+/**
+ * Returns true if `mask` has every bit of `cap` set. Both operands are
+ * coerced to unsigned 32-bit (`>>> 0`) before comparing so a high bit such
+ * as `1 << 31` doesn't fall foul of `&` yielding a signed result.
+ */
+export function hasCap(mask: number, cap: number): boolean {
+  const capU32 = cap >>> 0;
+  return ((mask & capU32) >>> 0) === capU32;
+}
+
+/** Returns `mask` with every bit of `cap` set (u32-normalized). */
+export function withCap(mask: number, cap: number): number {
+  return (mask | cap) >>> 0;
+}
+
+/** Returns `mask` with every bit of `cap` cleared (u32-normalized). */
+export function withoutCap(mask: number, cap: number): number {
+  return (mask & ~cap) >>> 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,4 +33,7 @@ export type { SseEventData, WsEventData } from './events';
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud';
 
+// Member capability bitmask constants & helpers
+export * from './capabilities';
+
 // Utilities


### PR DESCRIPTION
Tracks core PR #2338 (*generic metadata records — replace group alias*, merged as `054a784f`) and adds first-class capability constants. Three changes in one PR:

## JS-1 — capability constants (`src/capabilities.ts`)
- `CAPABILITIES` const mirroring core's `MemberCapabilities`: `CAN_CREATE_CONTEXT=1<<0`, `CAN_INVITE_MEMBERS=1<<1`, `CAN_JOIN_OPEN_SUBGROUPS=1<<2`, `MANAGE_MEMBERS=1<<3`, `MANAGE_APPLICATION=1<<4`, `CAN_CREATE_SUBGROUP=1<<5`, `CAN_DELETE_SUBGROUP=1<<6`, `CAN_MANAGE_VISIBILITY=1<<7`, `CAN_MANAGE_METADATA=1<<8`. Core currently assigns bits 0–8; bits 9+ are unassigned and may be claimed by a future core release — apps must not repurpose them.
- Helpers `hasCap(mask, cap)`, `withCap(mask, cap)`, `withoutCap(mask, cap)` (return `>>> 0`-normalized); types `CapabilityName`, `CapabilityBit`.
- Re-exported from `src/index.ts`.

Consumers previously hard-coded these bit values — that caused at least one downstream collision (an app's `READ/WRITE/CREATE_GROUP/...` bitmask overlapping core's real bit meanings). One source of truth now.

## JS-3 — metadata API (replaces group/member/context alias)
- New types: `MetadataRecord { name: string|null; data: Record<string,string>; updatedAt: number; updatedBy: string }`, `SetMetadataRequest { name?; data?; requester? }` (+ `SetGroupMetadataRequest`/`SetMemberMetadataRequest`/`SetContextMetadataRequest` aliases), `SetMetadataResponseData`, `GetMetadataResponseData { data: MetadataRecord|null }`.
- New `AdminApiClient` methods: `setGroupMetadata`/`getGroupMetadata`, `setMemberMetadata`/`getMemberMetadata`, `setContextMetadata`/`getContextMetadata` (hitting `PUT/GET /admin-api/groups/:gid/metadata`, `…/members/:id/metadata`, `…/contexts/:cid/metadata`). `set*` **wholly replaces** the record (`data` defaults to `{}`; omit `name` to keep current) — documented on the type.
- **Removed:** `setGroupAlias`, `setMemberAlias` (+ `SetGroupAliasRequest`/`SetMemberAliasRequest`/their `*ResponseData`).
- **Field renames** (matching #2338): `alias`→`name` on `Namespace`, `SubgroupEntry`, `GroupMember`, `GroupContextEntry`, `CreateNamespaceRequest`, `CreateGroupInNamespaceRequest`, `CreateGroupRequest`; `CreateContextRequest.alias`→`groupName`; `groupAlias`→`groupName` on `RecursiveInvitationEntry`, `CreateNamespaceInvitationResponseData`, `CreateGroupInvitationResponseData`, `JoinNamespaceRequest`, `JoinGroupRequest`. `GroupInfo.alias` → `GroupInfo.metadata: MetadataRecord|null`.
- The node-local merod alias system (`createContextAlias`/`lookupContextAlias`/`createContextIdentityAlias`/…) is unrelated to #2338 and is left untouched.

## JS-2 — convenience read accessors
- `getDefaultCapabilities(groupId): Promise<number>` and `getSubgroupVisibility(groupId): Promise<string>` — thin wrappers over `getGroupInfo`.

## Tests / verification
- New `src/capabilities.test.ts`; `admin-client.test.ts` updated (metadata methods + new getters; old alias tests removed).
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm test:unit` ✓ (188) · `pnpm build` ✓.

## ⚠️ Breaking
Removes `setGroupAlias`/`setMemberAlias` and renames `alias`/`groupAlias` fields. Consumers must migrate to the metadata methods + `name`/`groupName` fields. (Matches the breaking change already in core #2338 — the `…/alias` HTTP routes no longer exist.) `mero-react` PR + a mero-drive bump follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces breaking API renames/removals (`alias`/`groupAlias` -> `name`/`groupName`, removes `setGroupAlias`/`setMemberAlias`) and adds new Admin API endpoints that downstream consumers must adopt.
> 
> **Overview**
> **Admin API breaking rename + metadata support.** Updates Admin API request/response types and tests to rename `alias`/`groupAlias` fields to `name`/`groupName`, and replaces `GroupInfo.alias` with `GroupInfo.metadata`.
> 
> Adds new group/member/context metadata endpoints to `AdminApiClient` (`set*Metadata`/`get*Metadata`) and corresponding types (`MetadataRecord`, `SetMetadataRequest`, `GetMetadataResponseData`), while removing the old alias setters (`setGroupAlias`, `setMemberAlias`).
> 
> **Capabilities utilities.** Introduces `src/capabilities.ts` with exported `CAPABILITIES` bit constants plus `hasCap`/`withCap`/`withoutCap` helpers (u32-normalized), adds unit tests, and re-exports from `src/index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c94a72a5f01a30292875ca0ebbcdfc36d5e9fac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->