### PR TITLE
fix(admin,auth)!: correct 4 wire-contract drifts vs core (alias, blob, context hash, key permissions)

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -261,20 +261,22 @@ describe('AdminApiClient', () => {
       expect(mock.getRequestBody('DELETE', '/admin-api/contexts/ctx-1')).toEqual({ requester: 'pk-admin' });
     });
 
-    it('getContexts returns contexts with groupId', async () => {
-      const ctx = { id: 'ctx-1', applicationId: 'app-1', rootHash: 'abc', dagHeads: [], groupId: 'g-1' };
+    it('getContexts returns contexts with groupId and contextStateHash', async () => {
+      const ctx = { id: 'ctx-1', applicationId: 'app-1', contextStateHash: 'abc', dagHeads: [], groupId: 'g-1' };
       mock.setMockResponse('GET', '/admin-api/contexts', { data: { contexts: [ctx] } });
       const result = await client.getContexts();
       expect(result.contexts).toHaveLength(1);
       expect(result.contexts[0].id).toBe('ctx-1');
       expect(result.contexts[0].groupId).toBe('g-1');
+      expect(result.contexts[0].contextStateHash).toBe('abc');
     });
 
-    it('getContext unwraps data', async () => {
-      const ctx = { id: 'ctx-1', applicationId: 'app-1', rootHash: 'abc', dagHeads: [] };
+    it('getContext unwraps data and exposes contextStateHash (core wire key)', async () => {
+      const ctx = { id: 'ctx-1', applicationId: 'app-1', contextStateHash: 'abc', dagHeads: [] };
       mock.setMockResponse('GET', '/admin-api/contexts/ctx-1', { data: ctx });
       const result = await client.getContext('ctx-1');
       expect(result.id).toBe('ctx-1');
+      expect(result.contextStateHash).toBe('abc');
     });
 
     it('getContextsForApplication unwraps data', async () => {
@@ -404,10 +406,21 @@ describe('AdminApiClient', () => {
   });
 
   describe('Blob Management', () => {
-    it('uploadBlob uses PUT and unwraps data', async () => {
-      mock.setMockResponse('PUT', '/admin-api/blobs', { data: { blobId: 'blob-1', size: 3 } });
-      const result = await client.uploadBlob({ data: new Uint8Array([1, 2, 3]) });
+    it('uploadBlob streams raw bytes with snake_case query params and maps blob_id', async () => {
+      mock.setMockResponse('PUT', '/admin-api/blobs?hash=h1&context_id=ctx-1', {
+        data: { blob_id: 'blob-1', size: 3 },
+      });
+      const result = await client.uploadBlob({ data: new Uint8Array([1, 2, 3]), hash: 'h1', contextId: 'ctx-1' });
       expect(result).toEqual({ blobId: 'blob-1', size: 3 });
+      // body must be the RAW bytes, not a JSON wrapper like {"data":{"0":1,...}}
+      const body = mock.getRequestBody('PUT', '/admin-api/blobs?hash=h1&context_id=ctx-1');
+      expect(Array.from(new Uint8Array(body as ArrayBuffer))).toEqual([1, 2, 3]);
+    });
+
+    it('uploadBlob omits the query string when no hash/contextId given', async () => {
+      mock.setMockResponse('PUT', '/admin-api/blobs', { data: { blob_id: 'blob-2', size: 1 } });
+      const result = await client.uploadBlob({ data: new Uint8Array([9]) });
+      expect(result).toEqual({ blobId: 'blob-2', size: 1 });
     });
 
     it('deleteBlob parses the flat snake_case payload and maps to camelCase', async () => {
@@ -417,30 +430,38 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ blobId: 'blob-1', deleted: true });
     });
 
-    it('listBlobs unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/blobs', { data: { blobs: [{ blobId: 'blob-1', size: 100 }] } });
+    it('listBlobs maps snake_case blob_id to blobId', async () => {
+      mock.setMockResponse('GET', '/admin-api/blobs', { data: { blobs: [{ blob_id: 'blob-1', size: 100 }] } });
       const result = await client.listBlobs();
       expect(result).toEqual({ blobs: [{ blobId: 'blob-1', size: 100 }] });
     });
 
-    it('getBlob unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/blobs/blob-1', { data: { blobId: 'blob-1', size: 100 } });
+    it('getBlob maps snake_case blob_id to blobId', async () => {
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1', { data: { blob_id: 'blob-1', size: 100 } });
       const result = await client.getBlob('blob-1');
       expect(result).toEqual({ blobId: 'blob-1', size: 100 });
     });
   });
 
   describe('Alias Management', () => {
-    it('createContextAlias unwraps data', async () => {
+    it('createContextAlias sends { alias, contextId }', async () => {
       mock.setMockResponse('POST', '/admin-api/alias/create/context', { data: {} });
-      const result = await client.createContextAlias({ name: 'my-ctx', value: 'ctx-1' });
+      const result = await client.createContextAlias({ alias: 'my-ctx', contextId: 'ctx-1' });
       expect(result).toEqual({});
+      expect(mock.getRequestBody('POST', '/admin-api/alias/create/context')).toEqual({
+        alias: 'my-ctx',
+        contextId: 'ctx-1',
+      });
     });
 
-    it('createApplicationAlias unwraps data', async () => {
+    it('createApplicationAlias sends { alias, applicationId }', async () => {
       mock.setMockResponse('POST', '/admin-api/alias/create/application', { data: {} });
-      const result = await client.createApplicationAlias({ name: 'my-app', value: 'app-1' });
+      const result = await client.createApplicationAlias({ alias: 'my-app', applicationId: 'app-1' });
       expect(result).toEqual({});
+      expect(mock.getRequestBody('POST', '/admin-api/alias/create/application')).toEqual({
+        alias: 'my-app',
+        applicationId: 'app-1',
+      });
     });
 
     it('lookupContextAlias unwraps data', async () => {
@@ -487,10 +508,14 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ aliases: [{ name: 'alice', value: 'pk-1' }] });
     });
 
-    it('createContextIdentityAlias unwraps data', async () => {
+    it('createContextIdentityAlias sends { alias, identity } with context in the path', async () => {
       mock.setMockResponse('POST', '/admin-api/alias/create/identity/ctx-1', { data: {} });
-      const result = await client.createContextIdentityAlias('ctx-1', { name: 'alice', value: 'pk-1' });
+      const result = await client.createContextIdentityAlias('ctx-1', { alias: 'alice', identity: 'pk-1' });
       expect(result).toEqual({});
+      expect(mock.getRequestBody('POST', '/admin-api/alias/create/identity/ctx-1')).toEqual({
+        alias: 'alice',
+        identity: 'pk-1',
+      });
     });
 
     it('lookupContextIdentityAlias unwraps data', async () => {

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -406,21 +406,23 @@ describe('AdminApiClient', () => {
   });
 
   describe('Blob Management', () => {
-    it('uploadBlob streams raw bytes with snake_case query params and maps blob_id', async () => {
+    it('uploadBlob streams the raw Uint8Array with snake_case query params and maps blob_id', async () => {
+      const bytes = new Uint8Array([1, 2, 3]);
       mock.setMockResponse('PUT', '/admin-api/blobs?hash=h1&context_id=ctx-1', {
         data: { blob_id: 'blob-1', size: 3 },
       });
-      const result = await client.uploadBlob({ data: new Uint8Array([1, 2, 3]), hash: 'h1', contextId: 'ctx-1' });
+      const result = await client.uploadBlob({ data: bytes, hash: 'h1', contextId: 'ctx-1' });
       expect(result).toEqual({ blobId: 'blob-1', size: 3 });
-      // body must be the RAW bytes, not a JSON wrapper like {"data":{"0":1,...}}
-      const body = mock.getRequestBody('PUT', '/admin-api/blobs?hash=h1&context_id=ctx-1');
-      expect(Array.from(new Uint8Array(body as ArrayBuffer))).toEqual([1, 2, 3]);
+      // the exact bytes are streamed verbatim, NOT a JSON wrapper like {"data":{"0":1,...}}
+      expect(mock.getRequestBody('PUT', '/admin-api/blobs?hash=h1&context_id=ctx-1')).toBe(bytes);
     });
 
-    it('uploadBlob omits the query string when no hash/contextId given', async () => {
-      mock.setMockResponse('PUT', '/admin-api/blobs', { data: { blob_id: 'blob-2', size: 1 } });
-      const result = await client.uploadBlob({ data: new Uint8Array([9]) });
-      expect(result).toEqual({ blobId: 'blob-2', size: 1 });
+    it('uploadBlob streams an ArrayBuffer body and omits the query when no hash/contextId', async () => {
+      const buf = new Uint8Array([9, 9]).buffer;
+      mock.setMockResponse('PUT', '/admin-api/blobs', { data: { blob_id: 'blob-2', size: 2 } });
+      const result = await client.uploadBlob({ data: buf });
+      expect(result).toEqual({ blobId: 'blob-2', size: 2 });
+      expect(mock.getRequestBody('PUT', '/admin-api/blobs')).toBe(buf);
     });
 
     it('deleteBlob parses the flat snake_case payload and maps to camelCase', async () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -36,7 +36,9 @@ import type {
   DeleteBlobResponseData,
   ListBlobsResponseData,
   GetBlobResponseData,
-  CreateAliasRequest,
+  CreateContextAliasRequest,
+  CreateApplicationAliasRequest,
+  CreateContextIdentityAliasRequest,
   CreateAliasResponseData,
   LookupAliasResponseData,
   DeleteAliasResponseData,
@@ -378,8 +380,30 @@ export class AdminApiClient {
 
   // ---- Blob Management ----
 
-  async uploadBlob(data: UploadBlobRequest): Promise<UploadBlobResponseData> {
-    return unwrap(await this.httpClient.put<{ data: UploadBlobResponseData }>('/admin-api/blobs', data));
+  async uploadBlob(request: UploadBlobRequest): Promise<UploadBlobResponseData> {
+    // Core streams the raw request body into blob storage (no JSON) and takes
+    // its params from the query string (`hash`, `context_id` — snake_case).
+    const params = new URLSearchParams();
+    if (request.hash) params.set('hash', request.hash);
+    if (request.contextId) params.set('context_id', request.contextId);
+    const query = params.toString();
+    const path = query ? `/admin-api/blobs?${query}` : '/admin-api/blobs';
+    const body =
+      request.data instanceof Uint8Array
+        ? request.data.buffer.slice(
+            request.data.byteOffset,
+            request.data.byteOffset + request.data.byteLength,
+          )
+        : request.data;
+    // Core's BlobInfo is snake_case (`blob_id`); map to camelCase like deleteBlob.
+    const res = unwrap(
+      await this.httpClient.request<{ data: { blob_id: string; size: number } }>(path, {
+        method: 'PUT',
+        body: body as BodyInit,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }),
+    );
+    return { blobId: res.blob_id, size: res.size };
   }
 
   async deleteBlob(blobId: string): Promise<DeleteBlobResponseData> {
@@ -393,21 +417,46 @@ export class AdminApiClient {
   }
 
   async listBlobs(): Promise<ListBlobsResponseData> {
-    return unwrap(await this.httpClient.get<{ data: ListBlobsResponseData }>('/admin-api/blobs'));
+    // Core's BlobInfo is snake_case (`blob_id`); map to camelCase.
+    const res = unwrap(
+      await this.httpClient.get<{ data: { blobs: Array<{ blob_id: string; size: number }> } }>(
+        '/admin-api/blobs',
+      ),
+    );
+    return { blobs: res.blobs.map((b) => ({ blobId: b.blob_id, size: b.size })) };
   }
 
   async getBlob(blobId: string): Promise<GetBlobResponseData> {
-    return unwrap(await this.httpClient.get<{ data: GetBlobResponseData }>(`/admin-api/blobs/${blobId}`));
+    const res = unwrap(
+      await this.httpClient.get<{ data: { blob_id: string; size: number } }>(
+        `/admin-api/blobs/${blobId}`,
+      ),
+    );
+    return { blobId: res.blob_id, size: res.size };
   }
 
   // ---- Alias Management ----
 
-  async createContextAlias(request: CreateAliasRequest): Promise<CreateAliasResponseData> {
-    return unwrap(await this.httpClient.post<{ data: CreateAliasResponseData }>('/admin-api/alias/create/context', request));
+  async createContextAlias(
+    request: CreateContextAliasRequest,
+  ): Promise<CreateAliasResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: CreateAliasResponseData }>(
+        '/admin-api/alias/create/context',
+        { alias: request.alias, contextId: request.contextId },
+      ),
+    );
   }
 
-  async createApplicationAlias(request: CreateAliasRequest): Promise<CreateAliasResponseData> {
-    return unwrap(await this.httpClient.post<{ data: CreateAliasResponseData }>('/admin-api/alias/create/application', request));
+  async createApplicationAlias(
+    request: CreateApplicationAliasRequest,
+  ): Promise<CreateAliasResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: CreateAliasResponseData }>(
+        '/admin-api/alias/create/application',
+        { alias: request.alias, applicationId: request.applicationId },
+      ),
+    );
   }
 
   async lookupContextAlias(name: string): Promise<LookupAliasResponseData> {
@@ -466,12 +515,12 @@ export class AdminApiClient {
 
   async createContextIdentityAlias(
     contextId: string,
-    request: CreateAliasRequest,
+    request: CreateContextIdentityAliasRequest,
   ): Promise<CreateContextIdentityAliasResponseData> {
     return unwrap(
       await this.httpClient.post<{ data: CreateContextIdentityAliasResponseData }>(
         `/admin-api/alias/create/identity/${contextId}`,
-        request,
+        { alias: request.alias, identity: request.identity },
       ),
     );
   }

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -388,18 +388,14 @@ export class AdminApiClient {
     if (request.contextId) params.set('context_id', request.contextId);
     const query = params.toString();
     const path = query ? `/admin-api/blobs?${query}` : '/admin-api/blobs';
-    const body =
-      request.data instanceof Uint8Array
-        ? request.data.buffer.slice(
-            request.data.byteOffset,
-            request.data.byteOffset + request.data.byteLength,
-          )
-        : request.data;
+    // request.data (Uint8Array view | ArrayBuffer | Blob) is a valid BodyInit and
+    // is streamed verbatim — no JSON, no cast. fetch honors a Uint8Array view's
+    // byteOffset/byteLength, so subarrays upload the correct region.
     // Core's BlobInfo is snake_case (`blob_id`); map to camelCase like deleteBlob.
     const res = unwrap(
       await this.httpClient.request<{ data: { blob_id: string; size: number } }>(path, {
         method: 'PUT',
-        body: body as BodyInit,
+        body: request.data,
         headers: { 'Content-Type': 'application/octet-stream' },
       }),
     );

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -145,7 +145,12 @@ export interface Context {
   id: string;
   applicationId: string;
   serviceName?: string;
-  rootHash: string;
+  /**
+   * Context state/root hash. Core's wire key is `contextStateHash` (part of the
+   * cross-DAG auth three-level naming: contextStateHash / groupStateHash /
+   * namespaceStateHash). Renamed from `rootHash`, which never populated.
+   */
+  contextStateHash: string;
   dagHeads: number[][];
   /** Bundle semver of the installed application (skew #2). Absent on older nodes. */
   applicationVersion?: string;
@@ -243,7 +248,12 @@ export type ContextsWithExecutorsResponseData = ContextWithExecutors[];
 // ---- Blobs ----
 
 export interface UploadBlobRequest {
-  data: Uint8Array | ArrayBuffer;
+  /** Raw blob bytes; streamed verbatim as the request body (octet-stream). */
+  data: Uint8Array | ArrayBuffer | Blob;
+  /** Optional expected blob hash; sent as the `hash` query param for server-side verification. */
+  hash?: string;
+  /** Optional context to announce the blob to; sent as the `context_id` query param. */
+  contextId?: string;
 }
 
 export interface BlobInfo {
@@ -266,9 +276,21 @@ export type GetBlobResponseData = BlobInfo;
 
 // ---- Aliases ----
 
-export interface CreateAliasRequest {
-  name: string;
-  value: string;
+// Core's CreateAliasRequest is `{ alias, #[serde(flatten)] value }`, so each
+// alias kind flattens a different id field at the top level of the body.
+export interface CreateContextAliasRequest {
+  alias: string;
+  contextId: string;
+}
+
+export interface CreateApplicationAliasRequest {
+  alias: string;
+  applicationId: string;
+}
+
+export interface CreateContextIdentityAliasRequest {
+  alias: string;
+  identity: string;
 }
 
 export interface AliasEntry {

--- a/src/auth-api/auth-client.test.ts
+++ b/src/auth-api/auth-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthApiClient } from './auth-client';
+import { HttpClient } from '../http-client';
+
+// Mock HttpClient that records request bodies (mirrors admin-client.test.ts).
+class MockHttpClient implements HttpClient {
+  private mockResponses = new Map<string, unknown>();
+  private requestBodies = new Map<string, unknown>();
+
+  setMockResponse(method: string, path: string, response: unknown) {
+    this.mockResponses.set(`${method} ${path}`, response);
+  }
+  getRequestBody(method: string, path: string): unknown {
+    return this.requestBodies.get(`${method} ${path}`);
+  }
+  private getResponse(method: string, path: string): unknown {
+    const key = `${method} ${path}`;
+    if (!this.mockResponses.has(key)) throw new Error(`No mock response for ${key}`);
+    return this.mockResponses.get(key);
+  }
+  async get<T>(path: string): Promise<T> {
+    return this.getResponse('GET', path) as T;
+  }
+  async post<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`POST ${path}`, body);
+    return this.getResponse('POST', path) as T;
+  }
+  async put<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`PUT ${path}`, body);
+    return this.getResponse('PUT', path) as T;
+  }
+  async delete<T>(path: string): Promise<T> {
+    return this.getResponse('DELETE', path) as T;
+  }
+  async patch<T>(path: string, body?: unknown): Promise<T> {
+    this.requestBodies.set(`PATCH ${path}`, body);
+    return this.getResponse('PATCH', path) as T;
+  }
+  async head(): Promise<{ headers: Record<string, string>; status: number }> {
+    return { headers: {}, status: 200 };
+  }
+  async request<T>(path: string, init?: { method?: string; body?: unknown }): Promise<T> {
+    const method = init?.method ?? 'GET';
+    let body = init?.body;
+    if (typeof body === 'string') body = JSON.parse(body);
+    this.requestBodies.set(`${method} ${path}`, body);
+    return this.getResponse(method, path) as T;
+  }
+}
+
+describe('AuthApiClient', () => {
+  let mock: MockHttpClient;
+  let client: AuthApiClient;
+
+  beforeEach(() => {
+    mock = new MockHttpClient();
+    client = new AuthApiClient(mock);
+  });
+
+  describe('updateKeyPermissions', () => {
+    it('sends an { add, remove } delta (not a { permissions } replacement)', async () => {
+      mock.setMockResponse('PUT', '/admin/keys/key1/permissions', {
+        data: { permissions: ['context:execute'] },
+        error: null,
+      });
+
+      const result = await client.updateKeyPermissions('key1', {
+        add: ['context:execute'],
+        remove: ['admin'],
+      });
+
+      expect(result).toEqual({ data: { permissions: ['context:execute'] }, error: null });
+      const body = mock.getRequestBody('PUT', '/admin/keys/key1/permissions');
+      expect(body).toEqual({ add: ['context:execute'], remove: ['admin'] });
+      // Regression guard: core ignores a `permissions` field, so it must not be sent.
+      expect(body).not.toHaveProperty('permissions');
+    });
+
+    it('supports an add-only delta', async () => {
+      mock.setMockResponse('PUT', '/admin/keys/key1/permissions', {
+        data: { permissions: ['a', 'b'] },
+        error: null,
+      });
+
+      await client.updateKeyPermissions('key1', { add: ['b'] });
+
+      expect(mock.getRequestBody('PUT', '/admin/keys/key1/permissions')).toEqual({ add: ['b'] });
+    });
+  });
+});

--- a/src/auth-api/auth-client.ts
+++ b/src/auth-api/auth-client.ts
@@ -27,6 +27,7 @@ import {
   DeleteClientResponse,
   // Permissions
   PermissionResponse,
+  UpdateKeyPermissionsRequest,
   // Auth Status
   AuthStatus,
 } from './auth-types';
@@ -184,11 +185,12 @@ export class AuthApiClient {
 
   async updateKeyPermissions(
     keyId: string,
-    permissions: string[],
+    changes: UpdateKeyPermissionsRequest,
   ): Promise<PermissionResponse> {
+    // Core expects an { add, remove } delta, not a { permissions } replacement.
     return this.httpClient.put<PermissionResponse>(
       `/admin/keys/${keyId}/permissions`,
-      { permissions },
+      { add: changes.add, remove: changes.remove },
     );
   }
 }

--- a/src/auth-api/auth-types.ts
+++ b/src/auth-api/auth-types.ts
@@ -132,6 +132,15 @@ export interface DeleteClientResponse {
 }
 
 // Permission Management Types
+// Core applies an { add, remove } delta (remove first, then add) — NOT a
+// full-set replacement. A `permissions` field is ignored by core.
+export interface UpdateKeyPermissionsRequest {
+  /** Permission strings to add (OR-ed onto the key's current set). */
+  add?: string[];
+  /** Permission strings to remove (applied before `add`). */
+  remove?: string[];
+}
+
 export interface PermissionResponse {
   data: {
     permissions: string[];


### PR DESCRIPTION
## Summary

Fixes 4 confirmed wire-contract **drift bugs (P0)** from the SDK↔core audit, where mero-js silently sent/expected the wrong shape — each masked by a unit test that asserted the *wrong* shape.

## Fixes

### `fix(admin)!`
- **Alias create** — `createContextAlias` / `createApplicationAlias` / `createContextIdentityAlias` sent `{ name, value }`, but core's `CreateAliasRequest` is a flattened `{ alias, contextId | applicationId | identity }`. Every call was failing serde deserialization (4xx). Split into kind-specific request types and send the correct flat body.
- **uploadBlob** — JSON-stringified the `Uint8Array` (corrupting the blob) and dropped the `?hash=&context_id=` query params. Now streams the raw bytes as `application/octet-stream` with the snake_case query params (via the low-level `request()`), and maps core's snake_case `blob_id` → `blobId` for `uploadBlob` / `listBlobs` / `getBlob` (`deleteBlob` already did this).
- **Context.rootHash** — never populated; core's wire key is `contextStateHash`. Renamed the field.

### `fix(auth)!`
- **updateKeyPermissions** — sent `{ permissions }`, which core ignores → a silent no-op that echoed the old permissions with 200. Now sends the `{ add, remove }` delta core actually applies.

## Tests & verification
Added body/response-asserting unit tests (the kind that would have caught the original drift). 6 new RED tests now green; **219 unit tests pass**, typecheck + lint + build all clean. Each wire shape was re-validated against **current core source** before implementing.

> The docker-based e2e suite (`merobox run --auth-service`) wasn't runnable in this environment (no Docker daemon); verification was unit + source-level. Recommend running e2e in CI.

## Breaking changes (semantic-release will major-bump)
- `CreateAliasRequest` → `CreateContextAliasRequest` / `CreateApplicationAliasRequest` / `CreateContextIdentityAliasRequest`
- `UploadBlobRequest` gains optional `hash` / `contextId`
- `Context.rootHash` → `Context.contextStateHash`
- `updateKeyPermissions(keyId, string[])` → `updateKeyPermissions(keyId, { add?, remove? })`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Fixes P0 wire mismatches (broken alias/blob calls, silent permission no-ops) but ships intentional breaking API/type changes that require consumer updates.
> 
> **Overview**
> Aligns **admin** and **auth** clients with core’s actual HTTP shapes so calls stop failing or silently doing nothing.
> 
> **Admin:** Alias create endpoints now send flattened `{ alias, contextId | applicationId | identity }` instead of `{ name, value }`. **`uploadBlob`** streams raw bytes as `application/octet-stream`, optional `hash` / `context_id` query params, and maps snake_case `blob_id` on upload/list/get. **`Context`** exposes **`contextStateHash`** (core’s wire key) instead of **`rootHash`**.
> 
> **Auth:** **`updateKeyPermissions`** sends an **`{ add?, remove? }`** delta instead of **`{ permissions }`**, which core ignored.
> 
> Types split **`CreateAliasRequest`** into kind-specific requests; tests assert request bodies and response mapping. **Breaking** for SDK consumers on those APIs and fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c68a4663d96603481aa9a856033b110a1b50dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->