### PR TITLE
fix(admin): tolerate null metadata payload in metadata getters

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -771,6 +771,14 @@ describe('AdminApiClient', () => {
       expect(await client.getGroupMetadata('g1')).toBeNull();
     });
 
+    // Server omits the inner envelope entirely (`{ data: null }`) when no
+    // metadata row exists — the unwrapped payload is then null, so reading
+    // `.data` off it used to throw "Cannot read properties of null".
+    it('getGroupMetadata returns null (not throws) when the payload itself is null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: null });
+      expect(await client.getGroupMetadata('g1')).toBeNull();
+    });
+
     it('setMemberMetadata sends PUT to the member path', async () => {
       mock.setMockResponse('PUT', '/admin-api/groups/g1/members/pk-1/metadata', {});
       await client.setMemberMetadata('g1', 'pk-1', { name: 'Alice' });
@@ -780,6 +788,13 @@ describe('AdminApiClient', () => {
     it('getMemberMetadata returns the inner MetadataRecord', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', { data: { data: record } });
       expect(await client.getMemberMetadata('g1', 'pk-1')).toEqual(record);
+    });
+
+    // The display-name lookup that surfaced the crash: a member with no name
+    // set yields `{ data: null }`, which must read back as null, not throw.
+    it('getMemberMetadata returns null (not throws) when the payload itself is null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', { data: null });
+      expect(await client.getMemberMetadata('g1', 'pk-1')).toBeNull();
     });
 
     it('setContextMetadata sends PUT to the context path', async () => {
@@ -793,6 +808,11 @@ describe('AdminApiClient', () => {
     it('getContextMetadata returns the inner MetadataRecord', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: { data: record } });
       expect(await client.getContextMetadata('g1', 'ctx-1')).toEqual(record);
+    });
+
+    it('getContextMetadata returns null (not throws) when the payload itself is null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: null });
+      expect(await client.getContextMetadata('g1', 'ctx-1')).toBeNull();
     });
   });
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -659,7 +659,10 @@ export class AdminApiClient {
   }
 
   async getGroupMetadata(groupId: string): Promise<MetadataRecord | null> {
-    return unwrap(await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/metadata`)).data;
+    // Server sends `{ data: null }` when no metadata is set, so the unwrapped
+    // payload can be null — guard the trailing `.data` (else it throws
+    // "Cannot read properties of null (reading 'data')").
+    return unwrap(await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/metadata`))?.data ?? null;
   }
 
   async setMemberMetadata(
@@ -671,9 +674,11 @@ export class AdminApiClient {
   }
 
   async getMemberMetadata(groupId: string, identity: string): Promise<MetadataRecord | null> {
+    // `{ data: null }` when no metadata (e.g. no display name set) → the
+    // unwrapped payload is null; guard the trailing `.data`.
     return unwrap(
-      await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/members/${identity}/metadata`),
-    ).data;
+      await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/members/${identity}/metadata`),
+    )?.data ?? null;
   }
 
   async setContextMetadata(
@@ -685,9 +690,11 @@ export class AdminApiClient {
   }
 
   async getContextMetadata(groupId: string, contextId: string): Promise<MetadataRecord | null> {
+    // `{ data: null }` when no metadata → the unwrapped payload is null; guard
+    // the trailing `.data`.
     return unwrap(
-      await this.httpClient.get<{ data: GetMetadataResponseData }>(`/admin-api/groups/${groupId}/contexts/${contextId}/metadata`),
-    ).data;
+      await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/contexts/${contextId}/metadata`),
+    )?.data ?? null;
   }
 
   async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {


### PR DESCRIPTION
## What

`getGroupMetadata`, `getMemberMetadata`, and `getContextMetadata` unwrapped the HTTP envelope and then read `.data` off the result. When no metadata row exists, the server returns `{ data: null }` — so the unwrapped payload is `null` and `.data` threw:

```
Cannot read properties of null (reading 'data')
```

This surfaced in consumers as a hard error wherever metadata is read for an entity that has none set — e.g. resolving a member's display name when that member hasn't set one.

## Fix

Guard the trailing access in all three getters:

```ts
return unwrap(await this.httpClient.get<{ data: GetMetadataResponseData | null }>(...))?.data ?? null;
```

A missing record now reads back as `null` (the documented return type) instead of throwing.

## Tests

Added regression tests covering the `{ data: null }` (no-record) payload shape for all three getters — previously only the inner `{ data: { data: null } }` shape was covered, which never reproduced the crash. `tsc`, the full admin-client suite (114 tests), `vite` build, and `eslint --max-warnings 0` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive client fix aligned with documented return types; regression tests cover the previously failing response shape.
> 
> **Overview**
> Fixes a runtime crash in **`getGroupMetadata`**, **`getMemberMetadata`**, and **`getContextMetadata`** when the admin API returns **`{ data: null }`** for entities with no metadata row. After `unwrap`, the payload is `null`, and the previous **`.data`** access threw instead of returning **`null`**.
> 
> All three getters now use optional chaining and **`?? null`** (`unwrap(...)?.data ?? null`), with response types updated to allow a null inner envelope. Regression tests mock **`{ data: null }`** for each getter—the shape that previously wasn’t covered and that broke flows like member display-name lookup when no name is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d422aad4f3d59e92e812b85d9591d08a011c1970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->