### PR TITLE
test(auth): cover success:false payloads in revokeTokens/createRootKey

### DIFF
--- a/src/auth-api/auth-client.test.ts
+++ b/src/auth-api/auth-client.test.ts
@@ -98,6 +98,25 @@ describe('AuthApiClient', () => {
       expect(result).toEqual({ success: true, message: 'Tokens revoked successfully' });
       expect(mock.getRequestBody('POST', '/admin/revoke')).toEqual({ client_id: 'client-1' });
     });
+
+    it('returns a success:false payload rather than throwing', async () => {
+      mock.setMockResponse('POST', '/admin/revoke', {
+        data: { success: false, message: 'no active client tokens' },
+        error: null,
+      });
+      const result = await client.revokeTokens({ client_id: 'client-1' });
+      expect(result).toEqual({ success: false, message: 'no active client tokens' });
+    });
+
+    it('throws when the payload is absent (data: null error envelope)', async () => {
+      mock.setMockResponse('POST', '/admin/revoke', {
+        data: null,
+        error: { message: 'unauthorized' },
+      });
+      await expect(client.revokeTokens({ client_id: 'client-1' })).rejects.toThrow(
+        /response data is null/,
+      );
+    });
   });
 
   describe('createRootKey', () => {
@@ -117,6 +136,19 @@ describe('AuthApiClient', () => {
         auth_method: 'user_password',
         provider_data: {},
       });
+    });
+
+    it('returns a status:false payload rather than throwing', async () => {
+      mock.setMockResponse('POST', '/admin/keys', {
+        data: { status: false, message: 'key already exists' },
+        error: null,
+      });
+      const result = await client.createRootKey({
+        public_key: 'ed25519:pk',
+        auth_method: 'user_password',
+        provider_data: {},
+      });
+      expect(result).toEqual({ status: false, message: 'key already exists' });
     });
   });
 


### PR DESCRIPTION
## Summary

Test-only follow-up to #52. Adds the regression coverage that was written during #52's review but didn't make it into the merge.

A reviewer flagged that `if (!response.data)` in `revokeTokens`/`createRootKey` would discard a `{ success: false }` / `{ status: false }` response. It does not — `response.data` is the `RevokeTokenResponse`/`CreateKeyResponse` **object** (the boolean lives one level deeper), so a falsy business result is still a truthy object and is returned to the caller. The guard only trips on a genuinely-absent payload (`{ data: null }` error envelope).

## Tests (3 added, 226 → 229)
- `revokeTokens` returns a `success: false` payload (not thrown)
- `revokeTokens` throws on a `data: null` error envelope
- `createRootKey` returns a `status: false` payload (not thrown)

No production code change. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds **test-only** regression coverage in `auth-client.test.ts` for how `AuthApiClient` handles admin API envelopes on `revokeTokens` and `createRootKey`.
> 
> For **`revokeTokens`**, new cases assert that a `{ success: false, message }` body inside `data` is **returned to the caller** (not treated as a missing payload), and that **`data: null`** with an error envelope still **throws** with a `response data is null` message.
> 
> For **`createRootKey`**, a new case asserts that `{ status: false, message }` in `data` is likewise **returned** rather than thrown.
> 
> No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b299e0a95b45a9793395456857059e6ec49fb50b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->