### PR TITLE
fix(sdk): wire fixes + method-aware e2e coverage (pairs core #2960)

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -443,10 +443,11 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({ blobs: [{ blobId: 'blob-1', size: 100 }] });
     });
 
-    it('getBlob maps snake_case blob_id to blobId', async () => {
-      mock.setMockResponse('GET', '/admin-api/blobs/blob-1', { data: { blob_id: 'blob-1', size: 100 } });
+    it('getBlob returns the raw blob bytes (not JSON)', async () => {
+      const bytes = new Uint8Array([1, 2, 3, 4]).buffer;
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1', bytes);
       const result = await client.getBlob('blob-1');
-      expect(result).toEqual({ blobId: 'blob-1', size: 100 });
+      expect(result).toBe(bytes);
     });
   });
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -35,7 +35,6 @@ import type {
   UploadBlobResponseData,
   DeleteBlobResponseData,
   ListBlobsResponseData,
-  GetBlobResponseData,
   CreateContextAliasRequest,
   CreateApplicationAliasRequest,
   CreateContextIdentityAliasRequest,
@@ -356,10 +355,13 @@ export class AdminApiClient {
     // Core's `ResyncContextApiResponse` is a flat payload (no inner `data`
     // field), so parse the body directly — do NOT `unwrap`, or `resyncStarted`
     // reads as undefined and the resync silently appears to never start.
-    return this.httpClient.post<ResyncContextResponseData>(
+    const r = await this.httpClient.post<ResyncContextResponseData | null>(
       `/admin-api/contexts/${contextId}/resync`,
       request,
     );
+    // An empty 2xx body means the resync was accepted; synthesize the result so
+    // callers always get a typed value instead of null.
+    return r ?? { contextId, resyncStarted: true };
   }
 
   async inviteSpecializedNode(request: InviteSpecializedNodeRequest): Promise<InviteSpecializedNodeResponseData> {
@@ -437,13 +439,15 @@ export class AdminApiClient {
     return { blobs: res.blobs.map((b) => ({ blobId: b.blob_id, size: b.size })) };
   }
 
-  async getBlob(blobId: string): Promise<GetBlobResponseData> {
-    const res = unwrap(
-      await this.httpClient.get<{ data: { blob_id: string; size: number } }>(
-        `/admin-api/blobs/${blobId}`,
-      ),
-    );
-    return { blobId: res.blob_id, size: res.size };
+  /**
+   * Download a blob's raw bytes. `GET /admin-api/blobs/:id` streams the blob
+   * content (e.g. `application/gzip`), NOT JSON — so fetch it as an ArrayBuffer.
+   * Use {@link listBlobs} for `{ blobId, size }` metadata.
+   */
+  async getBlob(blobId: string): Promise<ArrayBuffer> {
+    return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}`, {
+      parse: 'arrayBuffer',
+    });
   }
 
   // ---- Alias Management ----

--- a/src/events/ws.test.ts
+++ b/src/events/ws.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WsClient } from './ws';
+
+describe('WsClient', () => {
+  let client: WsClient;
+
+  beforeEach(() => {
+    client = new WsClient({
+      baseUrl: 'http://localhost:4001',
+      getAuthToken: async () => 'test-token',
+    });
+  });
+
+  afterEach(() => {
+    client.close();
+  });
+
+  describe('handleMessage', () => {
+    // Core serializes context events with `type` as a SIBLING of `data` (the
+    // tag is flattened): `result: { contextId, type, data }`. Drive the tests
+    // through handleMessage with that real wire shape, matching SseClient.
+    it('forwards the event type tag from msg.result.type', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          contextId: 'ctx-1',
+          type: 'AppVersionChanged',
+          data: { fromVersion: '1.0.0', toVersion: '2.0.0' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        contextId: 'ctx-1',
+        type: 'AppVersionChanged',
+        data: { fromVersion: '1.0.0', toVersion: '2.0.0' },
+      });
+    });
+
+    it('emits event on context event message (type undefined when absent)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          contextId: 'ctx-1',
+          data: { action: 'updated' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        contextId: 'ctx-1',
+        type: undefined,
+        data: { action: 'updated' },
+      });
+    });
+
+    it('decodes byte-array data while still forwarding type', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      const encoded = Array.from(new TextEncoder().encode('{"name":"test"}'));
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          contextId: 'ctx-1',
+          type: 'StateMutation',
+          data: encoded,
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        contextId: 'ctx-1',
+        type: 'StateMutation',
+        data: { name: 'test' },
+      });
+    });
+  });
+});

--- a/src/events/ws.ts
+++ b/src/events/ws.ts
@@ -1,5 +1,8 @@
 export interface WsEventData {
   contextId: string;
+  /** The context-event discriminator (core serializes it as a sibling of
+   * `data`, e.g. `"AppVersionChanged"`). Undefined for events without a tag. */
+  type?: string;
   data: unknown;
 }
 
@@ -148,6 +151,9 @@ export class WsClient {
 
         this.emit('event', {
           contextId: msg.result.contextId,
+          // Forward the event tag (sibling of `data` in core's flattened
+          // payload) so consumers can discriminate, matching `SseClient`.
+          type: msg.result.type,
           data: eventData,
         });
       }


### PR DESCRIPTION
SDK wire-correctness fixes **plus** the mero-js side of method-aware route coverage. Pairs with **core #2960** (`sdk-ref` points here).

## SDK fixes
- **WsClient event-`type` parity** — forwards the context-event `type` discriminator, matching `SseClient`. +`ws.test.ts`.
- **`getBlob` returns raw bytes** — `GET /admin-api/blobs/:id` streams the blob (`application/gzip`, confirmed live), not JSON. Now fetched as `ArrayBuffer` (the old JSON-unwrap threw on any real blob). Use `listBlobs()` for metadata. **Breaking** (the old signature never worked).
- **`resyncContext` empty 2xx** — yields `{ contextId, resyncStarted: true }` instead of `null`.
- **`getTeeAdmissionPolicy` added** — the GET was missing; only the PUT setter existed (surfaced by method-aware coverage).

## Method-aware coverage
- **Recorder** now records `METHOD /path` (was path-only), so a broken verb can't hide behind another verb on the same route — exactly the gap that let the `getBlob` bug ship green (`GET` vs `DELETE /blobs/:id`).
- **Sweep** exercises the 7 verb-level gaps this surfaced: blob list/get/delete (re-adds `getBlob`), the metadata getters, `setMemberCapabilities`, `updateGroupSettings`, `getTeeAdmissionPolicy`, `uninstallApplication`, and no-arg `syncContext`.

## Verification
232 unit pass; typecheck/lint/build clean. Against a live node: **99 e2e pass → 87/87 method-routes exercised, 0 baselined**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)