### PR TITLE
test(e2e): method-aware coverage recorder + getTeeAdmissionPolicy (pairs core #2960)

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,22 @@ const ctx = await admin.createContext({
 });
 ```
 
+### Blobs
+```typescript
+const { blobs } = await admin.listBlobs();        // [{ blobId, size }, ...] metadata
+const bytes = await admin.getBlob(blobId);        // ArrayBuffer — the raw blob content
+await admin.deleteBlob(blobId);
+```
+> `getBlob` returns the **raw bytes** as an `ArrayBuffer` (the endpoint streams the
+> blob, e.g. `application/gzip`, not JSON). Use `listBlobs()` for `{ blobId, size }`
+> metadata.
+
+### Group settings (TEE admission policy)
+```typescript
+await admin.setTeeAdmissionPolicy(groupId, policy);
+const current = await admin.getTeeAdmissionPolicy(groupId); // allowed MRTD/RTMR sets, acceptMock, ...
+```
+
 ### Cloud (TEE High Availability)
 ```typescript
 import { CloudClient } from '@calimero-network/mero-js';
@@ -470,12 +486,31 @@ pnpm install
 # Build
 pnpm build
 
-# Test
+# Test (unit)
 pnpm test
 
 # Lint
 pnpm lint
 ```
+
+### Testing & the contract gate
+
+The SDK mirrors core's HTTP wire types by hand, so two layers guard against drift:
+
+- **Unit tests** (`pnpm test`) — mocked, fast, cover the client logic.
+- **E2E** (`pnpm test:e2e`) — runs the real SDK against a live `merod`. Point it at a
+  node and provide credentials:
+  ```bash
+  NODE_URL=http://localhost:2528 MERO_E2E_USER=dev MERO_E2E_PASS=dev pnpm test:e2e
+  ```
+  In CI this runs both against a released `merod` (this repo) and against a
+  PR-built `merod` (core's `sdk-e2e`).
+
+The e2e records every request as `METHOD /path` (see `tests/e2e/coverage-recorder.ts`).
+Core's route-coverage gate is **method-aware**: it fails if any admin route *or verb*
+ships without an SDK test — so e.g. `GET /blobs/:id` can't hide behind `DELETE /blobs/:id`.
+When you add an SDK method for a new endpoint, exercise it in the e2e (the sweep in
+`tests/e2e/coverage-sweep.test.ts` is the catch-all) so coverage stays complete.
 
 ## License
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -755,14 +755,12 @@ export class AdminApiClient {
   }
 
   async getTeeAdmissionPolicy(groupId: string): Promise<GetTeeAdmissionPolicyResponseData> {
+    // Intersection (not union) so the type is unambiguous: `data` is optional, so
+    // `?? response` cleanly falls back to a flat (un-enveloped) response.
     const response = await this.httpClient.get<
-      { data: GetTeeAdmissionPolicyResponseData } | GetTeeAdmissionPolicyResponseData
+      GetTeeAdmissionPolicyResponseData & { data?: GetTeeAdmissionPolicyResponseData }
     >(`/admin-api/groups/${groupId}/settings/tee-admission-policy`);
-    // Tolerate flat or {data}-enveloped responses.
-    return (
-      (response as { data?: GetTeeAdmissionPolicyResponseData })?.data ??
-      (response as GetTeeAdmissionPolicyResponseData)
-    );
+    return response.data ?? response;
   }
 
   async updateGroupSettings(

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -74,6 +74,7 @@ import type {
   SetDefaultCapabilitiesRequest,
   SetSubgroupVisibilityRequest,
   SetTeeAdmissionPolicyRequest,
+  GetTeeAdmissionPolicyResponseData,
   UpdateGroupSettingsRequest,
   SetGroupMetadataRequest,
   SetMemberMetadataRequest,
@@ -751,6 +752,17 @@ export class AdminApiClient {
     request: SetTeeAdmissionPolicyRequest,
   ): Promise<void> {
     await this.httpClient.put(`/admin-api/groups/${groupId}/settings/tee-admission-policy`, request);
+  }
+
+  async getTeeAdmissionPolicy(groupId: string): Promise<GetTeeAdmissionPolicyResponseData> {
+    const response = await this.httpClient.get<
+      { data: GetTeeAdmissionPolicyResponseData } | GetTeeAdmissionPolicyResponseData
+    >(`/admin-api/groups/${groupId}/settings/tee-admission-policy`);
+    // Tolerate flat or {data}-enveloped responses.
+    return (
+      (response as { data?: GetTeeAdmissionPolicyResponseData })?.data ??
+      (response as GetTeeAdmissionPolicyResponseData)
+    );
   }
 
   async updateGroupSettings(

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -643,6 +643,16 @@ export interface SetTeeAdmissionPolicyRequest {
 // Returns empty
 export type SetTeeAdmissionPolicyResponseData = Record<string, never>;
 
+export interface GetTeeAdmissionPolicyResponseData {
+  allowedMrtd: string[];
+  allowedRtmr0: string[];
+  allowedRtmr1: string[];
+  allowedRtmr2: string[];
+  allowedRtmr3: string[];
+  allowedTcbStatuses: string[];
+  acceptMock: boolean;
+}
+
 export interface UpdateGroupSettingsRequest {
   upgradePolicy: string;
   requester?: string;

--- a/tests/e2e/coverage-recorder.ts
+++ b/tests/e2e/coverage-recorder.ts
@@ -1,10 +1,12 @@
 /**
  * E2E endpoint-coverage recorder (test infra, node-only — never bundled).
  *
- * When MERO_COVERAGE_OUT is set, wraps global fetch to record the pathname of
+ * When MERO_COVERAGE_OUT is set, wraps global fetch to record "METHOD /path" for
  * every request the SDK issues during the e2e run, and writes the deduped set to
  * that file as a JSON array. Core's `check-endpoint-coverage.sh` then diffs it
- * against the route manifest to flag endpoints with no SDK e2e coverage.
+ * against the route manifest to flag endpoints with no SDK e2e coverage. Recording
+ * the method (not just the path) means a broken verb can't hide behind another
+ * verb on the same route (e.g. GET vs DELETE /admin-api/blobs/:id).
  *
  * Loaded as a vitest setupFile (see vitest.e2e.config.ts). No-op when the env var
  * is unset, so normal runs are unaffected. Requires a single test process
@@ -16,17 +18,18 @@ const OUT = process.env.MERO_COVERAGE_OUT;
 const seen = new Set<string>();
 let installed = false;
 
-/** Extract the pathname from any fetch input and record it. */
-export function recordUrl(raw: string): void {
+/** Record a request as "METHOD /pathname" (method upper-cased, defaults to GET). */
+export function recordRequest(method: string, raw: string): void {
   try {
     // Base covers relative URLs; absolute URLs ignore the base.
-    seen.add(new URL(raw, 'http://localhost').pathname);
+    const { pathname } = new URL(raw, 'http://localhost');
+    seen.add(`${(method || 'GET').toUpperCase()} ${pathname}`);
   } catch {
     /* ignore unparseable inputs */
   }
 }
 
-/** Current recorded pathnames (sorted) — exposed for assertions/inspection. */
+/** Current recorded "METHOD /path" entries (sorted) — exposed for inspection. */
 export function recordedPaths(): string[] {
   return [...seen].sort();
 }
@@ -45,6 +48,15 @@ function inputToUrl(input: unknown): string {
   return String(input);
 }
 
+/** Resolve the HTTP method from the fetch args (init wins, then a Request input). */
+function inputToMethod(input: unknown, init?: Parameters<typeof fetch>[1]): string {
+  if (init?.method) return init.method;
+  if (input && typeof input === 'object' && 'method' in input) {
+    return String((input as { method: unknown }).method);
+  }
+  return 'GET';
+}
+
 export function installFetchRecorder(): void {
   if (installed || !OUT) return;
   installed = true;
@@ -52,7 +64,7 @@ export function installFetchRecorder(): void {
   globalThis.fetch = (async (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
     // Recording must never break a request — swallow any record/flush error.
     try {
-      recordUrl(inputToUrl(input));
+      recordRequest(inputToMethod(input, init), inputToUrl(input));
       flush();
     } catch {
       /* ignore — coverage recording is best-effort */

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -64,6 +64,22 @@ describe('Admin API E2E — Route coverage sweep', () => {
     await cover('usage', () => mero.admin.getUsage());
     await cover('certificate', () => mero.admin.getCertificate());
     await cover('resync', () => mero.admin.resyncContext(contextId, { force: true }));
+    await cover('syncOne', () => mero.admin.syncContext(contextId));
+    await cover('syncAll', () => mero.admin.syncContext()); // no-arg → POST /contexts/sync
+    expect(true).toBe(true);
+  });
+
+  it('blob ops: list, get raw bytes, delete', async () => {
+    // 32-zero-byte bs58 id: valid shape, won't exist — DELETE fires safely (no
+    // real blob removed); GET uses a real blob if one exists (read-only).
+    const dummyBlob = '1'.repeat(32);
+    let realBlob = dummyBlob;
+    await cover('listBlobs', async () => {
+      const list = (await mero.admin.listBlobs()) as { blobs?: Array<{ blobId: string }> };
+      if (list?.blobs?.length) realBlob = list.blobs[0].blobId;
+    });
+    await cover('getBlob', () => mero.admin.getBlob(realBlob));
+    await cover('deleteBlob', () => mero.admin.deleteBlob(dummyBlob));
     expect(true).toBe(true);
   });
 
@@ -101,6 +117,8 @@ describe('Admin API E2E — Route coverage sweep', () => {
 
   it('group/context settings + proofs + standalone group', async () => {
     await cover('teePolicy', () => mero.admin.setTeeAdmissionPolicy(groupId, { policy: 'open' } as never));
+    await cover('getTeePolicy', () => mero.admin.getTeeAdmissionPolicy(groupId));
+    await cover('updateGroupSettings', () => mero.admin.updateGroupSettings(groupId, {} as never));
     await cover('signingKey', () => mero.admin.registerGroupSigningKey(groupId, {} as never));
     await cover('ctxMeta', () => mero.admin.setContextMetadata(groupId, contextId, { data: {} } as never));
     await cover('updateApp', () =>
@@ -109,6 +127,18 @@ describe('Admin API E2E — Route coverage sweep', () => {
     await cover('ownProof', () => mero.admin.issueOwnershipProof(groupId, { requester: executor }));
     await cover('nsOwnProof', () => mero.admin.issueNamespaceOwnershipProof(groupId, { requester: executor }));
     await cover('createGroup', () => mero.admin.createGroup({ name: `sweep-grp-${RUN}` }));
+    expect(true).toBe(true);
+  });
+
+  it('metadata getters + member capabilities + app uninstall', async () => {
+    await cover('getGroupMeta', () => mero.admin.getGroupMetadata(groupId));
+    await cover('getMemberMeta', () => mero.admin.getMemberMetadata(groupId, executor));
+    await cover('getCtxMeta', () => mero.admin.getContextMetadata(groupId, contextId));
+    await cover('setMemberCaps', () =>
+      mero.admin.setMemberCapabilities(groupId, memberPk, { capabilities: [] } as never),
+    );
+    // Uninstall a non-existent app — fires DELETE /applications/:id safely.
+    await cover('uninstallApp', () => mero.admin.uninstallApplication('1'.repeat(32)));
     expect(true).toBe(true);
   });
 


### PR DESCRIPTION
The mero-js side of **method-aware** route coverage. Pairs with **core #2960**.

## Why
Path-level coverage let the `getBlob` bug ship green: `/admin-api/blobs/:id` read as "covered" via `DELETE`, hiding that the `GET` verb was never exercised. Recording the **method** closes that whole class.

## Changes
- **`coverage-recorder`** — records `METHOD /path` (was path-only).
- **`coverage-sweep`** — exercises the 7 verb-level gaps the method-aware core check surfaced: blob list/get/delete (re-adds `getBlob`, now that it returns bytes on master), the three metadata getters, `setMemberCapabilities`, `updateGroupSettings`, `getTeeAdmissionPolicy`, `uninstallApplication`, and no-arg `syncContext` (`POST /contexts/sync`).
- **`getTeeAdmissionPolicy`** added to the admin client — the GET was missing (only the PUT setter existed).

## Verification
232 unit pass; typecheck clean. Against a live node with core #2960's check: **87/87 method-routes exercised, 0 baselined**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)