### PR TITLE
feat(admin): failed migration state + BundleMigration type + installFromRegistry (#2539)

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -82,6 +82,56 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ applicationId: 'app-1' });
     });
 
+    it('installFromRegistry resolves the artifact URL and installs', async () => {
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe(
+          'https://registry.example.com/api/v2/bundles/com.acme.app/2.0.0',
+        );
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ package: 'com.acme.app', appVersion: '2.0.0' }),
+        } as Response;
+      }) as typeof fetch;
+      try {
+        mock.setMockResponse('POST', '/admin-api/install-application', {
+          data: { applicationId: 'app-9' },
+        });
+        const result = await client.installFromRegistry(
+          'https://registry.example.com',
+          'com.acme.app',
+          '2.0.0',
+        );
+        expect(result.applicationId).toBe('app-9');
+        const body = mock.getRequestBody('POST', '/admin-api/install-application') as {
+          url: string;
+          package?: string;
+          version?: string;
+        };
+        expect(body.url).toBe(
+          'https://registry.example.com/artifacts/com.acme.app/2.0.0/com.acme.app-2.0.0.mpk',
+        );
+        expect(body.package).toBe('com.acme.app');
+        expect(body.version).toBe('2.0.0');
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
+    it('installFromRegistry throws on a registry error', async () => {
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = (async () =>
+        ({ ok: false, status: 404, json: async () => ({}) }) as Response) as typeof fetch;
+      try {
+        await expect(
+          client.installFromRegistry('https://registry.example.com', 'missing', '9.9.9'),
+        ).rejects.toThrow(/registry manifest fetch failed \(404\)/);
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
     it('installDevApplication unwraps data', async () => {
       mock.setMockResponse('POST', '/admin-api/install-dev-application', { data: { applicationId: 'app-2' } });
       const result = await client.installDevApplication({ path: '/tmp/app.mpk', metadata: [] });

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AdminApiClient } from './admin-client';
+import { AdminApiClient, compareSemver } from './admin-client';
 import { HttpClient } from '../http-client';
 
 // Mock HttpClient that stores expected responses and records request bodies
@@ -85,13 +85,17 @@ describe('AdminApiClient', () => {
     it('installFromRegistry resolves the artifact URL and installs', async () => {
       const origFetch = globalThis.fetch;
       globalThis.fetch = (async (input: RequestInfo | URL) => {
+        // Manifest is fetched by the CALLER's package@version...
         expect(String(input)).toBe(
           'https://registry.example.com/api/v2/bundles/com.acme.app/2.0.0',
         );
+        // ...but resolves to the registry's canonical appVersion (here it
+        // differs from the arg, so the asserts below prove the manifest value
+        // — not the caller's arg — builds the artifact URL + install request).
         return {
           ok: true,
           status: 200,
-          json: async () => ({ package: 'com.acme.app', appVersion: '2.0.0' }),
+          json: async () => ({ package: 'com.acme.app', appVersion: '2.0.1' }),
         } as Response;
       }) as typeof fetch;
       try {
@@ -110,10 +114,10 @@ describe('AdminApiClient', () => {
           version?: string;
         };
         expect(body.url).toBe(
-          'https://registry.example.com/artifacts/com.acme.app/2.0.0/com.acme.app-2.0.0.mpk',
+          'https://registry.example.com/artifacts/com.acme.app/2.0.1/com.acme.app-2.0.1.mpk',
         );
         expect(body.package).toBe('com.acme.app');
-        expect(body.version).toBe('2.0.0');
+        expect(body.version).toBe('2.0.1');
       } finally {
         globalThis.fetch = origFetch;
       }
@@ -127,6 +131,34 @@ describe('AdminApiClient', () => {
         await expect(
           client.installFromRegistry('https://registry.example.com', 'missing', '9.9.9'),
         ).rejects.toThrow(/registry manifest fetch failed \(404\)/);
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
+    it('getRegistryVersions returns versions newest-first by semver', async () => {
+      const origFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        expect(String(input)).toBe(
+          'https://registry.example.com/api/v2/bundles?package=com.acme.app',
+        );
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { package: 'com.acme.app', appVersion: '1.9.0' },
+            { package: 'com.acme.app', appVersion: '1.10.0' },
+            { package: 'com.acme.app', appVersion: '1.2.0' },
+          ],
+        } as Response;
+      }) as typeof fetch;
+      try {
+        const versions = await client.getRegistryVersions(
+          'https://registry.example.com',
+          'com.acme.app',
+        );
+        // 1.10.0 must sort ABOVE 1.9.0 — numeric, not lexical.
+        expect(versions).toEqual(['1.10.0', '1.9.0', '1.2.0']);
       } finally {
         globalThis.fetch = origFetch;
       }
@@ -1039,5 +1071,18 @@ describe('AdminApiClient', () => {
       const result = await client.getPeersCount();
       expect(result).toEqual({ count: 3 });
     });
+  });
+});
+
+describe('compareSemver', () => {
+  it('orders numerically, not lexically', () => {
+    expect(compareSemver('1.10.0', '1.9.0')).toBeGreaterThan(0);
+    expect(compareSemver('2.0.0', '1.9.9')).toBeGreaterThan(0);
+    expect(compareSemver('1.9.0', '1.10.0')).toBeLessThan(0);
+  });
+
+  it('treats equal and zero-padded versions as equal', () => {
+    expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
+    expect(compareSemver('1.2', '1.2.0')).toBe(0);
   });
 });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -110,6 +110,31 @@ function unwrap<T>(response: { data: T }): T {
   return response.data;
 }
 
+/**
+ * Compare two dotted version strings, ascending: negative if `a < b`, positive
+ * if `a > b`, `0` if equal. Components are compared numerically when both parse
+ * as integers (so `1.10.0 > 1.9.0`), else lexically; a missing component is `0`.
+ * Minimal by design — sufficient for the `major.minor.patch` registry versions.
+ */
+export function compareSemver(a: string, b: string): number {
+  const pa = a.split('.');
+  const pb = b.split('.');
+  const n = Math.max(pa.length, pb.length);
+  for (let i = 0; i < n; i++) {
+    const sa = pa[i] ?? '0';
+    const sb = pb[i] ?? '0';
+    const na = Number.parseInt(sa, 10);
+    const nb = Number.parseInt(sb, 10);
+    if (Number.isNaN(na) || Number.isNaN(nb)) {
+      const c = sa.localeCompare(sb);
+      if (c !== 0) return c;
+    } else if (na !== nb) {
+      return na - nb;
+    }
+  }
+  return 0;
+}
+
 export class AdminApiClient {
   constructor(private httpClient: HttpClient) {}
 
@@ -144,7 +169,7 @@ export class AdminApiClient {
   ): Promise<InstallApplicationResponseData> {
     const base = new URL(registryUrl).origin;
     const manifestUrl = new URL(
-      `/api/v2/bundles/${packageName}/${version}`,
+      `/api/v2/bundles/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`,
       base,
     ).toString();
     const resp = await fetch(manifestUrl);
@@ -154,13 +179,42 @@ export class AdminApiClient {
       );
     }
     const bundle = (await resp.json()) as RegistryBundleManifest;
-    const artifactUrl = `${base}/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`;
+    // Encode the path segments — the package/version come from a (best-effort
+    // trusted) registry response, so guard against odd characters breaking or
+    // traversing the artifact path. For normal ids/semvers this is a no-op.
+    const pkg = encodeURIComponent(bundle.package);
+    const ver = encodeURIComponent(bundle.appVersion);
+    const artifactUrl = `${base}/artifacts/${pkg}/${ver}/${pkg}-${ver}.mpk`;
     return this.installApplication({
       url: artifactUrl,
       package: bundle.package,
       version: bundle.appVersion,
       metadata: [],
     });
+  }
+
+  /**
+   * List a package's published versions from the registry, newest-first by
+   * semver. Reads the registry's V2 bundle listing
+   * (`GET {registry}/api/v2/bundles?package={package}`), taking each bundle's
+   * `appVersion`. Registry-side data — distinct from the node's
+   * installed-version list — and the source an Updates view compares against
+   * the running `Context.applicationVersion` to detect "a new version exists".
+   */
+  async getRegistryVersions(registryUrl: string, packageName: string): Promise<string[]> {
+    const url = new URL('/api/v2/bundles', new URL(registryUrl).origin);
+    url.searchParams.set('package', packageName);
+    const resp = await fetch(url.toString());
+    if (!resp.ok) {
+      throw new Error(
+        `registry versions fetch failed (${resp.status}) for ${packageName}`,
+      );
+    }
+    const bundles = (await resp.json()) as RegistryBundleManifest[];
+    return (Array.isArray(bundles) ? bundles : [])
+      .map((b) => b.appVersion)
+      .filter((v): v is string => typeof v === 'string')
+      .sort((a, b) => compareSemver(b, a));
   }
 
   async installDevApplication(request: InstallDevApplicationRequest): Promise<InstallApplicationResponseData> {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -11,6 +11,7 @@ import type {
   GetLatestVersionResponseData,
   ListPackagesResponseData,
   ListVersionsResponseData,
+  RegistryBundleManifest,
   CreateContextRequest,
   CreateContextResponseData,
   DeleteContextRequest,
@@ -126,6 +127,40 @@ export class AdminApiClient {
 
   async installApplication(request: InstallApplicationRequest): Promise<InstallApplicationResponseData> {
     return unwrap(await this.httpClient.post<{ data: InstallApplicationResponseData }>('/admin-api/install-application', request));
+  }
+
+  /**
+   * Resolve a `package@version` to its registry artifact URL and install it.
+   * Node install is URL-based (no node-side package+version resolution), so this
+   * fetches the bundle manifest from the registry, derives the `.mpk` artifact
+   * URL, then calls {@link installApplication}. `registryUrl` is the registry
+   * origin. This is the discrete "download" step an Updates flow pairs with a
+   * subsequent `upgradeGroup`.
+   */
+  async installFromRegistry(
+    registryUrl: string,
+    packageName: string,
+    version: string,
+  ): Promise<InstallApplicationResponseData> {
+    const base = new URL(registryUrl).origin;
+    const manifestUrl = new URL(
+      `/api/v2/bundles/${packageName}/${version}`,
+      base,
+    ).toString();
+    const resp = await fetch(manifestUrl);
+    if (!resp.ok) {
+      throw new Error(
+        `registry manifest fetch failed (${resp.status}) for ${packageName}@${version}`,
+      );
+    }
+    const bundle = (await resp.json()) as RegistryBundleManifest;
+    const artifactUrl = `${base}/artifacts/${bundle.package}/${bundle.appVersion}/${bundle.package}-${bundle.appVersion}.mpk`;
+    return this.installApplication({
+      url: artifactUrl,
+      package: bundle.package,
+      version: bundle.appVersion,
+      metadata: [],
+    });
   }
 
   async installDevApplication(request: InstallDevApplicationRequest): Promise<InstallApplicationResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -73,6 +73,33 @@ export interface ListVersionsResponseData {
   versions: string[];
 }
 
+// ---- Bundle migration metadata ----
+
+/**
+ * Per-service migration descriptor carried in a multi-service bundle manifest,
+ * emitted from the app's `#[app::migrate]` declaration. `toSchemaVersion` is the
+ * CRDT schema version the migrate targets (the engine's gate); `toVersion` is
+ * the user-facing bundle semver an admin matches on; `method` is the migrate
+ * entrypoint.
+ */
+export interface BundleMigration {
+  method: string;
+  toSchemaVersion: number;
+  toVersion?: string;
+}
+
+/**
+ * The subset of a registry bundle manifest that `installFromRegistry` consumes
+ * to resolve an artifact URL. The registry serves it at
+ * `GET {registry}/api/v2/bundles/{package}/{version}`.
+ */
+export interface RegistryBundleManifest {
+  package: string;
+  appVersion: string;
+  /** Present when this bundle's app declares a migration. */
+  migration?: BundleMigration;
+}
+
 // ---- Contexts ----
 
 export interface CreateContextRequest {
@@ -378,7 +405,14 @@ export interface GroupUpgradeStatus {
 
 // ---- Migration status (migration-UX core surfaces) ----
 
-export type MemberMigrationState = 'migrated' | 'in_progress' | 'unknown';
+export type MemberMigrationState =
+  | 'migrated'
+  | 'in_progress'
+  | 'unknown'
+  | 'failed';
+
+/** Why a member's migration did not complete. */
+export type MigrationFailureReason = 'check_aborted' | 'apply_failed';
 
 export interface MemberMigrationReport {
   schemaVersion: number;
@@ -388,6 +422,11 @@ export interface MemberMigrationReport {
   reportedAt: number;
   /** Member's self-reported pending-authored count (best-effort; skew #1). */
   authoredRemaining: number;
+  /**
+   * Set when the member's migrate did not complete (its migration-check
+   * aborted, or the apply errored). Absent otherwise.
+   */
+  migrationFailed?: MigrationFailureReason;
 }
 
 export interface MemberMigrationStatusEntry {
@@ -401,6 +440,8 @@ export interface MigrationStatusRollup {
   migrated: number;
   inProgress: number;
   unknown: number;
+  /** Members whose migrate aborted (migration-check failed or apply errored). */
+  failed: number;
   total: number;
   allMigrated: boolean;
   /** Count of members with authoredRemaining > 0 (owners still to re-sign). */


### PR DESCRIPTION
## What

Three additive SDK surfaces that continue the migration-UX work, consumed by mero-react / the Updates admin view and the version picker:

1. **Failed migration state.** The node now reports a member whose migrate aborted (the developer's migration-check failed) or whose apply errored as a distinct `failed` state instead of a silent `in_progress`. This mirrors that into the status types:
   - `MemberMigrationState` gains `'failed'`.
   - `MemberMigrationReport.migrationFailed?: 'check_aborted' | 'apply_failed'` — the categorized reason.
   - `MigrationStatusRollup.failed: number` — the cohort counter.

2. **`BundleMigration` type.** The per-service migrate descriptor carried in a multi-service bundle manifest (emitted from the app's `#[app::migrate]` declaration): `method`, `toSchemaVersion` (the engine's CRDT-schema gate), and the user-facing semver `toVersion` an admin matches on. Plus a minimal `RegistryBundleManifest` for the slice `installFromRegistry` consumes.

3. **`installFromRegistry(registry, package, version)`.** Resolves a bundle's `.mpk` artifact URL from the registry (`GET {registry}/api/v2/bundles/{package}/{version}` → `{base}/artifacts/{pkg}/{ver}/{pkg}-{ver}.mpk`) and installs by URL — node install is URL-based, with no node-side package+version resolution. This is the discrete "download" step an Updates flow pairs with a subsequent `upgradeGroup` (kept composable, not a mega-convenience).

## Tests

- `installFromRegistry` resolves the manifest, constructs the artifact URL, and forwards it to `installApplication` (asserts the exact URL + package/version); and throws on a registry error.
- Full suite green (202 tests), typecheck + build clean.

Part of #2539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK types and client methods with tests; no changes to existing admin HTTP behavior beyond new optional migration fields consumers must handle.
> 
> **Overview**
> Extends the admin SDK for **migration UX** and **registry-driven installs**.
> 
> **Migration status types** now mirror the node’s failed-migrate reporting: `MemberMigrationState` adds `'failed'`, reports can include `migrationFailed` (`check_aborted` | `apply_failed`), and rollups expose a `failed` count.
> 
> **Registry helpers** on `AdminApiClient`: `installFromRegistry` fetches the V2 bundle manifest, builds the `.mpk` artifact URL from the manifest’s canonical `appVersion`, and calls `installApplication`; `getRegistryVersions` lists published versions from the registry (newest-first via exported `compareSemver`). New types `RegistryBundleManifest` and `BundleMigration` describe manifest/migrate metadata.
> 
> Tests cover registry install (including manifest vs. caller version), registry errors, semver sorting, and `compareSemver`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54ecc99c593dc472319da001efc395cba87e596a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->