### PR TITLE
docs(pr): wire-contract (core gate) PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!-- What changed and why. Link the issue if any. -->
+
+## Wire contract (core gate)
+
+mero-js types mirror core's HTTP wire DTOs by hand. If this PR touches admin/auth
+types or RPC shapes:
+
+- [ ] `npm run typecheck:contract` passes (run the wire contract test against a
+      core checkout: `CALIMERO_CORE_DIR=/path/to/core npm run test:contract`)
+- [ ] Linked the matching core PR if this mirrors a core wire change
+
+To run the contract test / e2e against a specific core branch, add a line to this
+body (defaults to `master`):
+
+```
+core-ref: <your-core-branch>
+```
+
+## Test plan
+
+- [ ] `npm run test:unit`
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run build`


### PR DESCRIPTION
Adds the mero-js PR template with a **Wire contract (core gate)** checklist (run `typecheck:contract` / the contract test against a core checkout, link the paired core PR) and the `core-ref:` convention.

Re-created off current `master` — supersedes the closed #56, which was stacked on the pre-#57 branch and would have regressed `master` if merged. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to PR authoring; no runtime or library behavior is modified.
> 
> **Overview**
> Introduces **`.github/pull_request_template.md`** so new PRs get a standard structure: description, a **Wire contract (core gate)** section, and a test plan.
> 
> The wire-contract block reminds authors that mero-js hand-mirrors core HTTP DTOs. When admin/auth types or RPC shapes change, they should run **`npm run typecheck:contract`** / **`CALIMERO_CORE_DIR=... npm run test:contract`**, link the paired core PR, and optionally set **`core-ref: <branch>`** in the PR body for contract/e2e against a non-`master` core branch. The test plan lists **`test:unit`**, **`typecheck`**, **`lint`**, and **`build`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5301d7c298020cae2cccd0ae01a6cf7e85999d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->