### PR TITLE
fix(auth)!: align auth-api key/token/health methods with core wire contract

### DIFF
--- a/src/auth-api/auth-client.test.ts
+++ b/src/auth-api/auth-client.test.ts
@@ -87,4 +87,119 @@ describe('AuthApiClient', () => {
       expect(mock.getRequestBody('PUT', '/admin/keys/key1/permissions')).toEqual({ add: ['b'] });
     });
   });
+
+  describe('revokeTokens', () => {
+    it('sends { client_id } and unwraps the { data } envelope', async () => {
+      mock.setMockResponse('POST', '/admin/revoke', {
+        data: { success: true, message: 'Tokens revoked successfully' },
+        error: null,
+      });
+      const result = await client.revokeTokens({ client_id: 'client-1' });
+      expect(result).toEqual({ success: true, message: 'Tokens revoked successfully' });
+      expect(mock.getRequestBody('POST', '/admin/revoke')).toEqual({ client_id: 'client-1' });
+    });
+  });
+
+  describe('createRootKey', () => {
+    it('sends { public_key, auth_method, provider_data } and unwraps the { data } envelope', async () => {
+      mock.setMockResponse('POST', '/admin/keys', {
+        data: { status: true, message: 'Key was created' },
+        error: null,
+      });
+      const result = await client.createRootKey({
+        public_key: 'ed25519:pk',
+        auth_method: 'user_password',
+        provider_data: {},
+      });
+      expect(result).toEqual({ status: true, message: 'Key was created' });
+      expect(mock.getRequestBody('POST', '/admin/keys')).toEqual({
+        public_key: 'ed25519:pk',
+        auth_method: 'user_password',
+        provider_data: {},
+      });
+    });
+  });
+
+  describe('listRootKeys', () => {
+    it('unwraps the flat data array of root keys', async () => {
+      const keys = [
+        {
+          key_id: 'k1',
+          public_key: 'pk',
+          auth_method: 'user_password',
+          created_at: 1,
+          revoked_at: null,
+          permissions: ['admin'],
+        },
+      ];
+      mock.setMockResponse('GET', '/admin/keys', { data: keys, error: null });
+      expect(await client.listRootKeys()).toEqual(keys);
+    });
+  });
+
+  describe('listClientKeys', () => {
+    it('unwraps the flat data array of client keys', async () => {
+      const clients = [
+        {
+          client_id: 'c1',
+          root_key_id: 'k1',
+          name: 'ctx client',
+          permissions: ['context:execute'],
+          created_at: 1,
+          revoked_at: null,
+          is_valid: true,
+        },
+      ];
+      mock.setMockResponse('GET', '/admin/keys/clients', { data: clients, error: null });
+      expect(await client.listClientKeys()).toEqual(clients);
+    });
+  });
+
+  describe('generateClientKey', () => {
+    it('sends the context_id/context_identity/permissions body', async () => {
+      mock.setMockResponse('POST', '/admin/client-key', {
+        data: { access_token: 'a', refresh_token: 'r' },
+        error: null,
+      });
+      await client.generateClientKey({
+        context_id: 'ctx-1',
+        context_identity: 'id-1',
+        permissions: ['context:execute'],
+      });
+      expect(mock.getRequestBody('POST', '/admin/client-key')).toEqual({
+        context_id: 'ctx-1',
+        context_identity: 'id-1',
+        permissions: ['context:execute'],
+      });
+    });
+  });
+
+  describe('generateMockTokens', () => {
+    it('sends snake_case { client_name, access_token_expiry }', async () => {
+      mock.setMockResponse('POST', '/auth/mock-token', {
+        data: { access_token: 'a', refresh_token: 'r' },
+        error: null,
+      });
+      await client.generateMockTokens({
+        client_name: 'cli',
+        permissions: ['admin'],
+        access_token_expiry: 3600,
+      });
+      expect(mock.getRequestBody('POST', '/auth/mock-token')).toEqual({
+        client_name: 'cli',
+        permissions: ['admin'],
+        access_token_expiry: 3600,
+      });
+    });
+  });
+
+  describe('getHealth', () => {
+    it('exposes the alive/not_alive status and uptime_seconds (snake_case)', async () => {
+      mock.setMockResponse('GET', '/auth/health', {
+        data: { status: 'alive', storage: true, uptime_seconds: 42 },
+        error: null,
+      });
+      expect(await client.getHealth()).toEqual({ status: 'alive', storage: true, uptime_seconds: 42 });
+    });
+  });
 });

--- a/src/auth-api/auth-client.ts
+++ b/src/auth-api/auth-client.ts
@@ -10,7 +10,6 @@ import {
   TokenRequest,
   TokenResponse,
   RefreshTokenRequest,
-  ChallengeResponse,
   // Mock Token (testing)
   MockTokenRequest,
   // Token Management
@@ -20,16 +19,14 @@ import {
   CreateKeyRequest,
   CreateKeyResponse,
   DeleteKeyResponse,
-  RootKeysResponse,
+  RootKey,
   // Client Management
-  ClientKeysResponse,
+  ClientKey,
   GenerateClientKeyRequest,
   DeleteClientResponse,
   // Permissions
   PermissionResponse,
   UpdateKeyPermissionsRequest,
-  // Auth Status
-  AuthStatus,
 } from './auth-types';
 
 export class AuthApiClient {
@@ -84,10 +81,6 @@ export class AuthApiClient {
     return this.httpClient.post<TokenResponse>('/auth/mock-token', request);
   }
 
-  async getChallenge(): Promise<ChallengeResponse> {
-    return this.httpClient.get<ChallengeResponse>('/auth/challenge');
-  }
-
   async validateToken(token: string): Promise<{
     valid: boolean;
     headers: Record<string, string>;
@@ -121,21 +114,26 @@ export class AuthApiClient {
     };
   }
 
-  async isAuthed(): Promise<AuthStatus> {
-    return this.httpClient.get<AuthStatus>('/auth/is-authed');
-  }
-
   // Token Management Endpoints
+  // NOTE: node auth status lives on AdminApiClient.isAuthed() (/admin-api/is-authed);
+  // there is no /auth/is-authed on the auth service.
   async revokeTokens(
     request: RevokeTokenRequest,
   ): Promise<RevokeTokenResponse> {
-    return this.httpClient.post<RevokeTokenResponse>('/admin/revoke', request);
+    const response = await this.httpClient.post<ApiResponse<RevokeTokenResponse>>(
+      '/admin/revoke',
+      request,
+    );
+    if (!response.data) {
+      throw new Error('Revoke tokens response data is null');
+    }
+    return response.data;
   }
 
   // Key Management Endpoints
-  async listRootKeys(): Promise<RootKeysResponse> {
+  async listRootKeys(): Promise<RootKey[]> {
     const response =
-      await this.httpClient.get<ApiResponse<RootKeysResponse>>('/admin/keys');
+      await this.httpClient.get<ApiResponse<RootKey[]>>('/admin/keys');
     if (!response.data) {
       throw new Error('Root keys response data is null');
     }
@@ -143,7 +141,14 @@ export class AuthApiClient {
   }
 
   async createRootKey(request: CreateKeyRequest): Promise<CreateKeyResponse> {
-    return this.httpClient.post<CreateKeyResponse>('/admin/keys', request);
+    const response = await this.httpClient.post<ApiResponse<CreateKeyResponse>>(
+      '/admin/keys',
+      request,
+    );
+    if (!response.data) {
+      throw new Error('Create root key response data is null');
+    }
+    return response.data;
   }
 
   async deleteRootKey(keyId: string): Promise<DeleteKeyResponse> {
@@ -151,8 +156,8 @@ export class AuthApiClient {
   }
 
   // Client Management Endpoints
-  async listClientKeys(): Promise<ClientKeysResponse> {
-    const response = await this.httpClient.get<ApiResponse<ClientKeysResponse>>(
+  async listClientKeys(): Promise<ClientKey[]> {
+    const response = await this.httpClient.get<ApiResponse<ClientKey[]>>(
       '/admin/keys/clients',
     );
     if (!response.data) {

--- a/src/auth-api/auth-types.ts
+++ b/src/auth-api/auth-types.ts
@@ -5,15 +5,15 @@ export { ApiResponse } from '../http-client';
 
 // Health and Status Types
 export interface HealthResponse {
-  status: 'healthy' | 'unhealthy';
+  status: 'alive' | 'not_alive';
   storage: boolean;
-  uptimeSeconds: number;
+  uptime_seconds: number;
 }
 
 export interface IdentityResponse {
   service: string;
   version: string;
-  authenticationMode: string;
+  authentication_mode: string;
   providers: string[];
 }
 
@@ -52,22 +52,19 @@ export interface RefreshTokenRequest {
   refresh_token: string;
 }
 
-export interface ChallengeResponse {
-  challenge: string;
-  expiresAt: string;
-}
-
-// Mock Token (testing)
+// Mock Token (CI/testing). Core's MockTokenRequest is snake_case.
 export interface MockTokenRequest {
-  clientName: string;
+  client_name: string;
   permissions?: string[];
-  expiresIn?: number;
+  node_url?: string;
+  access_token_expiry?: number;
+  refresh_token_expiry?: number;
 }
 
 // Token Management Types
+// Core revokes by client_id (the request is `{ client_id }`).
 export interface RevokeTokenRequest {
-  token: string;
-  reason?: string;
+  client_id: string;
 }
 
 export interface RevokeTokenResponse {
@@ -77,17 +74,19 @@ export interface RevokeTokenResponse {
 
 // Key Management Types
 export interface CreateKeyRequest {
-  name: string;
-  permissions: string[];
-  expiresAt?: string;
+  /** Public key to register as a root key. */
+  public_key: string;
+  /** Auth method / provider name (e.g. "user_password"). */
+  auth_method: string;
+  /** Provider-specific data. */
+  provider_data: Record<string, unknown>;
+  /** Target node URL to scope the root key to (optional). */
+  target_node_url?: string;
 }
 
 export interface CreateKeyResponse {
-  keyId: string;
-  name: string;
-  permissions: string[];
-  createdAt: string;
-  expiresAt?: string;
+  status: boolean;
+  message: string;
 }
 
 export interface DeleteKeyResponse {
@@ -95,35 +94,37 @@ export interface DeleteKeyResponse {
   message: string;
 }
 
-export interface RootKeysResponse {
-  keys: Array<{
-    key_id: string;
-    name: string;
-    permissions: string[];
-    created_at: string;
-    expires_at?: string;
-  }>;
-  count: number;
+// Core returns a flat array of root keys (the `{ data }` payload).
+export interface RootKey {
+  key_id: string;
+  public_key: string;
+  auth_method: string;
+  created_at: number;
+  revoked_at?: number | null;
+  permissions: string[];
 }
 
 // Client Management Types
-export interface ClientKeysResponse {
-  clients: Array<{
-    client_id: string;
-    key_id: string;
-    name: string;
-    permissions: string[];
-    created_at: string;
-    last_used?: string;
-  }>;
-  count: number;
+// Core returns a flat array of client keys (the `{ data }` payload).
+export interface ClientKey {
+  client_id: string;
+  root_key_id: string;
+  name: string;
+  permissions: string[];
+  created_at: number;
+  revoked_at?: number | null;
+  is_valid: boolean;
 }
 
 export interface GenerateClientKeyRequest {
-  keyId: string;
-  clientName: string;
-  permissions: string[];
-  expiresAt?: string;
+  /** Context the client key is scoped to (optional). */
+  context_id?: string;
+  /** Context identity (executor public key) the client key is for (optional). */
+  context_identity?: string;
+  /** Additional permissions to request (validated against the root key). */
+  permissions?: string[];
+  /** Target node URL to scope the client key/tokens to (optional). */
+  target_node_url?: string;
 }
 
 export interface DeleteClientResponse {
@@ -146,17 +147,6 @@ export interface PermissionResponse {
     permissions: string[];
   };
   error?: string | null;
-}
-
-// Auth Status Types
-export interface AuthStatus {
-  status: string;
-  authenticated: boolean;
-  user?: {
-    id: string;
-    name: string;
-    permissions: string[];
-  };
 }
 
 // Client Configuration


### PR DESCRIPTION
## Summary

Fixes the remaining **auth-api wire drift** from the SDK↔core audit — the cluster #51 (admin) left untouched. Each shape was re-validated against current `core/crates/auth`.

## Fixes
| Method | Was → Now |
|---|---|
| `revokeTokens` | `{ token, reason }` (rejected by core) → **`{ client_id }`** + unwrap `{ data }` (was a no-op/throw) |
| `createRootKey` | `{ name, permissions, expiresAt }` → **`{ public_key, auth_method, provider_data, target_node_url? }`** + unwrap `{ data: { status, message } }` |
| `listRootKeys` | `{ keys, count }` → **flat `RootKey[]`** (`public_key`/`auth_method`/`revoked_at`/…) |
| `listClientKeys` | `{ clients, count }` → **flat `ClientKey[]`** (`root_key_id`/`is_valid`/…) |
| `generateClientKey` | `{ keyId, clientName, … }` → **`{ context_id, context_identity, permissions?, target_node_url? }`** |
| `generateMockTokens` | camelCase → **snake_case** `{ client_name, access_token_expiry, refresh_token_expiry, node_url? }` |
| `HealthResponse` | `'healthy'\|'unhealthy'` / `uptimeSeconds` → **`'alive'\|'not_alive'` / `uptime_seconds`** |
| `IdentityResponse` | `authenticationMode` → **`authentication_mode`** |
| `getChallenge` | **removed** — challenge auth had no provider after the NEAR removal (dead) |
| `isAuthed` | **removed** — it targeted a non-existent `/auth/is-authed`; node auth status is `AdminApiClient.isAuthed()` → `/admin-api/is-authed` |

## Tests
Body/response-asserting tests added. `revokeTokens` and `createRootKey` were genuine runtime failures (missing `{data}` unwrap) and went RED→green; the rest lock the corrected wire shapes (they're type-contract drifts the runtime forwarded verbatim). **226 tests pass**, typecheck + lint + build clean.

## Breaking changes (semantic-release will major-bump)
- Removed `AuthApiClient.getChallenge()` and `isAuthed()` (use `AdminApiClient.isAuthed()`).
- Changed types: `RevokeTokenRequest` (`{client_id}`), `CreateKeyRequest`/`CreateKeyResponse`, `GenerateClientKeyRequest`, `MockTokenRequest` (snake_case).
- `listRootKeys`/`listClientKeys` now return `RootKey[]`/`ClientKey[]` (the `RootKeysResponse`/`ClientKeysResponse`, `ChallengeResponse`, `AuthStatus` types are removed).
- `HealthResponse`/`IdentityResponse` field changes.

> Verification was unit + source-level (shapes confirmed against current core handlers); the Docker-based e2e suite wasn't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API and request/response shapes for token revocation, root/client key lifecycle, and health; callers must migrate types and use AdminApiClient for auth status.
> 
> **Overview**
> **Breaking change:** `AuthApiClient` and `auth-types` are updated to match the core auth service HTTP contract (snake_case fields, `{ data }` envelopes, and flat list payloads).
> 
> **Token and key admin:** `revokeTokens` now posts `{ client_id }` and unwraps `{ data }` (previously wrong body and no unwrap). `createRootKey` uses `{ public_key, auth_method, provider_data, … }` with the same unwrap. `listRootKeys` / `listClientKeys` return `RootKey[]` and `ClientKey[]` instead of wrapped `{ keys, count }` / `{ clients, count }`. `generateClientKey` and `generateMockTokens` request bodies are aligned to core (`context_id`, `context_identity`, snake_case mock fields).
> 
> **Types and removals:** `HealthResponse` uses `alive` / `not_alive` and `uptime_seconds`; `IdentityResponse` uses `authentication_mode`. Removed `getChallenge`, `isAuthed` on this client (node auth → `AdminApiClient.isAuthed()`), and dropped `ChallengeResponse`, `AuthStatus`, `RootKeysResponse`, `ClientKeysResponse`.
> 
> **Tests:** New unit tests assert request bodies and unwrapped responses for revoke, root/client keys, mock tokens, and health.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8e894df3ec0828e3dec60f7fd91c2169d5bf24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->