### PR TITLE
feat(admin): add joinSubgroupInheritance method

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -830,6 +830,23 @@ describe('AdminApiClient', () => {
         groupName: 'Lobby',
       });
     });
+
+    it('joinSubgroupInheritance posts to groups/:id/join-via-inheritance and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/g-1/join-via-inheritance', {
+        data: { groupId: 'g-1', memberPublicKey: 'pk-1', wasInherited: true },
+      });
+      const result = await client.joinSubgroupInheritance('g-1');
+      expect(result).toEqual({ groupId: 'g-1', memberPublicKey: 'pk-1', wasInherited: true });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/g-1/join-via-inheritance')).toEqual({});
+    });
+
+    it('joinSubgroupInheritance returns wasInherited=false on direct-member no-op', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/g-2/join-via-inheritance', {
+        data: { groupId: 'g-2', memberPublicKey: 'pk-2', wasInherited: false },
+      });
+      const result = await client.joinSubgroupInheritance('g-2');
+      expect(result.wasInherited).toBe(false);
+    });
   });
 
   describe('TEE', () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -20,6 +20,7 @@ import type {
   GenerateContextIdentityResponseData,
   GetContextIdentitiesResponseData,
   JoinContextResponseData,
+  JoinSubgroupInheritanceResponseData,
   ContextGroupResponseData,
   ContextStorageResponseData,
   InviteSpecializedNodeRequest,
@@ -673,6 +674,15 @@ export class AdminApiClient {
   async joinGroup(request: JoinGroupRequest): Promise<JoinGroupResponseData> {
     return unwrap(
       await this.httpClient.post<{ data: JoinGroupResponseData }>('/admin-api/groups/join', request),
+    );
+  }
+
+  async joinSubgroupInheritance(groupId: string): Promise<JoinSubgroupInheritanceResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: JoinSubgroupInheritanceResponseData }>(
+        `/admin-api/groups/${groupId}/join-via-inheritance`,
+        {},
+      ),
     );
   }
 

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -135,6 +135,17 @@ export interface JoinContextResponseData {
   memberPublicKey: string;
 }
 
+// ---- Open subgroup join via inheritance (POST /groups/:group_id/join-via-inheritance) ----
+
+export interface JoinSubgroupInheritanceResponseData {
+  groupId: string;
+  memberPublicKey: string;
+  // `true` if the call had to publish a `MemberJoinedOpen` op to materialise
+  // inherited membership; `false` if the caller was already a direct member
+  // and the call was a no-op.
+  wasInherited: boolean;
+}
+
 // ---- Context group / storage / sync ----
 
 export type ContextGroupResponseData = string | null;


### PR DESCRIPTION
## Summary

Wraps the new `POST /admin-api/groups/:group_id/join-via-inheritance` endpoint added in [calimero-network/core#2360](https://github.com/calimero-network/core/pull/2360) (closes [core#2357](https://github.com/calimero-network/core/issues/2357)). Lets a namespace member who is inherited into an Open subgroup materialise that membership locally without an admin-signed invitation.

- New `AdminApiClient.joinSubgroupInheritance(groupId)` mirroring the existing `joinContext` shape — takes a `groupId`, returns `{ groupId, memberPublicKey, wasInherited }`
- New `JoinSubgroupInheritanceResponseData` type (camelCase to match the wire format)
- Two unit tests: happy-path materialisation (`wasInherited: true`) and direct-member no-op (`wasInherited: false`)

The `wasInherited` flag distinguishes the two outcomes the endpoint can produce: `true` when the call published a `MemberJoinedOpen` op to materialise inherited membership, `false` when the caller was already a direct member (idempotent no-op).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test:unit` — 191 passed
- [x] `pnpm lint` — clean
- [ ] e2e against a node built from core master (after merge)

## Follow-ups

- mero-react: corresponding `useJoinSubgroupInheritance` hook (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a small, isolated Admin API client wrapper and type plus unit tests, with no changes to existing request/response handling beyond a new endpoint call.
> 
> **Overview**
> Adds `AdminApiClient.joinSubgroupInheritance(groupId)` to call the new `POST /admin-api/groups/:groupId/join-via-inheritance` endpoint and unwrap `{ data }` into a typed result.
> 
> Introduces `JoinSubgroupInheritanceResponseData` (including `wasInherited`) and covers the new method with unit tests for both inherited-materialization and idempotent no-op responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc09772c27afede806de2b9421427035932ddc50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->