### PR TITLE
fix!: metadata getters return the full MetadataRecord

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -837,19 +837,12 @@ describe('AdminApiClient', () => {
     });
 
     it('getGroupMetadata returns the inner MetadataRecord', async () => {
-      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: { data: record } });
+      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: record });
       expect(await client.getGroupMetadata('g1')).toEqual(record);
     });
 
+    // No metadata row: core returns a single-enveloped null (`{ data: null }`).
     it('getGroupMetadata returns null when no metadata has been set', async () => {
-      mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: { data: null } });
-      expect(await client.getGroupMetadata('g1')).toBeNull();
-    });
-
-    // Server omits the inner envelope entirely (`{ data: null }`) when no
-    // metadata row exists — the unwrapped payload is then null, so reading
-    // `.data` off it used to throw "Cannot read properties of null".
-    it('getGroupMetadata returns null (not throws) when the payload itself is null', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g1/metadata', { data: null });
       expect(await client.getGroupMetadata('g1')).toBeNull();
     });
@@ -867,7 +860,7 @@ describe('AdminApiClient', () => {
     });
 
     it('getMemberMetadata returns the inner MetadataRecord', async () => {
-      mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', { data: { data: record } });
+      mock.setMockResponse('GET', '/admin-api/groups/g1/members/pk-1/metadata', { data: record });
       expect(await client.getMemberMetadata('g1', 'pk-1')).toEqual(record);
     });
 
@@ -892,7 +885,7 @@ describe('AdminApiClient', () => {
     });
 
     it('getContextMetadata returns the inner MetadataRecord', async () => {
-      mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: { data: record } });
+      mock.setMockResponse('GET', '/admin-api/groups/g1/contexts/ctx-1/metadata', { data: record });
       expect(await client.getContextMetadata('g1', 'ctx-1')).toEqual(record);
     });
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -797,14 +797,14 @@ export class AdminApiClient {
   }
 
   async getGroupMetadata(groupId: string): Promise<MetadataRecord | null> {
-    // The "no record yet" wire shape varies across server versions:
-    // `{data:{data:null}}`, `{data:null}`, and a bare `null` body have all
-    // been observed. Optional-chain the whole path so every flavour collapses
-    // to a clean `null`.
-    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+    // Core single-envelopes the record: `{ data: MetadataRecord | null }`.
+    // "No record yet" is `{ data: null }` (or a bare null body on older nodes),
+    // so optional-chain to a clean null. Returns the full record (name + data +
+    // updatedAt/updatedBy), not just the data map.
+    const response = await this.httpClient.get<GetMetadataResponseData | null>(
       `/admin-api/groups/${groupId}/metadata`,
     );
-    return response?.data?.data ?? null;
+    return response?.data ?? null;
   }
 
   async setMemberMetadata(
@@ -816,11 +816,11 @@ export class AdminApiClient {
   }
 
   async getMemberMetadata(groupId: string, identity: string): Promise<MetadataRecord | null> {
-    // Tolerates every observed "no record yet" shape (see getGroupMetadata).
-    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+    // Single-enveloped record; see getGroupMetadata.
+    const response = await this.httpClient.get<GetMetadataResponseData | null>(
       `/admin-api/groups/${groupId}/members/${identity}/metadata`,
     );
-    return response?.data?.data ?? null;
+    return response?.data ?? null;
   }
 
   async setContextMetadata(
@@ -832,11 +832,11 @@ export class AdminApiClient {
   }
 
   async getContextMetadata(groupId: string, contextId: string): Promise<MetadataRecord | null> {
-    // Tolerates every observed "no record yet" shape (see getGroupMetadata).
-    const response = await this.httpClient.get<{ data: GetMetadataResponseData | null } | null>(
+    // Single-enveloped record; see getGroupMetadata.
+    const response = await this.httpClient.get<GetMetadataResponseData | null>(
       `/admin-api/groups/${groupId}/contexts/${contextId}/metadata`,
     );
-    return response?.data?.data ?? null;
+    return response?.data ?? null;
   }
 
   async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -86,14 +86,16 @@ describe('Round-trip E2E — Metadata set→get', () => {
     const value = { team: `rt-${RUN}`, role: 'lead' };
     await mero.admin.setGroupMetadata(groupId, { data: value } as never);
     const got = await mero.admin.getGroupMetadata(groupId);
-    expect(got).toMatchObject(value);
+    // Returns the full MetadataRecord: the map lives under `.data`.
+    expect(got?.data).toMatchObject(value);
+    expect(got).toHaveProperty('updatedBy');
   });
 
   it('context metadata: set then get returns the same value', async () => {
     const value = { ctx: `rt-${RUN}` };
     await mero.admin.setContextMetadata(groupId, contextId, { data: value } as never);
     const got = await mero.admin.getContextMetadata(groupId, contextId);
-    expect(got).toMatchObject(value);
+    expect(got?.data).toMatchObject(value);
   });
 });
 
@@ -123,7 +125,7 @@ describe('Round-trip E2E — Member lifecycle [Tier 2]', () => {
 
     await mero.admin.setMemberMetadata(groupId, memberPk, { data: { tag: `rt-${RUN}` } } as never);
     const meta = await mero.admin.getMemberMetadata(groupId, memberPk);
-    expect(meta).toMatchObject({ tag: `rt-${RUN}` });
+    expect(meta?.data).toMatchObject({ tag: `rt-${RUN}` });
 
     await mero.admin.removeGroupMembers(groupId, { members: [memberPk] } as never);
     const post = (await mero.admin.listGroupMembers(groupId)) as {


### PR DESCRIPTION
The three metadata getters are typed `MetadataRecord | null` but did `response.data.data`. Core single-envelopes the record (`{ data: MetadataRecord }`), so they reached one level too deep and returned the bare data map — silently dropping `name`, `updatedAt`, and `updatedBy`. Surfaced by mero-react integration tests (`useGroupMetadata` got the map, not the record) and confirmed against the raw wire:

```
{"data":{"name":"e2e","data":{"marker":"x1"},"updatedAt":...,"updatedBy":"..."}}
```

## Fix
- `getGroupMetadata` / `getMemberMetadata` / `getContextMetadata`: unwrap once (`response?.data ?? null`) and type the response as the existing `GetMetadataResponseData` (`{ data: MetadataRecord | null }`).
- Unit mocks had encoded a fictional double-envelope (`{ data: { data: record } }`) — corrected to the real single-envelope shape; dropped the now-redundant fictional "no record" case.
- e2e round-trips now assert the record (`got.data` matches the set map; `updatedBy` present).

## ⚠️ Breaking
The getters now resolve to the full `MetadataRecord` (`{ name, data, updatedAt, updatedBy }`) instead of the bare data map. Read values under `.data`.

## Verification
typecheck · lint · unit (231) · build · 3 metadata e2e round-trips against a live merod (0.11.0-rc.8) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
