### PR TITLE
feat(sdk): add getBlobInfo (HEAD /blobs/:id)

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ const ctx = await admin.createContext({
 ### Blobs
 ```typescript
 const { blobs } = await admin.listBlobs();        // [{ blobId, size }, ...] metadata
+const info = await admin.getBlobInfo(blobId);     // { blobId, size, hash, mimeType } via HEAD (no download)
 const bytes = await admin.getBlob(blobId);        // ArrayBuffer — the raw blob content
 await admin.deleteBlob(blobId);
 ```

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -458,10 +458,14 @@ export class AdminApiClient {
    * `x-blob-id`/`x-blob-hash`/`x-blob-mime-type`).
    */
   async getBlobInfo(blobId: string): Promise<GetBlobInfoResponseData> {
+    // HEAD throws (HttpError) on a non-2xx status, so we only reach here on success
+    // — the x-blob-* headers are present. Guard size against a missing/non-numeric
+    // content-length anyway (defaults to 0 rather than NaN).
     const { headers } = await this.httpClient.head(`/admin-api/blobs/${blobId}`);
+    const size = Number(headers['content-length']);
     return {
       blobId: headers['x-blob-id'] ?? blobId,
-      size: Number(headers['content-length'] ?? 0),
+      size: Number.isFinite(size) ? size : 0,
       hash: headers['x-blob-hash'],
       mimeType: headers['x-blob-mime-type'],
     };

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -35,6 +35,7 @@ import type {
   UploadBlobResponseData,
   DeleteBlobResponseData,
   ListBlobsResponseData,
+  GetBlobInfoResponseData,
   CreateContextAliasRequest,
   CreateApplicationAliasRequest,
   CreateContextIdentityAliasRequest,
@@ -449,6 +450,21 @@ export class AdminApiClient {
     return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}`, {
       parse: 'arrayBuffer',
     });
+  }
+
+  /**
+   * Fetch a blob's metadata without downloading it. `HEAD /admin-api/blobs/:id`
+   * returns the info in response headers (size via `content-length`, plus
+   * `x-blob-id`/`x-blob-hash`/`x-blob-mime-type`).
+   */
+  async getBlobInfo(blobId: string): Promise<GetBlobInfoResponseData> {
+    const { headers } = await this.httpClient.head(`/admin-api/blobs/${blobId}`);
+    return {
+      blobId: headers['x-blob-id'] ?? blobId,
+      size: Number(headers['content-length'] ?? 0),
+      hash: headers['x-blob-hash'],
+      mimeType: headers['x-blob-mime-type'],
+    };
   }
 
   // ---- Alias Management ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -273,6 +273,13 @@ export interface ListBlobsResponseData {
 
 export type GetBlobResponseData = BlobInfo;
 
+export interface GetBlobInfoResponseData {
+  blobId: string;
+  size: number;
+  hash?: string;
+  mimeType?: string;
+}
+
 // ---- Aliases ----
 
 // Core's CreateAliasRequest is `{ alias, #[serde(flatten)] value }`, so each

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -273,9 +273,7 @@ export interface ListBlobsResponseData {
 
 export type GetBlobResponseData = BlobInfo;
 
-export interface GetBlobInfoResponseData {
-  blobId: string;
-  size: number;
+export interface GetBlobInfoResponseData extends BlobInfo {
   hash?: string;
   mimeType?: string;
 }

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -79,6 +79,7 @@ describe('Admin API E2E — Route coverage sweep', () => {
       if (list?.blobs?.length) realBlob = list.blobs[0].blobId;
     });
     await cover('getBlob', () => mero.admin.getBlob(realBlob));
+    await cover('getBlobInfo', () => mero.admin.getBlobInfo(realBlob)); // HEAD /blobs/:id
     await cover('deleteBlob', () => mero.admin.deleteBlob(dummyBlob));
     expect(true).toBe(true);
   });


### PR DESCRIPTION
Adds `getBlobInfo(blobId)` — fetches blob metadata via `HEAD /admin-api/blobs/:id` (no download), mapping `content-length` + `x-blob-id`/`x-blob-hash`/`x-blob-mime-type` headers to `{ blobId, size, hash, mimeType }`.

## Why
Core registers `.head(blob::info_handler)` on `/blobs/:blob_id`, but the SDK had **no binding** for it — surfaced by the method-aware coverage gate (the `HEAD` verb was a real, untested route). Closes that gap.

- New `getBlobInfo` + `GetBlobInfoResponseData` type.
- Exercised in the e2e sweep; documented in the README Blobs section.
- 232 unit pass; typecheck/lint clean.

Pairs with **core #2960**, which adds `HEAD` to the method-aware route manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)