### PR TITLE
docs(pr): wire-contract (core gate) PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- What changed and why. Link the issue if any. -->
+
+## Wire contract (core gate)
+
+mero-js types mirror core's HTTP wire DTOs by hand. If this PR touches admin/auth
+types or RPC shapes:
+
+- [ ] `npm run typecheck:contract` passes (run the wire contract test against a
+      core checkout: `CALIMERO_CORE_DIR=/path/to/core npm run test:contract`)
+- [ ] Linked the matching core PR if this mirrors a core wire change
+
+To run the contract test / e2e against a specific core branch, add a line to this
+body (defaults to `master`):
+
+```
+core-ref: <your-core-branch>
+```
+
+## Test plan
+
+- [ ] `npm run test:unit`
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run build`

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "lint:fix": "eslint . --fix",
     "eslint": "eslint .",
     "typecheck": "tsc --noEmit",
+    "typecheck:contract": "tsc --noEmit -p tsconfig.contract.json",
+    "test:contract": "vitest run --config vitest.config.ts src/__contract__",
     "tsc": "tsc -b",
     "prettier": "prettier --check \"src/**/*.{ts,js,json,md}\"",
     "prettier:fix": "prettier --write \"src/**/*.{ts,js,json,md}\"",

--- a/src/__contract__/wire.contract.test.ts
+++ b/src/__contract__/wire.contract.test.ts
@@ -1,0 +1,129 @@
+/**
+ * SDK ↔ core wire contract (the SDK-side half of the fixture canary).
+ *
+ * Loads core's committed wire fixtures (via CALIMERO_CORE_DIR) and checks each
+ * against the SDK type that mirrors it:
+ *   (a) every key core emits is one the SDK type declares (catches a core
+ *       rename/addition the hand-written type doesn't know — the #51 `groupName`
+ *       class of bug), and
+ *   (b) every key the SDK marks required is present in the core wire.
+ *
+ * The `key<T>()` helper makes each declared key a *compile-time* reference to the
+ * SDK type, so a renamed/removed field fails `typecheck:contract`. Skips when
+ * CALIMERO_CORE_DIR is unset, so it is a no-op in the plain unit run.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import type {
+  CreateContextRequest,
+  CreateContextResponseData,
+  ReparentGroupRequest,
+  ReparentGroupResponseData,
+} from '../admin-api/admin-types';
+import type { ExecuteParams } from '../rpc';
+
+const CORE_DIR = process.env.CALIMERO_CORE_DIR;
+const WIRE_DIR = CORE_DIR
+  ? join(CORE_DIR, 'crates/server/primitives/fixtures/wire')
+  : null;
+
+/** `key<T>()('x')` is a compile-time assertion that `x` is a field of `T`. */
+function key<T>() {
+  return (k: keyof T & string): string => k;
+}
+
+interface Spec {
+  type: string;
+  file: string;
+  /** SDK-required keys — must be present in core's wire. */
+  required: string[];
+  /** SDK-optional keys — allowed but not required. */
+  optional: string[];
+  /** Core-optional fields the SDK intentionally does not model (no drift). */
+  ignoredCoreKeys?: string[];
+}
+
+const ctxReq = key<CreateContextRequest>();
+const ctxRes = key<CreateContextResponseData>();
+const reReq = key<ReparentGroupRequest>();
+const reRes = key<ReparentGroupResponseData>();
+const exec = key<ExecuteParams>();
+
+const SPECS: Spec[] = [
+  {
+    type: 'CreateContextRequest',
+    file: 'contexts/create_context.req.json',
+    required: [ctxReq('applicationId'), ctxReq('groupId')],
+    optional: [
+      ctxReq('serviceName'),
+      ctxReq('contextSeed'),
+      ctxReq('initializationParams'),
+      ctxReq('identitySecret'),
+      ctxReq('name'),
+    ],
+  },
+  {
+    type: 'CreateContextResponseData',
+    file: 'contexts/create_context.res.json',
+    required: [ctxRes('contextId'), ctxRes('memberPublicKey')],
+    optional: [ctxRes('groupId'), ctxRes('groupCreated')],
+  },
+  {
+    type: 'ReparentGroupRequest',
+    file: 'groups/reparent.req.json',
+    required: [reReq('newParentId')],
+    optional: [reReq('requester')],
+  },
+  {
+    type: 'ReparentGroupResponseData',
+    file: 'groups/reparent.res.json',
+    required: [reRes('reparented')],
+    optional: [],
+  },
+  {
+    type: 'ExecuteParams',
+    file: 'jsonrpc/execute.req.json',
+    required: [exec('contextId'), exec('method')],
+    optional: [exec('argsJson'), exec('executorPublicKey')],
+    // core defaults these; the SDK does not send them.
+    ignoredCoreKeys: ['substitute'],
+  },
+];
+
+describe('wire contract (core fixtures ↔ SDK types)', () => {
+  if (!WIRE_DIR) {
+    it.skip('skipped: set CALIMERO_CORE_DIR to a core checkout to run', () => {});
+    return;
+  }
+
+  for (const spec of SPECS) {
+    it(`${spec.type} ↔ ${spec.file}`, () => {
+      const fixture = JSON.parse(
+        readFileSync(join(WIRE_DIR, spec.file), 'utf8'),
+      ) as Record<string, unknown>;
+      const fixtureKeys = Object.keys(fixture);
+      const known = new Set([
+        ...spec.required,
+        ...spec.optional,
+        ...(spec.ignoredCoreKeys ?? []),
+      ]);
+
+      // (a) the SDK type knows every field core emits.
+      for (const k of fixtureKeys) {
+        expect(
+          known.has(k),
+          `core wire key '${k}' is not declared by SDK type ${spec.type} (${spec.file})`,
+        ).toBe(true);
+      }
+      // (b) core's wire carries every field the SDK requires.
+      for (const r of spec.required) {
+        expect(
+          fixtureKeys.includes(r),
+          `SDK ${spec.type} requires '${r}' but core fixture ${spec.file} omits it`,
+        ).toBe(true);
+      }
+    });
+  }
+});

--- a/tests/e2e/auth-api.test.ts
+++ b/tests/e2e/auth-api.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MeroJs } from '@calimero-network/mero-js';
+import { startNode, resolveBaseUrl, type StartedNode } from './harness';
 
 // Test configuration
 const AUTH_CONFIG = {
-  baseUrl: process.env.AUTH_API_BASE_URL || 'http://localhost',
+  baseUrl: resolveBaseUrl(),
   credentials: {
     username: 'admin',
     password: 'admin123',
@@ -13,35 +14,12 @@ const AUTH_CONFIG = {
 
 describe('Auth API E2E Tests', () => {
   let meroJs: MeroJs;
+  let node: StartedNode;
 
   beforeAll(async () => {
-    console.log('🚀 Starting merobox environment...');
-
-    // Start merobox with auth service
-    const { spawn } = await import('child_process');
-
-    console.log('🔧 Starting Calimero node with auth service...');
-    const meroboxProcess = spawn('merobox', ['run', '--auth-service'], {
-      stdio: 'pipe',
-      cwd: process.cwd(),
-    });
-
-    // Add error handling for merobox process
-    meroboxProcess.on('error', (error) => {
-      console.error('❌ Merobox process error:', error);
-    });
-
-    meroboxProcess.stderr.on('data', (data) => {
-      console.error('❌ Merobox stderr:', data.toString());
-    });
-
-    meroboxProcess.stdout.on('data', (data) => {
-      console.log('📝 Merobox stdout:', data.toString());
-    });
-
-    // Wait for services to be ready
-    console.log('⏳ Waiting for services to start...');
-    await new Promise((resolve) => setTimeout(resolve, 60000)); // Wait 60 seconds
+    // Attaches to NODE_BASE_URL when set (core CI injects its merod), else spawns
+    // merobox/merod locally. See ./harness.
+    node = await startNode();
 
     console.log('🔧 Creating MeroJs SDK...');
     console.log('Auth API URL:', AUTH_CONFIG.baseUrl);
@@ -58,45 +36,12 @@ describe('Auth API E2E Tests', () => {
   }, 120000); // 2 minute timeout for beforeAll
 
   afterAll(async () => {
-    console.log('🧹 Cleaning up merobox environment...');
-
+    // No-op when attached to an injected node; tears down a locally-spawned one.
     try {
-      const { spawn } = await import('child_process');
-
-      console.log('🗑️ Running merobox nuke --force...');
-      const nukeProcess = spawn('merobox', ['nuke', '--force'], {
-        stdio: 'inherit',
-        cwd: process.cwd(),
-      });
-
-      // Wait for nuke to complete with timeout
-      await new Promise((resolve) => {
-        const timeout = setTimeout(() => {
-          console.warn('⚠️ Merobox cleanup timeout, killing process...');
-          nukeProcess.kill('SIGTERM');
-          resolve(void 0);
-        }, 90000); // 90 second timeout
-
-        nukeProcess.on('close', (code) => {
-          clearTimeout(timeout);
-          if (code === 0) {
-            console.log('✅ Merobox cleanup completed successfully');
-            resolve(void 0);
-          } else {
-            console.warn('⚠️ Merobox cleanup completed with code:', code);
-            resolve(void 0); // Don't fail the test for cleanup issues
-          }
-        });
-        nukeProcess.on('error', (error) => {
-          clearTimeout(timeout);
-          console.warn('⚠️ Merobox cleanup failed:', error);
-          resolve(void 0); // Don't fail the test for cleanup issues
-        });
-      });
+      await node?.stop();
     } catch (error) {
-      console.warn('⚠️ Merobox cleanup failed:', error);
+      console.warn('⚠️ node cleanup failed:', error);
     }
-
     console.log('🧹 Test cleanup completed');
   }, 120000); // 2 minute timeout for afterAll
 

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,0 +1,81 @@
+/**
+ * E2E node harness — resolves where the SDK should point and whether to boot a
+ * node itself. Lets the same e2e suite run two ways:
+ *
+ *   - locally: spawn merobox (the default), or
+ *   - in core CI: point at an already-running node via NODE_BASE_URL (and skip
+ *     spawning), so "core breaks first" — core's freshly-built merod drives the
+ *     same tests against its own wire.
+ *
+ * Env:
+ *   NODE_BASE_URL   if set, the suite uses this URL and does NOT spawn anything.
+ *   MEROD_BINARY    if set (and NODE_BASE_URL unset), spawn this merod binary.
+ *   AUTH_API_BASE_URL  legacy override for the auth base URL (default http://localhost).
+ */
+import type { ChildProcess } from 'child_process';
+
+export function resolveBaseUrl(): string {
+  return (
+    process.env.NODE_BASE_URL ||
+    process.env.AUTH_API_BASE_URL ||
+    'http://localhost'
+  );
+}
+
+/** True when an external node is already running and the suite must not spawn one. */
+export function usingInjectedNode(): boolean {
+  return Boolean(process.env.NODE_BASE_URL);
+}
+
+export interface StartedNode {
+  baseUrl: string;
+  /** Stop anything this harness started. No-op for an injected node. */
+  stop: () => Promise<void>;
+}
+
+/**
+ * Start (or attach to) a node for the e2e run. When NODE_BASE_URL is set, attaches
+ * without spawning; otherwise spawns merod (MEROD_BINARY) or merobox and waits.
+ */
+export async function startNode(opts?: { waitMs?: number }): Promise<StartedNode> {
+  const baseUrl = resolveBaseUrl();
+
+  if (usingInjectedNode()) {
+    return { baseUrl, stop: async () => {} };
+  }
+
+  const { spawn } = await import('child_process');
+  const merodBinary = process.env.MEROD_BINARY;
+
+  let child: ChildProcess;
+  let stop: () => Promise<void>;
+
+  if (merodBinary) {
+    child = spawn(merodBinary, ['run'], { stdio: 'pipe' });
+    stop = async () => {
+      child.kill('SIGTERM');
+    };
+  } else {
+    child = spawn('merobox', ['run', '--auth-service'], { stdio: 'pipe' });
+    stop = async () => {
+      const { spawn: spawn2 } = await import('child_process');
+      await new Promise<void>((resolve) => {
+        const nuke = spawn2('merobox', ['nuke', '--force'], { stdio: 'inherit' });
+        const t = setTimeout(() => {
+          nuke.kill();
+          resolve();
+        }, 30000);
+        nuke.on('exit', () => {
+          clearTimeout(t);
+          resolve();
+        });
+      });
+    };
+  }
+
+  child.on('error', (err) => console.error('node process error:', err));
+  child.stderr?.on('data', (d) => console.error('node stderr:', d.toString()));
+
+  await new Promise((resolve) => setTimeout(resolve, opts?.waitMs ?? 60000));
+  return { baseUrl, stop };
+}

--- a/tsconfig.contract.json
+++ b/tsconfig.contract.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.contract.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What this adds

A mero-js PR template with a **Wire contract (core gate)** section: prompts contributors to run `typecheck:contract` / the wire contract test against a core checkout and link the paired core PR when mirroring a wire change. Documents the `core-ref: <branch>` line for pointing the contract test / e2e at a paired core branch.

Mirror of the core-side template section (`sdk-ref:`).

## Why

mero-js types mirror core's wire by hand; the template makes "did you keep them in sync?" an explicit checklist step on every PR.

## Stacked
On #55 (the SDK contract test + injectable e2e harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)