### PR TITLE
feat: migration-UX SDK surfaces — migration/cascade status, typed SSE, migrateMyEntries (6g, #2539)

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -771,6 +771,77 @@ describe('AdminApiClient', () => {
     });
   });
 
+  describe('Migration status', () => {
+    it('getMigrationStatus reads the top-level rollup (no data envelope)', async () => {
+      const body = {
+        targetVersion: 2,
+        expectedMembers: 3,
+        rollup: {
+          migrated: 2,
+          inProgress: 0,
+          unknown: 1,
+          total: 3,
+          allMigrated: false,
+          membersPendingSignature: 1,
+        },
+        members: [
+          {
+            peer: 'aa',
+            report: {
+              schemaVersion: 2,
+              residueAuto: 0,
+              residueIdentity: 0,
+              syncedUpToHlc: 0,
+              reportedAt: 0,
+              authoredRemaining: 0,
+            },
+            state: 'migrated',
+          },
+          {
+            peer: 'bb',
+            report: {
+              schemaVersion: 1,
+              residueAuto: 0,
+              residueIdentity: 0,
+              syncedUpToHlc: 0,
+              reportedAt: 0,
+              authoredRemaining: 2,
+            },
+            state: 'in_progress',
+          },
+          { peer: 'cc', report: null, state: 'unknown' },
+        ],
+      };
+      mock.setMockResponse('GET', '/admin-api/groups/ns1/migration-status', body);
+      const res = await client.getMigrationStatus('ns1');
+      expect(res.rollup.membersPendingSignature).toBe(1);
+      expect(res.members[1].report?.authoredRemaining).toBe(2);
+      expect(res.members[2].report).toBeNull();
+    });
+
+    it('getCascadeStatus unwraps the data array', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/ns1/cascade-status', {
+        data: [
+          {
+            groupId: 'g1',
+            upgrade: {
+              fromVersion: '1.0.0',
+              toVersion: '2.0.0',
+              initiatedAt: 1,
+              initiatedBy: 'x',
+              status: 'completed',
+            },
+            cascadeHlc: 'h1',
+          },
+        ],
+      });
+      const res = await client.getCascadeStatus('ns1');
+      expect(res).toHaveLength(1);
+      expect(res[0].cascadeHlc).toBe('h1');
+      expect(res[0].upgrade.toVersion).toBe('2.0.0');
+    });
+  });
+
   describe('Group Nesting', () => {
     it('nestGroup sends childGroupId', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/parent-1/nest', {});

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -633,13 +633,15 @@ export class AdminApiClient {
    * envelope to unwrap here (unlike most admin reads).
    */
   async getMigrationStatus(namespaceId: string): Promise<MigrationStatus> {
-    return this.httpClient.get<MigrationStatus>(`/admin-api/groups/${namespaceId}/migration-status`);
+    const id = encodeURIComponent(namespaceId);
+    return this.httpClient.get<MigrationStatus>(`/admin-api/groups/${id}/migration-status`);
   }
 
   /** Per-group cascade-migration snapshots for a namespace. */
   async getCascadeStatus(namespaceId: string): Promise<CascadeStatusEntry[]> {
+    const id = encodeURIComponent(namespaceId);
     return unwrap(
-      await this.httpClient.get<{ data: CascadeStatusEntry[] }>(`/admin-api/groups/${namespaceId}/cascade-status`),
+      await this.httpClient.get<{ data: CascadeStatusEntry[] }>(`/admin-api/groups/${id}/cascade-status`),
     );
   }
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -82,6 +82,8 @@ import type {
   UpgradeGroupRequest,
   UpgradeGroupResponseData,
   GroupUpgradeStatusResponseData,
+  MigrationStatus,
+  CascadeStatusEntry,
   RetryGroupUpgradeRequest,
   RetryGroupUpgradeResponseData,
   NestGroupRequest,
@@ -622,6 +624,22 @@ export class AdminApiClient {
   async getGroupUpgradeStatus(groupId: string): Promise<GroupUpgradeStatusResponseData> {
     return unwrap(
       await this.httpClient.get<{ data: GroupUpgradeStatusResponseData }>(`/admin-api/groups/${groupId}/upgrade/status`),
+    );
+  }
+
+  /**
+   * The operator-facing "have all peers migrated?" rollup for a namespace.
+   * The handler serializes the payload directly, so there is no `{ data }`
+   * envelope to unwrap here (unlike most admin reads).
+   */
+  async getMigrationStatus(namespaceId: string): Promise<MigrationStatus> {
+    return this.httpClient.get<MigrationStatus>(`/admin-api/groups/${namespaceId}/migration-status`);
+  }
+
+  /** Per-group cascade-migration snapshots for a namespace. */
+  async getCascadeStatus(namespaceId: string): Promise<CascadeStatusEntry[]> {
+    return unwrap(
+      await this.httpClient.get<{ data: CascadeStatusEntry[] }>(`/admin-api/groups/${namespaceId}/cascade-status`),
     );
   }
 

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -423,13 +423,6 @@ export interface CascadeStatusEntry {
   cascadeHlc?: string;
 }
 
-// ---- Authored-entry convert (migrate_my_entries / count_my_pending) ----
-
-export interface MigrateMyEntriesSummary {
-  converted: number;
-  remaining: number;
-}
-
 export interface GroupInfo {
   groupId: string;
   appKey: string;

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -108,6 +108,8 @@ export interface Context {
   serviceName?: string;
   rootHash: string;
   dagHeads: number[][];
+  /** Bundle semver of the installed application (skew #2). Absent on older nodes. */
+  applicationVersion?: string;
 }
 
 export interface ContextWithGroup extends Context {
@@ -372,6 +374,60 @@ export interface GroupUpgradeStatus {
   completed?: number;
   failed?: number;
   completedAt?: number;
+}
+
+// ---- Migration status (migration-UX core surfaces) ----
+
+export type MemberMigrationState = 'migrated' | 'in_progress' | 'unknown';
+
+export interface MemberMigrationReport {
+  schemaVersion: number;
+  residueAuto: number;
+  residueIdentity: number;
+  syncedUpToHlc: number;
+  reportedAt: number;
+  /** Member's self-reported pending-authored count (best-effort; skew #1). */
+  authoredRemaining: number;
+}
+
+export interface MemberMigrationStatusEntry {
+  peer: string;
+  /** Freshest reported facts, or `null` when the member's state is `unknown`. */
+  report: MemberMigrationReport | null;
+  state: MemberMigrationState;
+}
+
+export interface MigrationStatusRollup {
+  migrated: number;
+  inProgress: number;
+  unknown: number;
+  total: number;
+  allMigrated: boolean;
+  /** Count of members with authoredRemaining > 0 (owners still to re-sign). */
+  membersPendingSignature: number;
+}
+
+export interface MigrationStatus {
+  targetVersion: number;
+  expectedMembers: number;
+  cohortPinnedAtHlc?: string;
+  rollup: MigrationStatusRollup;
+  members: MemberMigrationStatusEntry[];
+}
+
+// ---- Cascade status ----
+
+export interface CascadeStatusEntry {
+  groupId: string;
+  upgrade: GroupUpgradeStatus;
+  cascadeHlc?: string;
+}
+
+// ---- Authored-entry convert (migrate_my_entries / count_my_pending) ----
+
+export interface MigrateMyEntriesSummary {
+  converted: number;
+  remaining: number;
 }
 
 export interface GroupInfo {

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,4 +1,4 @@
 export { SseClient } from './sse';
-export type { SseEventData } from './sse';
+export type { SseEventData, AppVersionChangedEvent } from './sse';
 export { WsClient } from './ws';
 export type { WsEventData } from './ws';

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -45,6 +45,42 @@ describe('SseClient', () => {
     });
   });
 
+  describe('onAppVersionChanged', () => {
+    it('fires with parsed payload for AppVersionChanged events', () => {
+      const seen: Array<{ contextId: string; fromVersion?: string; toVersion?: string }> = [];
+      client.onAppVersionChanged((e) => seen.push(e));
+
+      (client as any).emit('event', {
+        contextId: 'ctx1',
+        data: { type: 'AppVersionChanged', data: { fromVersion: '1.0.0', toVersion: '2.0.0' } },
+      });
+
+      expect(seen).toEqual([{ contextId: 'ctx1', fromVersion: '1.0.0', toVersion: '2.0.0' }]);
+    });
+
+    it('ignores events of other types', () => {
+      const handler = vi.fn();
+      client.onAppVersionChanged(handler);
+
+      (client as any).emit('event', { contextId: 'ctx1', data: { type: 'StateMutation', data: {} } });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns an unsubscribe handle that stops delivery', () => {
+      const handler = vi.fn();
+      const off = client.onAppVersionChanged(handler);
+      off();
+
+      (client as any).emit('event', {
+        contextId: 'ctx1',
+        data: { type: 'AppVersionChanged', data: { toVersion: '2.0.0' } },
+      });
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
   describe('handleMessage', () => {
     it('emits connect on connect message', () => {
       const handler = vi.fn();

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -3,6 +3,13 @@ export interface SseEventData {
   data: unknown;
 }
 
+/** Parsed `AppVersionChanged` context event (bundle-version flip; skew #2). */
+export interface AppVersionChangedEvent {
+  contextId: string;
+  fromVersion?: string;
+  toVersion?: string;
+}
+
 type SseEventHandler = (event: SseEventData) => void;
 type SseConnectHandler = (sessionId: string) => void;
 type SseErrorHandler = (error: Error) => void;
@@ -57,6 +64,23 @@ export class SseClient {
       const idx = arr.indexOf(handler);
       if (idx !== -1) arr.splice(idx, 1);
     }
+  }
+
+  /**
+   * Typed convenience over the generic `'event'` stream: invokes `handler` only
+   * for `AppVersionChanged` context events, with the payload already parsed.
+   * Returns an unsubscribe closure (so callers need not retain the listener).
+   */
+  onAppVersionChanged(handler: (e: AppVersionChangedEvent) => void): () => void {
+    const listener: SseEventHandler = (ev) => {
+      const d = ev.data as
+        | { type?: string; data?: { fromVersion?: string; toVersion?: string } }
+        | undefined;
+      if (d?.type !== 'AppVersionChanged') return;
+      handler({ contextId: ev.contextId, fromVersion: d.data?.fromVersion, toVersion: d.data?.toVersion });
+    };
+    this.on('event', listener);
+    return () => this.off('event', listener);
   }
 
   private emit(event: 'connect', sessionId: string): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export type { TokenStore } from './token-store';
 
 // RPC client
 export { RpcClient, RpcError } from './rpc';
+export type { MigrateMyEntriesSummary } from './rpc';
 export type { ExecuteParams } from './rpc';
 
 // Events (SSE / WebSocket)

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export type { ExecuteParams } from './rpc';
 
 // Events (SSE / WebSocket)
 export { SseClient, WsClient } from './events';
-export type { SseEventData, WsEventData } from './events';
+export type { SseEventData, WsEventData, AppVersionChangedEvent } from './events';
 
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud';

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,5 +1,10 @@
 import type { HttpClient } from '../http-client';
-import type { MigrateMyEntriesSummary } from '../admin-api/admin-types';
+
+/** Result of the owner-driven `migrate_my_entries` convert (counts are u32). */
+export interface MigrateMyEntriesSummary {
+  converted: number;
+  remaining: number;
+}
 
 export interface ExecuteParams {
   contextId: string;

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,4 +1,5 @@
 import type { HttpClient } from '../http-client';
+import type { MigrateMyEntriesSummary } from '../admin-api/admin-types';
 
 export interface ExecuteParams {
   contextId: string;
@@ -75,5 +76,20 @@ export class RpcClient {
     }
 
     return response.result as T;
+  }
+
+  /**
+   * One-tap owner-driven convert: re-signs the caller's identity-gated entries
+   * to the current schema. The export converts all of the caller's
+   * below-target entries in a single sweep, so this issues one call and returns
+   * the resulting summary — it does not loop.
+   */
+  async migrateMyEntries(contextId: string): Promise<MigrateMyEntriesSummary> {
+    return this.execute<MigrateMyEntriesSummary>({ contextId, method: 'migrate_my_entries' });
+  }
+
+  /** Read-only count of the caller's entries still below the target schema. */
+  async countMyPending(contextId: string): Promise<number> {
+    return this.execute<number>({ contextId, method: 'count_my_pending' });
   }
 }

--- a/src/rpc/rpc.test.ts
+++ b/src/rpc/rpc.test.ts
@@ -137,4 +137,36 @@ describe('RpcClient', () => {
       }),
     }));
   });
+
+  it('migrateMyEntries returns the convert summary', async () => {
+    const httpClient = createMockHttpClient({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { output: { converted: 2, remaining: 0 } },
+    });
+
+    const rpc = new RpcClient({ httpClient });
+    const summary = await rpc.migrateMyEntries('ctx-1');
+
+    expect(summary).toEqual({ converted: 2, remaining: 0 });
+    expect(httpClient.post).toHaveBeenCalledWith('/jsonrpc', expect.objectContaining({
+      params: expect.objectContaining({ contextId: 'ctx-1', method: 'migrate_my_entries' }),
+    }));
+  });
+
+  it('countMyPending returns the pending count', async () => {
+    const httpClient = createMockHttpClient({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { output: 3 },
+    });
+
+    const rpc = new RpcClient({ httpClient });
+    const n = await rpc.countMyPending('ctx-1');
+
+    expect(n).toBe(3);
+    expect(httpClient.post).toHaveBeenCalledWith('/jsonrpc', expect.objectContaining({
+      params: expect.objectContaining({ contextId: 'ctx-1', method: 'count_my_pending' }),
+    }));
+  });
 });


### PR DESCRIPTION
## What

Layer **6g** of the migration-UX track (#2539): consume the migration-UX core surfaces (shipped in core via the 6f PR) in `@calimero-network/mero-js`. Strictly additive — no behaviour change to existing methods.

### Surfaces added

1. **`Context.applicationVersion?: string`** — the installed bundle's semver, surfaced by the node on `get_context` (skew #2, "is my bundle stale?"). Absent on older nodes.
2. **`AdminApiClient.getMigrationStatus(namespaceId)`** → typed `MigrationStatus` (the operator rollup: `membersPendingSignature`, per-member `{schemaVersion, residueAuto, residueIdentity, syncedUpToHlc, reportedAt, authoredRemaining, state}`). Wraps `GET /admin-api/groups/:id/migration-status`.
3. **`AdminApiClient.getCascadeStatus(namespaceId)`** → `CascadeStatusEntry[]`. Wraps `GET …/cascade-status`.
4. **`SseClient.onAppVersionChanged(cb)`** — typed dispatch over the generic event stream; fires only for `{type:"AppVersionChanged"}` context events with the payload parsed, and returns an unsubscribe closure.
5. **`RpcClient.migrateMyEntries(contextId)`** / **`countMyPending(contextId)`** — one-tap owner-driven convert summary, and the read-only pending count.

### Envelope note (intentional asymmetry, matches core)

`migration-status` serializes its payload **directly** (no `{data}` envelope), so `getMigrationStatus` reads the body as-is; `cascade-status`'s payload has its own `data` field, so `getCascadeStatus` unwraps it to the array. Both verified against the core handlers.

### `migrate_my_entries` is single-sweep

The export converts all of the caller's below-target entries in one call, so `migrateMyEntries` issues a single call and returns the summary — it does **not** loop (avoids spinning under concurrent writes).

## Tests

7 new unit tests (admin client ×2, SSE ×3, rpc ×2); full suite **200 pass**, typecheck / lint / build clean.

## Gate

Consumes core wire shapes frozen on master (6f merge). 6h (mero-react) pins the published mero-js release cut from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK types and methods only; no changes to existing client behavior beyond new exports and tests.
> 
> **Overview**
> Adds **migration-UX** client surfaces to `@calimero-network/mero-js` in a strictly additive way—existing APIs are unchanged.
> 
> **Admin:** New typed **`getMigrationStatus`** and **`getCascadeStatus`** for namespace/group migration rollups and cascade snapshots. **`getMigrationStatus`** returns the JSON body directly (no `{ data }` wrapper); **`getCascadeStatus`** unwraps the usual envelope. **`Context`** gains optional **`applicationVersion`** for installed bundle semver.
> 
> **Events:** **`SseClient.onAppVersionChanged`** filters the generic SSE stream for `AppVersionChanged`, parses `fromVersion` / `toVersion`, and returns an unsubscribe function. **`AppVersionChangedEvent`** is re-exported from the package entry.
> 
> **RPC:** **`migrateMyEntries`** and **`countMyPending`** wrap `migrate_my_entries` and `count_my_pending` (single-call owner convert summary and pending count). **`MigrateMyEntriesSummary`** is exported.
> 
> Seven new unit tests cover admin envelope behavior, SSE filtering/unsubscribe, and RPC wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809fd5b959332cbb4a26a88207a200914ddaa7fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->