### PR TITLE
fix(admin)!: align group reparent + createContext label with core wire contract

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -247,8 +247,6 @@ describe('AdminApiClient', () => {
         identitySecret: 'secret',
         name: 'my-ctx',
       });
-      // Regression guard: core's CreateContextRequest has no `groupName`/`alias`
-      // field, so the human label must be sent as `name` or it is silently dropped.
       expect(body).not.toHaveProperty('groupName');
       expect(body).not.toHaveProperty('alias');
     });
@@ -1047,9 +1045,6 @@ describe('AdminApiClient', () => {
   });
 
   describe('Group Reparent', () => {
-    // Core replaced the nest/unnest pair with a single atomic edge-swap:
-    // POST /admin-api/groups/:childGroupId/reparent  body { newParentId, requester? }
-    // (child is in the PATH, new parent is in the BODY) → { data: { reparented } }.
     it('reparentGroup moves the child (path) under newParentId (body) and unwraps { reparented }', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/child-1/reparent', { data: { reparented: true } });
       const result = await client.reparentGroup('child-1', { newParentId: 'parent-2' });

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -228,24 +228,29 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ contextId: 'ctx-1', memberPublicKey: 'key-1' });
     });
 
-    it('createContext sends all optional fields', async () => {
+    it('createContext sends all optional fields incl. the `name` label (core wire key, not groupName/alias)', async () => {
       mock.setMockResponse('POST', '/admin-api/contexts', { data: { contextId: 'ctx-1', memberPublicKey: 'key-1', groupId: 'g-1', groupCreated: true } });
       const result = await client.createContext({
         applicationId: 'app-1',
         groupId: 'group-1',
         serviceName: 'chat',
         identitySecret: 'secret',
-        alias: 'my-ctx',
+        name: 'my-ctx',
       });
       expect(result.groupId).toBe('g-1');
       expect(result.groupCreated).toBe(true);
-      expect(mock.getRequestBody('POST', '/admin-api/contexts')).toEqual({
+      const body = mock.getRequestBody('POST', '/admin-api/contexts') as Record<string, unknown>;
+      expect(body).toEqual({
         applicationId: 'app-1',
         groupId: 'group-1',
         serviceName: 'chat',
         identitySecret: 'secret',
-        alias: 'my-ctx',
+        name: 'my-ctx',
       });
+      // Regression guard: core's CreateContextRequest has no `groupName`/`alias`
+      // field, so the human label must be sent as `name` or it is silently dropped.
+      expect(body).not.toHaveProperty('groupName');
+      expect(body).not.toHaveProperty('alias');
     });
 
     it('deleteContext unwraps data', async () => {
@@ -1041,17 +1046,25 @@ describe('AdminApiClient', () => {
     });
   });
 
-  describe('Group Nesting', () => {
-    it('nestGroup sends childGroupId', async () => {
-      mock.setMockResponse('POST', '/admin-api/groups/parent-1/nest', {});
-      await client.nestGroup('parent-1', { childGroupId: 'child-1' });
-      expect(mock.getRequestBody('POST', '/admin-api/groups/parent-1/nest')).toEqual({ childGroupId: 'child-1' });
+  describe('Group Reparent', () => {
+    // Core replaced the nest/unnest pair with a single atomic edge-swap:
+    // POST /admin-api/groups/:childGroupId/reparent  body { newParentId, requester? }
+    // (child is in the PATH, new parent is in the BODY) → { data: { reparented } }.
+    it('reparentGroup moves the child (path) under newParentId (body) and unwraps { reparented }', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/child-1/reparent', { data: { reparented: true } });
+      const result = await client.reparentGroup('child-1', { newParentId: 'parent-2' });
+      expect(result).toEqual({ reparented: true });
+      expect(mock.getRequestBody('POST', '/admin-api/groups/child-1/reparent')).toEqual({ newParentId: 'parent-2' });
     });
 
-    it('unnestGroup sends childGroupId', async () => {
-      mock.setMockResponse('POST', '/admin-api/groups/parent-1/unnest', {});
-      await client.unnestGroup('parent-1', { childGroupId: 'child-1' });
-      expect(mock.getRequestBody('POST', '/admin-api/groups/parent-1/unnest')).toEqual({ childGroupId: 'child-1' });
+    it('reparentGroup forwards an explicit requester', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/child-1/reparent', { data: { reparented: false } });
+      const result = await client.reparentGroup('child-1', { newParentId: 'parent-2', requester: 'pk-admin' });
+      expect(result.reparented).toBe(false);
+      expect(mock.getRequestBody('POST', '/admin-api/groups/child-1/reparent')).toEqual({
+        newParentId: 'parent-2',
+        requester: 'pk-admin',
+      });
     });
 
     it('listSubgroups reads the `subgroups` field (current server shape)', async () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -92,8 +92,8 @@ import type {
   CascadeStatusEntry,
   RetryGroupUpgradeRequest,
   RetryGroupUpgradeResponseData,
-  NestGroupRequest,
-  UnnestGroupRequest,
+  ReparentGroupRequest,
+  ReparentGroupResponseData,
   DetachContextFromGroupRequest,
   CreateGroupInvitationRequest,
   CreateGroupInvitationResponseData,
@@ -840,12 +840,21 @@ export class AdminApiClient {
     );
   }
 
-  async nestGroup(parentGroupId: string, request: NestGroupRequest): Promise<void> {
-    await this.httpClient.post(`/admin-api/groups/${parentGroupId}/nest`, request);
-  }
-
-  async unnestGroup(parentGroupId: string, request: UnnestGroupRequest): Promise<void> {
-    await this.httpClient.post(`/admin-api/groups/${parentGroupId}/unnest`, request);
+  /**
+   * Atomically move `childGroupId` (path) under `request.newParentId` (body).
+   * Replaces the removed `nestGroup`/`unnestGroup` pair — core exposes a single
+   * `POST /admin-api/groups/:group_id/reparent` edge-swap.
+   */
+  async reparentGroup(
+    childGroupId: string,
+    request: ReparentGroupRequest,
+  ): Promise<ReparentGroupResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: ReparentGroupResponseData }>(
+        `/admin-api/groups/${childGroupId}/reparent`,
+        request,
+      ),
+    );
   }
 
   async listSubgroups(groupId: string): Promise<SubgroupEntry[]> {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -840,11 +840,7 @@ export class AdminApiClient {
     );
   }
 
-  /**
-   * Atomically move `childGroupId` (path) under `request.newParentId` (body).
-   * Replaces the removed `nestGroup`/`unnestGroup` pair — core exposes a single
-   * `POST /admin-api/groups/:group_id/reparent` edge-swap.
-   */
+  /** Move `childGroupId` under `request.newParentId`. */
   async reparentGroup(
     childGroupId: string,
     request: ReparentGroupRequest,

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -121,11 +121,7 @@ export interface CreateContextRequest {
   contextSeed?: string;
   initializationParams?: number[];
   identitySecret?: string;
-  /**
-   * Optional human-readable label for the context. Core's `CreateContextRequest`
-   * field is `name` (camelCase wire key) — there is no `groupName`/`alias` field,
-   * so any other key is silently dropped by the node.
-   */
+  /** Optional human-readable label for the context. */
   name?: string;
 }
 
@@ -749,20 +745,13 @@ export type RetryGroupUpgradeResponseData = UpgradeGroupResponseData;
 
 // ---- Group Reparent & Context Attachments ----
 
-/**
- * Atomically move a group under a new parent. Replaces the old nest/unnest pair
- * (core `ReparentGroupApiRequest`): the child being moved is passed in the URL
- * path, and `newParentId` is the destination parent. Orphan state is structurally
- * impossible. `newParentId` must be a 64-char group id.
- */
 export interface ReparentGroupRequest {
+  /** 64-char id of the destination parent group. */
   newParentId: string;
-  /** Optional explicit requester; the authenticated identity takes precedence. */
   requester?: string;
 }
 
 export interface ReparentGroupResponseData {
-  /** False when the group was already under `newParentId` (the op was a no-op). */
   reparented: boolean;
 }
 

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -121,9 +121,12 @@ export interface CreateContextRequest {
   contextSeed?: string;
   initializationParams?: number[];
   identitySecret?: string;
-  // Renamed from `alias` in core (`context create --alias` -> `--group-name`)
-  // because `--name` was already the node-local alias flag.
-  groupName?: string;
+  /**
+   * Optional human-readable label for the context. Core's `CreateContextRequest`
+   * field is `name` (camelCase wire key) — there is no `groupName`/`alias` field,
+   * so any other key is silently dropped by the node.
+   */
+  name?: string;
 }
 
 export interface CreateContextResponseData {
@@ -744,23 +747,24 @@ export interface RetryGroupUpgradeRequest {
 // Retry returns same shape as upgrade
 export type RetryGroupUpgradeResponseData = UpgradeGroupResponseData;
 
-// ---- Group Nesting & Context Attachments ----
+// ---- Group Reparent & Context Attachments ----
 
-export interface NestGroupRequest {
-  childGroupId: string;
+/**
+ * Atomically move a group under a new parent. Replaces the old nest/unnest pair
+ * (core `ReparentGroupApiRequest`): the child being moved is passed in the URL
+ * path, and `newParentId` is the destination parent. Orphan state is structurally
+ * impossible. `newParentId` must be a 64-char group id.
+ */
+export interface ReparentGroupRequest {
+  newParentId: string;
+  /** Optional explicit requester; the authenticated identity takes precedence. */
   requester?: string;
 }
 
-// Returns empty
-export type NestGroupResponseData = Record<string, never>;
-
-export interface UnnestGroupRequest {
-  childGroupId: string;
-  requester?: string;
+export interface ReparentGroupResponseData {
+  /** False when the group was already under `newParentId` (the op was a no-op). */
+  reparented: boolean;
 }
-
-// Returns empty
-export type UnnestGroupResponseData = Record<string, never>;
 
 export interface DetachContextFromGroupRequest {
   requester?: string;


### PR DESCRIPTION
## Summary

Two confirmed `mero-js` ↔ core wire-contract drifts, verified against `crates/server` source (the SDK↔core audit notes were stale on both).

### 1. Group reparent — dead endpoints (runtime 404)
Core replaced the `nest`/`unnest` pair with a single atomic edge-swap:

```
POST /admin-api/groups/:group_id/reparent     body { newParentId, requester? }  →  { reparented }
```

The child being moved is in the **path**; the destination parent is in the **body**. The SDK's `nestGroup`/`unnestGroup` posted to `/groups/:id/nest` and `/groups/:id/unnest`, which **no longer exist in core (404)**.

- Removed `nestGroup` / `unnestGroup`, added `reparentGroup(childGroupId, { newParentId, requester? })` (unwraps `{ data: { reparented } }`).
- Swapped `NestGroupRequest`/`UnnestGroupRequest`/`...ResponseData` for `ReparentGroupRequest`/`ReparentGroupResponseData`.

### 2. `createContext` label — silently dropped field
Core's `CreateContextRequest` has **no** `groupName`/`alias` field — the optional human label is `name` (camelCase wire key). The SDK's `groupName` was forwarded verbatim and ignored by the node, so context labels never applied. Renamed the field to `name`.

> The 5 other `groupName` fields (namespace/group **invite & join** requests) are correct — core uses `group_name` there — and are left untouched.

## Tests
- 2 new `reparentGroup` tests (child in path / new parent in body / unwrap `{ reparented }` / explicit requester) — written first, watched fail (`reparentGroup is not a function`), then green.
- Updated `createContext` test to assert the `name` wire key + regression-guard against `groupName`/`alias`. (The old test passed `alias: 'my-ctx'`, a field that doesn't exist on the type — it compiled only because tests are excluded from `tsc`.)
- **219 tests pass**, typecheck + lint + build clean.

## ⚠ Breaking changes
- `AdminApiClient.nestGroup` / `unnestGroup` removed → use `reparentGroup`.
- `CreateContextRequest.groupName` renamed to `name`.

**Downstream:** `mero-react` exposes `useNestGroup`/`useUnnestGroup` hooks that need a corresponding `useReparentGroup` follow-up. Those hooks already 404 against current core, so nothing regresses at runtime — this only surfaces the mismatch at the type level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API (`nestGroup`/`unnestGroup` removal, `groupName` → `name`) affects group governance and context labeling; downstream hooks must migrate to `reparentGroup`.
> 
> **Overview**
> **Breaking admin SDK alignment** with the node’s current HTTP contract so callers stop hitting 404s and silently dropped fields.
> 
> **Group hierarchy:** `nestGroup` / `unnestGroup` are removed in favor of **`reparentGroup(childGroupId, { newParentId, requester? })`**, which posts to `POST /admin-api/groups/:childId/reparent` and unwraps `{ reparented }`. Types swap `NestGroupRequest` / `UnnestGroupRequest` for `ReparentGroupRequest` / `ReparentGroupResponseData`.
> 
> **Context creation:** `CreateContextRequest` now uses optional **`name`** (core’s camelCase label key) instead of `groupName`; invite/join `groupName` fields are unchanged.
> 
> Tests cover reparent path/body/response and assert create-context bodies send `name` and not `groupName`/`alias`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbfcbbe1f74f5cbd02ae095590dedbf83ab0ba66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->