### PR TITLE
feat(admin): cascade flag on UpgradeGroupRequest

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -829,6 +829,22 @@ describe('AdminApiClient', () => {
       });
     });
 
+    it('upgradeGroup forwards cascade so the upgrade fans out to subgroups', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
+        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+      });
+      await client.upgradeGroup('g-1', {
+        targetApplicationId: 'app-2',
+        migrateMethod: 'migrate_v2',
+        cascade: true,
+      });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/g-1/upgrade')).toEqual({
+        targetApplicationId: 'app-2',
+        migrateMethod: 'migrate_v2',
+        cascade: true,
+      });
+    });
+
     it('getGroupUpgradeStatus returns status', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g-1/upgrade/status', {
         data: { fromVersion: '1.0', toVersion: '2.0', initiatedAt: 123, initiatedBy: 'pk-1', status: 'completed', total: 3, completed: 3, failed: 0, completedAt: 456 },

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -671,6 +671,11 @@ export interface UpgradeGroupRequest {
   targetApplicationId: string;
   requester?: string;
   migrateMethod?: string;
+  /** Fan the upgrade out to every descendant subgroup running the same app
+   *  (one atomic cascade op). Without it the upgrade applies to the target
+   *  group only — members' subgroups never learn the migration. Server
+   *  default: false. */
+  cascade?: boolean;
 }
 
 export interface UpgradeGroupResponseData {


### PR DESCRIPTION
## What

Adds the optional `cascade` field to `UpgradeGroupRequest`:

```ts
await mero.admin.upgradeGroup(namespaceId, {
  targetApplicationId,
  migrateMethod: 'migrate_v1_to_v2',
  cascade: true,
});
```

## Why

The node's `POST /admin-api/groups/:id/upgrade` endpoint already accepts `cascade` (emit one atomic cascade op that fans the upgrade out to every descendant subgroup running the same app) — the Python client exposes it, but the JS SDK type omitted it. Apps calling `upgradeGroup` therefore always took the single-group path: the namespace root got the new target + migration, while members' subgroups never learned it, so member nodes' lazy migrations never triggered. This surfaced as "migration never reaches the other node" in multi-node app testing.

`upgradeGroup` POSTs the request object verbatim, so the field flows through with no client logic change. Server default stays `false`.

## Tests

Body-forwarding test asserting `cascade: true` reaches the wire. `tsc`, full admin-client suite, and `eslint --max-warnings 0` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only SDK alignment plus a forwarding test; behavior unchanged unless callers pass `cascade: true`.
> 
> **Overview**
> Adds the optional **`cascade`** flag to **`UpgradeGroupRequest`** so JS callers can match the node’s `POST /admin-api/groups/:id/upgrade` API (already supported by the Python client). When **`cascade: true`**, the server fans the upgrade out to descendant subgroups on the same app via one atomic cascade op; without it, only the target group is upgraded and member subgroups may never see the migration.
> 
> **`upgradeGroup`** still POSTs the request object as-is—no client logic change. A new test asserts **`cascade: true`** is included on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e756301d692e8b67221158a2028901da0a61e537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->