### PR TITLE
feat(admin)!: align admin SDK with migrations-v2 core API

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -187,6 +187,16 @@ describe('AdminApiClient', () => {
       const result = await client.getApplication('app-1');
       expect(result).toEqual({ application: { id: 'app-1' } });
     });
+
+    it('listApplicationVersions unwraps the installed-blob inventory', async () => {
+      const entries = [
+        { version: '1.0.0', blobId: 'blob-1', size: 100, package: 'pkg-a' },
+        { version: '2.0.0', blobId: 'blob-2', size: 200, package: 'pkg-a' },
+      ];
+      mock.setMockResponse('GET', '/admin-api/applications/app-1/versions', { data: entries });
+      const result = await client.listApplicationVersions('app-1');
+      expect(result).toEqual(entries);
+    });
   });
 
   describe('Package Management', () => {
@@ -329,6 +339,24 @@ describe('AdminApiClient', () => {
       expect(mock.getRequestBody('POST', '/admin-api/contexts/sync/')).toEqual({});
     });
 
+    it('resyncContext posts force and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/ctx-1/resync', {
+        data: { contextId: 'ctx-1', resyncStarted: true },
+      });
+      const result = await client.resyncContext('ctx-1', { force: true });
+      expect(result).toEqual({ contextId: 'ctx-1', resyncStarted: true });
+      expect(mock.getRequestBody('POST', '/admin-api/contexts/ctx-1/resync')).toEqual({ force: true });
+    });
+
+    it('resyncContext defaults to an empty request body', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/ctx-1/resync', {
+        data: { contextId: 'ctx-1', resyncStarted: false },
+      });
+      const result = await client.resyncContext('ctx-1');
+      expect(result.resyncStarted).toBe(false);
+      expect(mock.getRequestBody('POST', '/admin-api/contexts/ctx-1/resync')).toEqual({});
+    });
+
     it('getContextsWithExecutorsForApplication unwraps data', async () => {
       mock.setMockResponse('GET', '/admin-api/contexts/with-executors/for-application/app-1', {
         data: [{ contextId: 'ctx-1', executors: ['exec-1'] }],
@@ -362,12 +390,10 @@ describe('AdminApiClient', () => {
       await client.updateContextApplication('ctx-1', {
         applicationId: 'app-2',
         executorPublicKey: 'pk-1',
-        migrateMethod: 'migrate_v2',
       });
       expect(mock.getRequestBody('POST', '/admin-api/contexts/ctx-1/application')).toEqual({
         applicationId: 'app-2',
         executorPublicKey: 'pk-1',
-        migrateMethod: 'migrate_v2',
       });
     });
   });
@@ -509,6 +535,16 @@ describe('AdminApiClient', () => {
         applicationId: 'app-1',
         upgradePolicy: 'manual',
         name: 'My NS',
+      });
+    });
+
+    it('createNamespace forwards the appKey version pin', async () => {
+      mock.setMockResponse('POST', '/admin-api/namespaces', { data: { namespaceId: 'ns-1' } });
+      await client.createNamespace({ applicationId: 'app-1', upgradePolicy: 'manual', appKey: 'deadbeef' });
+      expect(mock.getRequestBody('POST', '/admin-api/namespaces')).toEqual({
+        applicationId: 'app-1',
+        upgradePolicy: 'manual',
+        appKey: 'deadbeef',
       });
     });
 
@@ -834,18 +870,16 @@ describe('AdminApiClient', () => {
   });
 
   describe('Group Upgrade', () => {
-    it('upgradeGroup sends request with migrateMethod', async () => {
+    it('upgradeGroup sends request and unwraps data', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
         data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
       });
       const result = await client.upgradeGroup('g-1', {
         targetApplicationId: 'app-2',
-        migrateMethod: 'migrate_v2',
       });
       expect(result.status).toBe('in_progress');
       expect(mock.getRequestBody('POST', '/admin-api/groups/g-1/upgrade')).toEqual({
         targetApplicationId: 'app-2',
-        migrateMethod: 'migrate_v2',
       });
     });
 
@@ -855,12 +889,10 @@ describe('AdminApiClient', () => {
       });
       await client.upgradeGroup('g-1', {
         targetApplicationId: 'app-2',
-        migrateMethod: 'migrate_v2',
         cascade: true,
       });
       expect(mock.getRequestBody('POST', '/admin-api/groups/g-1/upgrade')).toEqual({
         targetApplicationId: 'app-2',
-        migrateMethod: 'migrate_v2',
         cascade: true,
       });
     });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -8,6 +8,7 @@ import type {
   UninstallApplicationResponseData,
   ListApplicationsResponseData,
   GetApplicationResponseData,
+  ApplicationVersionEntry,
   GetLatestVersionResponseData,
   ListPackagesResponseData,
   ListVersionsResponseData,
@@ -27,6 +28,8 @@ import type {
   InviteSpecializedNodeRequest,
   InviteSpecializedNodeResponseData,
   UpdateContextApplicationRequest,
+  ResyncContextRequest,
+  ResyncContextResponseData,
   ContextsWithExecutorsResponseData,
   UploadBlobRequest,
   UploadBlobResponseData,
@@ -233,6 +236,17 @@ export class AdminApiClient {
     return unwrap(await this.httpClient.get<{ data: GetApplicationResponseData }>(`/admin-api/applications/${appId}`));
   }
 
+  /**
+   * Installed-blob inventory for an application — one entry per locally installed
+   * version. This is the *installed* inventory (source for a "pick a version to
+   * pin" UI); the registry equivalent is `listPackageVersions`.
+   */
+  async listApplicationVersions(applicationId: string): Promise<ApplicationVersionEntry[]> {
+    return unwrap(
+      await this.httpClient.get<{ data: ApplicationVersionEntry[] }>(`/admin-api/applications/${applicationId}/versions`),
+    );
+  }
+
   // ---- Package Management ----
 
   async listPackages(): Promise<ListPackagesResponseData> {
@@ -318,6 +332,23 @@ export class AdminApiClient {
 
   async syncContext(contextId?: string): Promise<void> {
     await this.httpClient.post(`/admin-api/contexts/sync/${contextId ?? ''}`, {});
+  }
+
+  /**
+   * Kick off a full state re-pull for a context (operator recovery for a
+   * stranded context). `force` re-pulls even when the node does not flag the
+   * context as stranded.
+   */
+  async resyncContext(
+    contextId: string,
+    request: ResyncContextRequest = {},
+  ): Promise<ResyncContextResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: ResyncContextResponseData }>(
+        `/admin-api/contexts/${contextId}/resync`,
+        request,
+      ),
+    );
   }
 
   async inviteSpecializedNode(request: InviteSpecializedNodeRequest): Promise<InviteSpecializedNodeResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -58,6 +58,18 @@ export interface GetApplicationResponseData {
   application: Application | null;
 }
 
+/** One installed blob for an application (distinct from the package registry). */
+export interface ApplicationVersionEntry {
+  version: string;
+  blobId: string;
+  size: number;
+  package: string;
+}
+
+export interface ListApplicationVersionsResponseData {
+  data: ApplicationVersionEntry[];
+}
+
 // ---- Packages ----
 
 export interface GetLatestVersionResponseData {
@@ -202,11 +214,22 @@ export interface InviteSpecializedNodeResponseData {
 export interface UpdateContextApplicationRequest {
   applicationId: string;
   executorPublicKey: string;
-  migrateMethod?: string;
 }
 
 // Update context application returns empty
 export type UpdateContextApplicationResponseData = Record<string, never>;
+
+// ---- Resync Context ----
+
+export interface ResyncContextRequest {
+  /** Force a full re-pull even if the context is not detected as stranded. */
+  force?: boolean;
+}
+
+export interface ResyncContextResponseData {
+  contextId: string;
+  resyncStarted: boolean;
+}
 
 // ---- Contexts With Executors ----
 
@@ -322,6 +345,8 @@ export interface CreateNamespaceRequest {
   applicationId: string;
   upgradePolicy: string;
   name?: string;
+  /** Hex 32-byte blob id; pins the namespace to a specific installed version. */
+  appKey?: string;
 }
 
 export interface CreateNamespaceResponseData {
@@ -670,7 +695,6 @@ export interface RegisterGroupSigningKeyResponseData {
 export interface UpgradeGroupRequest {
   targetApplicationId: string;
   requester?: string;
-  migrateMethod?: string;
   /** Fan the upgrade out to every descendant subgroup running the same app
    *  (one atomic cascade op). Without it the upgrade applies to the target
    *  group only — members' subgroups never learn the migration. Server


### PR DESCRIPTION
Finishes the JS-SDK side of the migrations-v2 client train. The core engine is merged and the node now derives the migrate method from the embedded bundle ABI, so the caller-supplied `migrateMethod` is gone from the core DTOs. This brings `@calimero-network/mero-js` in line.

## Changes

- **Remove `migrateMethod`** from `UpdateContextApplicationRequest` and `UpgradeGroupRequest`. The node derives the migrate method from the bundle ABI; a caller-supplied method is no longer accepted.
- **Add `appKey?`** (hex 32-byte blob id; pins a namespace to a specific installed version) to `CreateNamespaceRequest`, matching core's `CreateNamespaceApiRequest`. `createNamespace` passes the request through, so no client-method change.
- **Add `resyncContext(contextId, { force })`** → `POST /admin-api/contexts/{id}/resync` (`{data}` envelope), for operator recovery of a stranded context.
- **Add `listApplicationVersions(applicationId)`** → `GET /admin-api/applications/{id}/versions` (`{data}` envelope) — the *installed*-blob inventory, distinct from the registry's existing `listPackageVersions`.

Already present, left untouched: `getMigrationStatus`, `getCascadeStatus`, `Context.applicationVersion`, the polling hooks' counterparts.

## Breaking change

Removing `migrateMethod` from the two request types is a breaking change to the TypeScript surface, so this majors via semantic-release. The server already drops the field (it's gone from the core DTO), so any old client still sending it is harmlessly ignored at runtime.

## Tests

`npm test` (213 pass), `npm run lint`, `npm run typecheck`, and `npm run build` all green. The two pre-existing `migrateMethod` tests pinpointed the call sites; new tests cover `appKey` forwarding, `resyncContext` (with and without `force`), and `listApplicationVersions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript API for group/context upgrades affects all SDK consumers; `resyncContext` with `force` can trigger heavy operator recovery on live contexts.
> 
> **Overview**
> Aligns `@calimero-network/mero-js` admin types and client with migrations-v2: the node no longer accepts a caller-supplied migrate method.
> 
> **Breaking:** `migrateMethod` is removed from `UpdateContextApplicationRequest` and `UpgradeGroupRequest`. Upgrades and context app updates now only send `targetApplicationId` / `applicationId` plus executor fields (and `cascade` on group upgrade). TypeScript callers must stop passing `migrateMethod`; the server already ignores it.
> 
> **Additions:** Optional `appKey` on `CreateNamespaceRequest` pins a namespace to a specific installed blob. New `listApplicationVersions(applicationId)` returns the locally installed version inventory (not registry `listPackageVersions`). New `resyncContext(contextId, { force? })` triggers full state re-pull for stranded-context recovery.
> 
> Tests drop `migrateMethod` expectations and cover the new endpoints and `appKey` forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4447e8801abaa817c4870fec7edbf4763ab246b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->