### PR TITLE
fix(admin): correct migrations-v2 response envelopes + AppVersionChanged event

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -341,9 +341,11 @@ describe('AdminApiClient', () => {
       expect(mock.getRequestBody('POST', '/admin-api/contexts/sync/')).toEqual({});
     });
 
-    it('resyncContext posts force and unwraps data', async () => {
+    it('resyncContext posts force and parses the flat (un-enveloped) payload', async () => {
+      // Core's ResyncContextApiResponse is flat — no `data` envelope.
       mock.setMockResponse('POST', '/admin-api/contexts/ctx-1/resync', {
-        data: { contextId: 'ctx-1', resyncStarted: true },
+        contextId: 'ctx-1',
+        resyncStarted: true,
       });
       const result = await client.resyncContext('ctx-1', { force: true });
       expect(result).toEqual({ contextId: 'ctx-1', resyncStarted: true });
@@ -352,7 +354,8 @@ describe('AdminApiClient', () => {
 
     it('resyncContext defaults to an empty request body', async () => {
       mock.setMockResponse('POST', '/admin-api/contexts/ctx-1/resync', {
-        data: { contextId: 'ctx-1', resyncStarted: false },
+        contextId: 'ctx-1',
+        resyncStarted: false,
       });
       const result = await client.resyncContext('ctx-1');
       expect(result.resyncStarted).toBe(false);
@@ -407,8 +410,9 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ blobId: 'blob-1', size: 3 });
     });
 
-    it('deleteBlob unwraps data', async () => {
-      mock.setMockResponse('DELETE', '/admin-api/blobs/blob-1', { data: { blobId: 'blob-1', deleted: true } });
+    it('deleteBlob parses the flat snake_case payload and maps to camelCase', async () => {
+      // Core's BlobDeleteResponse is flat AND snake_case (`{ blob_id, deleted }`).
+      mock.setMockResponse('DELETE', '/admin-api/blobs/blob-1', { blob_id: 'blob-1', deleted: true });
       const result = await client.deleteBlob('blob-1');
       expect(result).toEqual({ blobId: 'blob-1', deleted: true });
     });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -343,11 +343,12 @@ export class AdminApiClient {
     contextId: string,
     request: ResyncContextRequest = {},
   ): Promise<ResyncContextResponseData> {
-    return unwrap(
-      await this.httpClient.post<{ data: ResyncContextResponseData }>(
-        `/admin-api/contexts/${contextId}/resync`,
-        request,
-      ),
+    // Core's `ResyncContextApiResponse` is a flat payload (no inner `data`
+    // field), so parse the body directly — do NOT `unwrap`, or `resyncStarted`
+    // reads as undefined and the resync silently appears to never start.
+    return this.httpClient.post<ResyncContextResponseData>(
+      `/admin-api/contexts/${contextId}/resync`,
+      request,
     );
   }
 
@@ -382,7 +383,13 @@ export class AdminApiClient {
   }
 
   async deleteBlob(blobId: string): Promise<DeleteBlobResponseData> {
-    return unwrap(await this.httpClient.delete<{ data: DeleteBlobResponseData }>(`/admin-api/blobs/${blobId}`));
+    // Core's `BlobDeleteResponse` is a flat, snake_case payload (`{ blob_id,
+    // deleted }`) — the lone admin DTO without a camelCase rename and without an
+    // inner `data` field. Parse directly (no `unwrap`) and map to camelCase.
+    const body = await this.httpClient.delete<{ blob_id: string; deleted: boolean }>(
+      `/admin-api/blobs/${blobId}`,
+    );
+    return { blobId: body.blob_id, deleted: body.deleted };
   }
 
   async listBlobs(): Promise<ListBlobsResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -437,7 +437,10 @@ export type MemberMigrationState =
   | 'failed';
 
 /** Why a member's migration did not complete. */
-export type MigrationFailureReason = 'check_aborted' | 'apply_failed';
+export type MigrationFailureReason =
+  | 'check_aborted'
+  | 'apply_failed'
+  | 'no_migration_path';
 
 export interface MemberMigrationReport {
   schemaVersion: number;

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -46,14 +46,18 @@ describe('SseClient', () => {
   });
 
   describe('onAppVersionChanged', () => {
+    // Core serializes context events with `type` as a SIBLING of `data` (the
+    // tag is flattened): `result: { contextId, type, data }`. Drive the tests
+    // through handleMessage with that real wire shape rather than hand-crafting
+    // the emitted event, so they exercise the full parse path.
+    const appVersionMsg = (contextId: string, data: Record<string, unknown>) =>
+      JSON.stringify({ result: { contextId, type: 'AppVersionChanged', data } });
+
     it('fires with parsed payload for AppVersionChanged events', () => {
       const seen: Array<{ contextId: string; fromVersion?: string; toVersion?: string }> = [];
       client.onAppVersionChanged((e) => seen.push(e));
 
-      (client as any).emit('event', {
-        contextId: 'ctx1',
-        data: { type: 'AppVersionChanged', data: { fromVersion: '1.0.0', toVersion: '2.0.0' } },
-      });
+      (client as any).handleMessage(appVersionMsg('ctx1', { fromVersion: '1.0.0', toVersion: '2.0.0' }));
 
       expect(seen).toEqual([{ contextId: 'ctx1', fromVersion: '1.0.0', toVersion: '2.0.0' }]);
     });
@@ -62,7 +66,9 @@ describe('SseClient', () => {
       const handler = vi.fn();
       client.onAppVersionChanged(handler);
 
-      (client as any).emit('event', { contextId: 'ctx1', data: { type: 'StateMutation', data: {} } });
+      (client as any).handleMessage(
+        JSON.stringify({ result: { contextId: 'ctx1', type: 'StateMutation', data: {} } }),
+      );
 
       expect(handler).not.toHaveBeenCalled();
     });
@@ -72,10 +78,7 @@ describe('SseClient', () => {
       const off = client.onAppVersionChanged(handler);
       off();
 
-      (client as any).emit('event', {
-        contextId: 'ctx1',
-        data: { type: 'AppVersionChanged', data: { toVersion: '2.0.0' } },
-      });
+      (client as any).handleMessage(appVersionMsg('ctx1', { toVersion: '2.0.0' }));
 
       expect(handler).not.toHaveBeenCalled();
     });

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,5 +1,8 @@
 export interface SseEventData {
   contextId: string;
+  /** The context-event discriminator (core serializes it as a sibling of
+   * `data`, e.g. `"AppVersionChanged"`). Undefined for events without a tag. */
+  type?: string;
   data: unknown;
 }
 
@@ -73,11 +76,11 @@ export class SseClient {
    */
   onAppVersionChanged(handler: (e: AppVersionChangedEvent) => void): () => void {
     const listener: SseEventHandler = (ev) => {
-      const d = ev.data as
-        | { type?: string; data?: { fromVersion?: string; toVersion?: string } }
-        | undefined;
-      if (d?.type !== 'AppVersionChanged') return;
-      handler({ contextId: ev.contextId, fromVersion: d.data?.fromVersion, toVersion: d.data?.toVersion });
+      // Core flattens the tagged payload: the event carries `type` as a sibling
+      // of `data`, and `data` is the `{ fromVersion?, toVersion? }` payload.
+      if (ev.type !== 'AppVersionChanged') return;
+      const d = ev.data as { fromVersion?: string; toVersion?: string } | undefined;
+      handler({ contextId: ev.contextId, fromVersion: d?.fromVersion, toVersion: d?.toVersion });
     };
     this.on('event', listener);
     return () => this.off('event', listener);
@@ -216,6 +219,9 @@ export class SseClient {
 
         this.emit('event', {
           contextId: msg.result.contextId,
+          // Forward the event tag (sibling of `data` in core's flattened
+          // payload) so typed helpers like `onAppVersionChanged` can discriminate.
+          type: msg.result.type,
           data: eventData,
         });
       }


### PR DESCRIPTION
Re-review of the migrations-v2 client surface against **merged core** (`calimero-network/core#2773`) surfaced three response-shape bugs where the SDK assumed an envelope/shape core doesn't emit. All three were hidden by unit tests that mocked the wrong shape, so the mocks are corrected to core's real wire format (they now catch the bugs instead of enshrining them).

## Fixes

**1. `resyncContext` — HIGH (silent failure).** Core's `ResyncContextApiResponse` is a flat payload (`{ contextId, resyncStarted }`, no inner `data`). The client `unwrap`-ped a non-existent `{ data }`, so the result was `undefined` and `resyncStarted` read as falsy — an operator-initiated recovery resync silently appeared to *never start* and never threw. Now parses the body directly.

**2. `deleteBlob` — HIGH.** Core's `BlobDeleteResponse` is flat **and** snake_case (`{ blob_id, deleted }`) — the one admin DTO without a `camelCase` rename. The client `unwrap`-ped `{ data }` and read camelCase, so both fields were `undefined`. Now parses directly and maps `blob_id → blobId`.

**3. `onAppVersionChanged` — HIGH (handler never fired).** Core flattens the tagged context event, so the wire is `{ contextId, type, data }` with `type` a **sibling** of `data`. `handleMessage` dropped `result.type`, so the `type === 'AppVersionChanged'` guard never matched. Now forwards `type` on the emitted `SseEventData` and discriminates on it.

**4. `MigrationFailureReason` — MED.** Added the missing `'no_migration_path'` variant (the stranded-context reason core emits via `migrationFailed`) so TS exhaustive switches handle a stranded member.

## Verification
- `npm run build` (tsc + esbuild) clean; `test:unit` 216/216 pass; eslint clean on changed files.
- Each shape verified against core: `ResyncContextApiResponse`/`BlobDeleteResponse`/`InstallApplicationResponse`(enveloped, untouched) structs, `ApiResponse::into_response` (serializes payload directly), and `ContextEventPayload` (`#[serde(tag="type", content="data")]` flattened).
- Confirmed the sibling blob methods (`uploadBlob`, `listBlobs`) are correctly enveloped in core, so no other method needed changing.

## Note (optional core follow-up)
`BlobDeleteResponse` is the lone admin DTO lacking `#[serde(rename_all = "camelCase")]`; aligning it in core would let `deleteBlob` drop the snake_case mapping. Not required for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes operator-critical paths (context resync, blob delete, bundle-version SSE) that previously failed silently; changes are localized parsing with updated tests, but incorrect assumptions elsewhere could still exist on other admin endpoints.
> 
> **Overview**
> Aligns the admin client and SSE layer with **core’s actual wire formats** where the SDK had been assuming `{ data }` envelopes or nested event tags—bugs that caused silent failures in production.
> 
> **`resyncContext`** no longer uses `unwrap` on a non-existent `{ data }` wrapper; it returns the flat `{ contextId, resyncStarted }` body so operator recovery resyncs report correctly.
> 
> **`deleteBlob`** parses the flat snake_case `{ blob_id, deleted }` response and maps to camelCase `DeleteBlobResponseData`.
> 
> **SSE:** `handleMessage` forwards `result.type` on `SseEventData`, and **`onAppVersionChanged`** filters on that sibling field (not a nested `data.type`). Tests drive **`handleMessage`** with core’s flattened `result: { contextId, type, data }` shape.
> 
> **Types:** `MigrationFailureReason` adds **`no_migration_path`** for stranded-member reporting from core.
> 
> Unit mocks for resync/deleteBlob are updated to match core so tests catch envelope mistakes instead of masking them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b70e13b077846e258b5e14e9b87c286e7832647a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->