### PR TITLE
fix(admin): tolerate a bare-null body in the metadata getters

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -17,11 +17,13 @@ class MockHttpClient implements HttpClient {
 
   private getResponse(method: string, path: string): unknown {
     const key = `${method} ${path}`;
-    const response = this.mockResponses.get(key);
-    if (!response) {
+    // .has(...) rather than truthiness so an explicitly-mocked `null` body
+    // (the "no metadata record" wire shape) is "set to null", not
+    // "never registered".
+    if (!this.mockResponses.has(key)) {
       throw new Error(`No mock response for ${key}`);
     }
-    return response;
+    return this.mockResponses.get(key);
   }
 
   async get<T>(path: string): Promise<T> { return this.getResponse('GET', path) as T; }
@@ -779,6 +781,12 @@ describe('AdminApiClient', () => {
       expect(await client.getGroupMetadata('g1')).toBeNull();
     });
 
+    // Third observed "no record" shape: a bare `null` body, no envelope at all.
+    it('getGroupMetadata returns null (not throws) when the body is bare null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', null);
+      expect(await client.getGroupMetadata('g1')).toBeNull();
+    });
+
     it('setMemberMetadata sends PUT to the member path', async () => {
       mock.setMockResponse('PUT', '/admin-api/groups/g1/members/pk-1/metadata', {});
       await client.setMemberMetadata('g1', 'pk-1', { name: 'Alice' });
@@ -797,6 +805,11 @@ describe('AdminApiClient', () => {
       expect(await client.getMemberMetadata('g1', 'pk-1')).toBeNull();
     });
 
+    it('getMemberMetadata returns null (not throws) when the body is bare null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', null);
+      expect(await client.getMemberMetadata('g1', 'pk-1')).toBeNull();
+    });
+
     it('setContextMetadata sends PUT to the context path', async () => {
       mock.setMockResponse('PUT', '/admin-api/groups/g1/contexts/ctx-1/metadata', {});
       await client.setContextMetadata('g1', 'ctx-1', { data: { region: 'eu' } });
@@ -812,6 +825,11 @@ describe('AdminApiClient', () => {
 
     it('getContextMetadata returns null (not throws) when the payload itself is null', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: null });
+      expect(await client.getContextMetadata('g1', 'ctx-1')).toBeNull();
+    });
+
+    it('getContextMetadata returns null (not throws) when the body is bare null', async () => {
+      mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', null);
       expect(await client.getContextMetadata('g1', 'ctx-1')).toBeNull();
     });
   });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -659,10 +659,14 @@ export class AdminApiClient {
   }
 
   async getGroupMetadata(groupId: string): Promise<MetadataRecord | null> {
-    // Server sends `{ data: null }` when no metadata is set, so the unwrapped
-    // payload can be null — guard the trailing `.data` (else it throws
-    // "Cannot read properties of null (reading 'data')").
-    return unwrap(await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/metadata`))?.data ?? null;
+    // The "no record yet" wire shape varies across server versions:
+    // `{data:{data:null}}`, `{data:null}`, and a bare `null` body have all
+    // been observed. Optional-chain the whole path so every flavour collapses
+    // to a clean `null`.
+    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+      `/admin-api/groups/${groupId}/metadata`,
+    );
+    return response?.data?.data ?? null;
   }
 
   async setMemberMetadata(
@@ -674,11 +678,11 @@ export class AdminApiClient {
   }
 
   async getMemberMetadata(groupId: string, identity: string): Promise<MetadataRecord | null> {
-    // `{ data: null }` when no metadata (e.g. no display name set) → the
-    // unwrapped payload is null; guard the trailing `.data`.
-    return unwrap(
-      await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/members/${identity}/metadata`),
-    )?.data ?? null;
+    // Tolerates every observed "no record yet" shape (see getGroupMetadata).
+    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+      `/admin-api/groups/${groupId}/members/${identity}/metadata`,
+    );
+    return response?.data?.data ?? null;
   }
 
   async setContextMetadata(
@@ -690,11 +694,11 @@ export class AdminApiClient {
   }
 
   async getContextMetadata(groupId: string, contextId: string): Promise<MetadataRecord | null> {
-    // `{ data: null }` when no metadata → the unwrapped payload is null; guard
-    // the trailing `.data`.
-    return unwrap(
-      await this.httpClient.get<{ data: GetMetadataResponseData | null }>(`/admin-api/groups/${groupId}/contexts/${contextId}/metadata`),
-    )?.data ?? null;
+    // Tolerates every observed "no record yet" shape (see getGroupMetadata).
+    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+      `/admin-api/groups/${groupId}/contexts/${contextId}/metadata`,
+    );
+    return response?.data?.data ?? null;
   }
 
   async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {


### PR DESCRIPTION
## What

Completes the "no record yet" tolerance from #45. The wire shape for an unset metadata record varies across server versions — three flavours have been observed:

| shape | before | after |
|---|---|---|
| `{ data: { data: null } }` | ✅ null | ✅ null |
| `{ data: null }` | ✅ null (since #45 / 2.4.1) | ✅ null |
| bare `null` body | ❌ throws inside `unwrap` | ✅ null |

All three getters (`getGroupMetadata`, `getMemberMetadata`, `getContextMetadata`) now optional-chain the whole path (`response?.data?.data ?? null`).

## Tests

Bare-null regression tests for all three getters. The test mock now uses `.has()` instead of truthiness so an explicitly-mocked `null` body is distinguishable from an unregistered route. 118 tests, `tsc`, `eslint --max-warnings 0` pass.

Ports the remaining increment from #36 (which predates the #45 rewrite of these getters and no longer applies cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive parsing change in three read-only admin client methods, with regression tests; no auth or write-path changes.
> 
> **Overview**
> Extends **“no metadata yet”** handling in `getGroupMetadata`, `getMemberMetadata`, and `getContextMetadata` so a **bare `null` HTTP body** (no `{ data }` envelope) returns `null` instead of throwing inside `unwrap`.
> 
> The getters now read the raw GET response and use **`response?.data?.data ?? null`**, covering `{ data: { data: null } }`, `{ data: null }`, and bare `null` across server versions. Tests add bare-null cases for all three getters, and the test `MockHttpClient` uses **`.has()`** so an explicitly mocked `null` body is not treated as an unregistered route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 409472d6983c769598239d25a353e5dee90f9912. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->