### PR TITLE
fix(admin): listSubgroups reads `subgroups` field from server response

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -784,10 +784,27 @@ describe('AdminApiClient', () => {
       expect(mock.getRequestBody('POST', '/admin-api/groups/parent-1/unnest')).toEqual({ childGroupId: 'child-1' });
     });
 
-    it('listSubgroups unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/groups/g-1/subgroups', { data: [{ groupId: 'sub-1', alias: 'Sub' }] });
+    it('listSubgroups reads the `subgroups` field (current server shape)', async () => {
+      // merod returns `{ subgroups: [...] }` for this endpoint
+      // (see ListSubgroupsApiResponse in core/crates/server/primitives/src/admin/mod.rs).
+      mock.setMockResponse('GET', '/admin-api/groups/g-1/subgroups', { subgroups: [{ groupId: 'sub-1', name: 'Sub' }] });
       const result = await client.listSubgroups('g-1');
-      expect(result).toEqual([{ groupId: 'sub-1', alias: 'Sub' }]);
+      expect(result).toEqual([{ groupId: 'sub-1', name: 'Sub' }]);
+    });
+
+    it('listSubgroups falls back to `data` if the server normalizes the wrapper', async () => {
+      // Forward-compat: if core ever standardizes this endpoint to the common
+      // `{ data: [...] }` wrapper used by the rest of the admin API, the SDK
+      // keeps working without a coordinated release.
+      mock.setMockResponse('GET', '/admin-api/groups/g-1/subgroups', { data: [{ groupId: 'sub-1', name: 'Sub' }] });
+      const result = await client.listSubgroups('g-1');
+      expect(result).toEqual([{ groupId: 'sub-1', name: 'Sub' }]);
+    });
+
+    it('listSubgroups returns [] when neither wrapper field is present', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g-1/subgroups', {});
+      const result = await client.listSubgroups('g-1');
+      expect(result).toEqual([]);
     });
 
     it('detachContextFromGroup sends request', async () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -646,7 +646,10 @@ export class AdminApiClient {
   }
 
   async listSubgroups(groupId: string): Promise<SubgroupEntry[]> {
-    return unwrap(await this.httpClient.get<{ data: SubgroupEntry[] }>(`/admin-api/groups/${groupId}/subgroups`));
+    const response = await this.httpClient.get<{ subgroups?: SubgroupEntry[]; data?: SubgroupEntry[] }>(
+      `/admin-api/groups/${groupId}/subgroups`,
+    );
+    return response.subgroups ?? response.data ?? [];
   }
 
   async detachContextFromGroup(


### PR DESCRIPTION
## Summary

- `listSubgroups` was reading `.data` from the server response via `unwrap()`, but `/admin-api/groups/:id/subgroups` in merod returns its payload under a `subgroups` key. The method silently returned `undefined`.
- Read `response.subgroups` first; fall back to `response.data` for forward-compat; default to `[]` so callers always get an array.

## Bug in the wild

In the Calimero desktop app, the entire Subgroups section disappeared from a group's detail view — even when the server was returning subgroups (with names). The React hook `useSubgroups` did `setSubgroups(undefined)` and the consuming component's destructuring default kicked in, hiding the section.

## Why `subgroups` and not `data`

`crates/server/primitives/src/admin/mod.rs` in core:

```rust
#[derive(Clone, Debug, Deserialize, Serialize)]
#[serde(rename_all = "camelCase")]
pub struct ListSubgroupsApiResponse {
    pub subgroups: Vec<SubgroupEntryApiResponse>,
}
```

Most other admin endpoints use `pub data: …`; this one is the odd one out. Rather than coordinate a server-side normalization release, this PR aligns the SDK with what the server actually emits today, while also handling the future-normalized shape transparently.

## Tests

- Replace the broken existing test (it mocked `{data: [...]}`, matching the bug rather than the server) — was passing for the wrong reason.
- Add a test for the real `{subgroups: [...]}` server shape.
- Add a forward-compat test for `{data: [...]}` normalization.
- Add a safety test that an empty response yields `[]`.

All 193 tests pass.

## Test plan

- [ ] CI passes
- [ ] Smoke-tested against a real merod (verified locally: subgroup with name "Cool new thing" now renders in the desktop app's Subgroups section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to response parsing for `listSubgroups`, plus tighter tests; behavior changes only for this endpoint and now defaults safely to an empty array.
> 
> **Overview**
> Fixes `AdminApiClient.listSubgroups()` to read the server’s current `{ subgroups: [...] }` response shape instead of assuming the standard `{ data: [...] }` wrapper, with a fallback to `data` for forward compatibility and a `[]` default when neither field exists.
> 
> Updates tests to match the real server payload, adds coverage for the `data` fallback, and asserts the empty-response behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f6d19230853c7bce795bad1c3d5a979be1e80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->