### PR TITLE
auth(v8): harden token refresh for server-side rotation and single-use refresh

### DIFF
--- a/src/http-client/auth-errors.test.ts
+++ b/src/http-client/auth-errors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AUTH_ERROR_HEADER,
+  AUTH_ERROR_TOKEN_EXPIRED,
+  AUTH_ERROR_TOKEN_REUSE,
+  isRefreshReuseError,
+} from './auth-errors';
+import { HTTPError } from './web-client';
+
+function httpError(status: number, authError?: string): HTTPError {
+  const headers = new Headers();
+  if (authError) headers.set(AUTH_ERROR_HEADER, authError);
+  return new HTTPError(status, 'err', 'https://node/auth/refresh', headers, '');
+}
+
+describe('auth-error wire constants', () => {
+  it('pins the contract values', () => {
+    expect(AUTH_ERROR_HEADER).toBe('x-auth-error');
+    expect(AUTH_ERROR_TOKEN_EXPIRED).toBe('token_expired');
+    expect(AUTH_ERROR_TOKEN_REUSE).toBe('token_reuse');
+  });
+});
+
+describe('isRefreshReuseError', () => {
+  it('is true for a 401 with x-auth-error: token_reuse', () => {
+    expect(isRefreshReuseError(httpError(401, AUTH_ERROR_TOKEN_REUSE))).toBe(true);
+  });
+
+  it('is true for any 403 from the refresh endpoint', () => {
+    expect(isRefreshReuseError(httpError(403))).toBe(true);
+    expect(isRefreshReuseError(httpError(403, 'whatever'))).toBe(true);
+  });
+
+  it('is false for a 401 token_expired (transient/refreshable)', () => {
+    expect(isRefreshReuseError(httpError(401, AUTH_ERROR_TOKEN_EXPIRED))).toBe(false);
+  });
+
+  it('is false for a bare 401 and for network/other errors', () => {
+    expect(isRefreshReuseError(httpError(401))).toBe(false);
+    expect(isRefreshReuseError(httpError(0))).toBe(false); // network error
+    expect(isRefreshReuseError(new Error('boom'))).toBe(false);
+    expect(isRefreshReuseError(undefined)).toBe(false);
+    expect(isRefreshReuseError('nope')).toBe(false);
+  });
+
+  it('duck-types a plain object shaped like HTTPError', () => {
+    expect(
+      isRefreshReuseError({ status: 401, headers: new Headers([[AUTH_ERROR_HEADER, 'token_reuse']]) }),
+    ).toBe(true);
+  });
+});

--- a/src/http-client/auth-errors.ts
+++ b/src/http-client/auth-errors.ts
@@ -1,0 +1,49 @@
+// Auth error wire contract (core ↔ mero-js).
+//
+// SINGLE SOURCE OF TRUTH for the auth failure signals the SDK keys off, so the
+// values track the server in one place. Core sets these on the `x-auth-error`
+// response header.
+
+/** Response header core uses to disambiguate auth failures. Always lowercase. */
+export const AUTH_ERROR_HEADER = 'x-auth-error';
+
+/**
+ * Access token expired. RECOVERABLE: a refresh is expected to mint a new pair,
+ * so the reactive layer refreshes once and retries the original request.
+ */
+export const AUTH_ERROR_TOKEN_EXPIRED = 'token_expired';
+
+/**
+ * Refresh-token reuse detected: a consumed/rotated refresh token was replayed.
+ * Core denylists the `jti` and revokes the entire token family (see core PR3).
+ *
+ * TERMINAL. The client MUST clear its tokens and force re-authentication, and
+ * MUST NOT retry — retrying replays the consumed token and widens the blast
+ * radius of the family revocation.
+ *
+ * Wire contract (core PR2/PR3): the refresh endpoint signals reuse as either a
+ * `401` carrying this `x-auth-error` value, or a `403`. Both are treated as
+ * terminal by {@link isRefreshReuseError}.
+ */
+export const AUTH_ERROR_TOKEN_REUSE = 'token_reuse';
+
+/**
+ * Classify a refresh failure: `true` iff it is a TERMINAL reuse / invalid-refresh
+ * error (clear + force re-auth, never retry), `false` for a transient/network
+ * error (keep tokens, surface to caller, never auto-retry the same refresh token).
+ *
+ * Duck-typed on `{ status, headers }` so it works for `HTTPError` without
+ * importing it (avoids an http-client import cycle) and stays trivially testable.
+ */
+export function isRefreshReuseError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const status = (error as { status?: unknown }).status;
+  // A 403 from the refresh endpoint is reuse/invalid-refresh by contract.
+  if (status === 403) return true;
+  if (status === 401) {
+    const headers = (error as { headers?: { get?: (k: string) => string | null } }).headers;
+    const code = typeof headers?.get === 'function' ? headers.get(AUTH_ERROR_HEADER) : undefined;
+    return code === AUTH_ERROR_TOKEN_REUSE;
+  }
+  return false;
+}

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -2,6 +2,14 @@
 export * from './http-types';
 export * from './api-response';
 
+// Auth error wire contract (token_expired / token_reuse classification)
+export {
+  AUTH_ERROR_HEADER,
+  AUTH_ERROR_TOKEN_EXPIRED,
+  AUTH_ERROR_TOKEN_REUSE,
+  isRefreshReuseError,
+} from './auth-errors';
+
 // Web Standards HTTP client implementation
 export { WebHttpClient, HTTPError } from './web-client';
 

--- a/src/http-client/web-client.test.ts
+++ b/src/http-client/web-client.test.ts
@@ -190,6 +190,44 @@ describe('WebHttpClient - Token Refresh', () => {
       expect(refreshToken).not.toHaveBeenCalled();
     });
 
+    it('should NOT attempt refresh on a terminal 401 token_reuse (no retry)', async () => {
+      const refreshToken = vi.fn();
+      transport.refreshToken = refreshToken;
+
+      const errorResponse = new Response(null, {
+        status: 401,
+        headers: { 'x-auth-error': 'token_reuse' },
+      });
+      mockFetch.mockResolvedValueOnce(errorResponse);
+
+      await expect(client.get('/protected-endpoint')).rejects.toThrow(HTTPError);
+      // token_reuse is terminal: never refreshed, never retried.
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface a TokenReuseError thrown by the refresh hook as-is (terminal)', async () => {
+      class TokenReuseError extends Error {
+        name = 'TokenReuseError' as const;
+      }
+      const refreshToken = vi.fn().mockRejectedValue(new TokenReuseError('reuse'));
+      const onTokenRefresh = vi.fn();
+      transport.refreshToken = refreshToken;
+      transport.onTokenRefresh = onTokenRefresh;
+
+      // A normal token_expired 401 triggers the refresh hook, which then reports
+      // reuse (the rotated/consumed token was replayed) — surfaced, not retried.
+      const errorResponse = new Response(null, {
+        status: 401,
+        headers: { 'x-auth-error': 'token_expired' },
+      });
+      mockFetch.mockResolvedValueOnce(errorResponse);
+
+      await expect(client.get('/protected-endpoint')).rejects.toThrow('reuse');
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1); // no retry
+    });
+
     it('should not call refreshToken for bare 401 without x-auth-error header', async () => {
       const refreshToken = vi.fn();
       transport.refreshToken = refreshToken;

--- a/src/http-client/web-client.ts
+++ b/src/http-client/web-client.ts
@@ -6,6 +6,7 @@ import {
   ResponseParser,
 } from './http-types';
 import { combineSignals, createTimeoutSignal } from './signal-utils';
+import { AUTH_ERROR_HEADER, AUTH_ERROR_TOKEN_EXPIRED } from './auth-errors';
 
 // Custom error class for HTTP errors
 export class HTTPError extends Error {
@@ -239,12 +240,15 @@ export class WebHttpClient implements HttpClient {
           bodyText,
         );
 
-        // Handle 401 with token_expired - attempt automatic token refresh
+        // Handle 401 with token_expired - attempt automatic token refresh.
+        // Only `token_expired` is refreshable; other auth errors (notably
+        // `token_reuse`) are terminal and fall through to `throw httpError`
+        // below — never retried.
         const userAborted = init?.signal?.aborted === true;
         if (
           response.status === 401 &&
           this.transport.refreshToken &&
-          response.headers.get('x-auth-error') === 'token_expired' &&
+          response.headers.get(AUTH_ERROR_HEADER) === AUTH_ERROR_TOKEN_EXPIRED &&
           retryCount < MAX_RETRY_ATTEMPTS &&
           !isStreamBody &&
           !userAborted
@@ -318,6 +322,12 @@ export class WebHttpClient implements HttpClient {
             // Clear caches on error
             this.refreshTokenPromise = null;
             this.onTokenRefreshPromise = null;
+            // Terminal refresh-reuse error: the refresh hook already cleared the
+            // tokens and the family is revoked server-side. Surface it as-is so
+            // the caller can force re-auth — do NOT retry, do NOT mask as a 401.
+            if (refreshError instanceof Error && refreshError.name === 'TokenReuseError') {
+              throw refreshError;
+            }
             // Configuration errors (missing onTokenRefresh) should be thrown as-is
             if (refreshError instanceof Error && refreshError.message.includes('onTokenRefresh')) {
               throw refreshError;
@@ -335,6 +345,12 @@ export class WebHttpClient implements HttpClient {
       return this.parseResponse<T>(response, init?.parse);
     } catch (error) {
       if (error instanceof HTTPError) {
+        throw error;
+      }
+      // Terminal refresh-reuse error: surface as-is so the caller can force
+      // re-auth. Mirrors the inner refresh catch — must NOT be masked as a
+      // generic HTTP 0 network error.
+      if (error instanceof Error && error.name === 'TokenReuseError') {
         throw error;
       }
       // Preserve configuration errors (like missing onTokenRefresh)

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,22 @@
 // This will contain the pure JavaScript SDK without React dependencies
 
 // Main SDK class
-export { MeroJs, createMeroJs } from './mero-js';
+export { MeroJs, createMeroJs, TokenReuseError } from './mero-js';
 export type { MeroJsConfig, TokenData } from './mero-js';
+
+// JWT claim helpers + token_type constants (read-only, signature NOT verified)
+export {
+  decodeJwtPayload,
+  expiresAtFromJwt,
+  tokenTypeFromJwt,
+  permissionsFromJwt,
+  isRefreshTokenInAccessSlot,
+  ACCESS_TOKEN_TYPE,
+  REFRESH_TOKEN_TYPE,
+} from './jwt';
+
+// Cross-tab refresh coordination (Web Locks with Node-safe fallback)
+export { withRefreshLock, getLockManager } from './refresh-lock';
 
 // HTTP client module (Web Standards based)
 export * from './http-client';

--- a/src/jwt.test.ts
+++ b/src/jwt.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  decodeJwtPayload,
+  expiresAtFromJwt,
+  tokenTypeFromJwt,
+  permissionsFromJwt,
+  isRefreshTokenInAccessSlot,
+} from './jwt';
+
+/** Build an unsigned (fake-signature) JWT carrying the given claims. */
+function makeJwt(claims: Record<string, unknown>): string {
+  const b64url = (o: unknown): string =>
+    Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(claims)}.fakesig`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('decodes a well-formed JWT payload', () => {
+    const token = makeJwt({ sub: 'user-1', token_type: 'access' });
+    expect(decodeJwtPayload(token)).toMatchObject({ sub: 'user-1', token_type: 'access' });
+  });
+
+  it('returns null for a non-JWT string', () => {
+    expect(decodeJwtPayload('not-a-jwt')).toBeNull();
+    expect(decodeJwtPayload('a.b')).toBeNull();
+    expect(decodeJwtPayload('')).toBeNull();
+  });
+
+  it('returns null for an undecodable payload segment', () => {
+    expect(decodeJwtPayload('aaa.!!!notbase64!!!.ccc')).toBeNull();
+  });
+});
+
+describe('expiresAtFromJwt', () => {
+  it('extracts exp as a ms timestamp', () => {
+    const expSeconds = 1_900_000_000;
+    const token = makeJwt({ exp: expSeconds });
+    expect(expiresAtFromJwt(token, 0)).toBe(expSeconds * 1000);
+  });
+
+  it('falls back when there is no exp claim', () => {
+    const token = makeJwt({ sub: 'x' });
+    expect(expiresAtFromJwt(token, 12345)).toBe(12345);
+  });
+
+  it('falls back for a non-JWT', () => {
+    expect(expiresAtFromJwt('mock-access-token', 999)).toBe(999);
+  });
+});
+
+describe('tokenTypeFromJwt', () => {
+  it('returns the lowercased token_type claim', () => {
+    expect(tokenTypeFromJwt(makeJwt({ token_type: 'access' }))).toBe('access');
+    expect(tokenTypeFromJwt(makeJwt({ token_type: 'Refresh' }))).toBe('refresh');
+  });
+
+  it('returns undefined when absent or not a JWT', () => {
+    expect(tokenTypeFromJwt(makeJwt({ sub: 'x' }))).toBeUndefined();
+    expect(tokenTypeFromJwt('mock-token')).toBeUndefined();
+  });
+});
+
+describe('permissionsFromJwt', () => {
+  it('returns the permissions claim as a string array', () => {
+    const token = makeJwt({ permissions: ['admin', 'context:read'] });
+    expect(permissionsFromJwt(token)).toEqual(['admin', 'context:read']);
+  });
+
+  it('filters out non-string entries', () => {
+    const token = makeJwt({ permissions: ['admin', 42, null, 'ok'] });
+    expect(permissionsFromJwt(token)).toEqual(['admin', 'ok']);
+  });
+
+  it('returns [] when there is no permissions claim or not a JWT', () => {
+    expect(permissionsFromJwt(makeJwt({ sub: 'x' }))).toEqual([]);
+    expect(permissionsFromJwt('mock-access-token')).toEqual([]);
+  });
+
+  it('surfaces a SHRUNK permission set (fewer than requested)', () => {
+    // Requested ['admin','context:write'] but the node granted only read.
+    const issued = makeJwt({ permissions: ['context:read'] });
+    expect(permissionsFromJwt(issued)).toEqual(['context:read']);
+  });
+});
+
+describe('isRefreshTokenInAccessSlot', () => {
+  it('is true only for an explicit refresh token_type', () => {
+    expect(isRefreshTokenInAccessSlot(makeJwt({ token_type: 'refresh' }))).toBe(true);
+    expect(isRefreshTokenInAccessSlot(makeJwt({ token_type: 'Refresh' }))).toBe(true);
+  });
+
+  it('is false for an access token, a typeless token, or a non-JWT', () => {
+    expect(isRefreshTokenInAccessSlot(makeJwt({ token_type: 'access' }))).toBe(false);
+    expect(isRefreshTokenInAccessSlot(makeJwt({ sub: 'x' }))).toBe(false);
+    expect(isRefreshTokenInAccessSlot('mock-access-token')).toBe(false);
+  });
+});

--- a/src/jwt.ts
+++ b/src/jwt.ts
@@ -1,0 +1,86 @@
+// JWT claim decoding helpers (read-only, signature is NOT verified here).
+//
+// The SDK only ever *reads* claims from tokens the node issued in order to make
+// local decisions (expiry, token-type assertion, effective permissions). It must
+// never trust these for authorization — the node re-verifies on every request.
+
+/**
+ * Canonical `token_type` claim values (must mirror core's `TokenType` serde
+ * representation). Compared case-insensitively by the helpers below so a
+ * PascalCase/lowercase serde skew on the core side cannot silently defeat the
+ * client-side defense-in-depth check.
+ */
+export const ACCESS_TOKEN_TYPE = 'access';
+export const REFRESH_TOKEN_TYPE = 'refresh';
+
+/**
+ * Decode a JWT payload without verifying its signature. Returns the parsed
+ * claims object, or `null` if the token is not a well-formed JWT.
+ */
+export function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return null;
+    // JWT uses base64url encoding: replace -/_ with +// and add padding.
+    let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    while (b64.length % 4) b64 += '=';
+    const json =
+      typeof atob === 'function'
+        ? atob(b64)
+        : // Node fallback (no atob): decode via Buffer.
+          (globalThis as { Buffer?: { from(s: string, e: string): { toString(e: string): string } } })
+            .Buffer?.from(b64, 'base64')
+            .toString('binary') ?? '';
+    const payload = JSON.parse(json);
+    return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : null;
+  } catch {
+    // Not a JWT or can't parse.
+    return null;
+  }
+}
+
+/** Try to extract `exp` (seconds) from a JWT, return ms timestamp or fallback. */
+export function expiresAtFromJwt(token: string, fallbackMs: number): number {
+  const payload = decodeJwtPayload(token);
+  if (payload && typeof payload.exp === 'number') {
+    return payload.exp * 1000;
+  }
+  return fallbackMs;
+}
+
+/**
+ * The `token_type` claim, lowercased, or `undefined` if the token is not a JWT
+ * or carries no `token_type` claim.
+ */
+export function tokenTypeFromJwt(token: string): string | undefined {
+  const payload = decodeJwtPayload(token);
+  const t = payload?.token_type;
+  return typeof t === 'string' ? t.toLowerCase() : undefined;
+}
+
+/**
+ * The EFFECTIVE permissions granted by an access token, as decoded from its
+ * `permissions` claim. This is what the node actually issued — which, after
+ * core's live re-derivation (#10), may be FEWER than what was requested. Returns
+ * `[]` when the token is not a JWT or declares no permissions.
+ */
+export function permissionsFromJwt(token: string): string[] {
+  const payload = decodeJwtPayload(token);
+  const perms = payload?.permissions;
+  if (Array.isArray(perms)) {
+    return perms.filter((p): p is string => typeof p === 'string');
+  }
+  return [];
+}
+
+/**
+ * True iff the token's `token_type` claim explicitly identifies it as a REFRESH
+ * token. A refresh token must never be presented as a bearer/access token.
+ *
+ * Note the asymmetry: a token with no decodable `token_type` (e.g. a legacy or
+ * mock token) is NOT flagged here — we only reject what we can prove is a
+ * refresh token, so this stays a safe, non-breaking guard.
+ */
+export function isRefreshTokenInAccessSlot(token: string): boolean {
+  return tokenTypeFromJwt(token) === REFRESH_TOKEN_TYPE;
+}

--- a/src/mero-js.test.ts
+++ b/src/mero-js.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MeroJs, createMeroJs } from './mero-js';
+import { MeroJs, createMeroJs, TokenReuseError } from './mero-js';
+import { HTTPError } from './http-client';
+import { MemoryTokenStore } from './token-store';
+
+/** Build an unsigned JWT carrying the given claims (for decode-only assertions). */
+function makeJwt(claims: Record<string, unknown>): string {
+  const b64url = (o: unknown): string =>
+    Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(claims)}.fakesig`;
+}
+
+/** An HTTPError mimicking core's refresh-reuse response. */
+function reuseHttpError(): HTTPError {
+  return new HTTPError(401, 'Unauthorized', 'https://node/auth/refresh',
+    new Headers([['x-auth-error', 'token_reuse']]), '');
+}
 
 // Mock the HTTP client and API clients
 const mockHttpClient = {
@@ -58,9 +73,13 @@ const mockAdminClient = {
   getApplication: vi.fn(),
 };
 
-vi.mock('./http-client', () => ({
-  createBrowserHttpClient: vi.fn(() => mockHttpClient),
-}));
+vi.mock('./http-client', async (importActual) => {
+  const actual = await importActual<typeof import('./http-client')>();
+  return {
+    ...actual,
+    createBrowserHttpClient: vi.fn(() => mockHttpClient),
+  };
+});
 
 vi.mock('./auth-api', () => ({
   createAuthApiClientFromHttpClient: vi.fn(() => mockAuthClient),
@@ -443,6 +462,151 @@ describe('MeroJs SDK', () => {
         onTokenRefresh: expect.any(Function),
         timeoutMs: 30000,
       });
+    });
+  });
+
+  describe('Refresh-reuse handling (v8)', () => {
+    beforeEach(async () => {
+      meroJs = new MeroJs({
+        baseUrl: 'http://localhost:3000',
+        credentials: { username: 'admin', password: 'admin123' },
+      });
+      mockAuthClient.generateTokens.mockResolvedValue({
+        data: { access_token: 'access-1', refresh_token: 'refresh-1' },
+      });
+      await meroJs.authenticate();
+    });
+
+    it('clears tokens and throws TokenReuseError on a reuse (401 token_reuse) error', async () => {
+      mockAuthClient.refreshToken.mockRejectedValue(reuseHttpError());
+
+      await expect((meroJs as any).performTokenRefresh()).rejects.toBeInstanceOf(
+        TokenReuseError,
+      );
+      // Terminal: tokens cleared, forcing re-auth.
+      expect(meroJs.isAuthenticated()).toBe(false);
+      expect(meroJs.getTokenData()).toBeNull();
+    });
+
+    it('clears tokens on a 403 from the refresh endpoint', async () => {
+      mockAuthClient.refreshToken.mockRejectedValue(
+        new HTTPError(403, 'Forbidden', 'https://node/auth/refresh', new Headers(), ''),
+      );
+
+      await expect((meroJs as any).performTokenRefresh()).rejects.toBeInstanceOf(
+        TokenReuseError,
+      );
+      expect(meroJs.isAuthenticated()).toBe(false);
+    });
+
+    it('keeps tokens on a transient/network error and never marks it terminal', async () => {
+      mockAuthClient.refreshToken.mockRejectedValue(new Error('network down'));
+
+      await expect((meroJs as any).performTokenRefresh()).rejects.toThrow(
+        'Token refresh failed: network down',
+      );
+      // Transient: access token may still be valid — tokens retained.
+      expect(meroJs.isAuthenticated()).toBe(true);
+      expect(meroJs.getTokenData()?.refresh_token).toBe('refresh-1');
+    });
+
+    it('persists the rotated pair to the store before returning', async () => {
+      mockAuthClient.refreshToken.mockResolvedValue({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+
+      const result = await (meroJs as any).performTokenRefresh();
+      expect(result.refresh_token).toBe('refresh-2');
+      expect(meroJs.getTokenData()).toEqual(
+        expect.objectContaining({ access_token: 'access-2', refresh_token: 'refresh-2' }),
+      );
+    });
+
+    it('single-flights concurrent refreshes (one network call)', async () => {
+      mockAuthClient.refreshToken.mockResolvedValue({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+
+      const [a, b] = await Promise.all([
+        (meroJs as any).refreshToken(),
+        (meroJs as any).refreshToken(),
+      ]);
+
+      expect(mockAuthClient.refreshToken).toHaveBeenCalledTimes(1);
+      expect(a.refresh_token).toBe('refresh-2');
+      expect(b.refresh_token).toBe('refresh-2');
+    });
+  });
+
+  describe('Cross-tab adoption (v8)', () => {
+    it('adopts a peer-rotated pair from the store instead of replaying a consumed token', async () => {
+      const store = new MemoryTokenStore();
+      meroJs = new MeroJs({
+        baseUrl: 'http://localhost:3000',
+        credentials: { username: 'admin', password: 'admin123' },
+        tokenStore: store,
+      });
+      mockAuthClient.generateTokens.mockResolvedValue({
+        data: { access_token: 'access-1', refresh_token: 'refresh-1' },
+      });
+      await meroJs.authenticate();
+
+      // Simulate another tab having already rotated the shared pair.
+      store.setTokens({
+        access_token: 'peer-access',
+        refresh_token: 'peer-refresh',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      const result = await (meroJs as any).refreshUnderCoordination();
+
+      expect(mockAuthClient.refreshToken).not.toHaveBeenCalled();
+      expect(result.refresh_token).toBe('peer-refresh');
+      expect(meroJs.getTokenData()?.access_token).toBe('peer-access');
+    });
+  });
+
+  describe('Permission-shrink awareness (v8, #10)', () => {
+    it('surfaces the EFFECTIVE granted permissions from the issued access token', () => {
+      meroJs = new MeroJs({ baseUrl: 'http://localhost:3000' });
+      meroJs.setTokenData({
+        access_token: makeJwt({ token_type: 'access', permissions: ['context:read'] }),
+        refresh_token: 'r',
+        expires_at: Date.now() + 3600_000,
+      });
+      // Requested admin earlier, but the node granted only read.
+      expect(meroJs.getGrantedPermissions()).toEqual(['context:read']);
+    });
+
+    it('returns [] when unauthenticated', () => {
+      meroJs = new MeroJs({ baseUrl: 'http://localhost:3000' });
+      expect(meroJs.getGrantedPermissions()).toEqual([]);
+    });
+  });
+
+  describe('token_type assertion (v8, #1)', () => {
+    it('treats a refresh token in the access slot as unauthenticated', async () => {
+      meroJs = new MeroJs({ baseUrl: 'http://localhost:3000' });
+      meroJs.setTokenData({
+        access_token: makeJwt({ token_type: 'refresh' }),
+        refresh_token: 'r',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      const valid = await (meroJs as any).getValidToken();
+      expect(valid).toBeNull();
+    });
+
+    it('allows a proper access token through', async () => {
+      meroJs = new MeroJs({ baseUrl: 'http://localhost:3000' });
+      meroJs.setTokenData({
+        access_token: makeJwt({ token_type: 'access' }),
+        refresh_token: 'r',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      const valid = await (meroJs as any).getValidToken();
+      expect(valid?.access_token).toBeDefined();
     });
   });
 });

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -1,4 +1,4 @@
-import { createBrowserHttpClient } from './http-client';
+import { createBrowserHttpClient, isRefreshReuseError } from './http-client';
 import { createAuthApiClientFromHttpClient } from './auth-api';
 import { createAdminApiClientFromHttpClient } from './admin-api';
 import type { AuthApiClient } from './auth-api';
@@ -10,6 +10,12 @@ import type { AuthCallbackResult, AuthLoginOptions } from './auth';
 import { RpcClient } from './rpc';
 import { SseClient } from './events/sse';
 import { WsClient } from './events/ws';
+import {
+  expiresAtFromJwt,
+  permissionsFromJwt,
+  isRefreshTokenInAccessSlot,
+} from './jwt';
+import { withRefreshLock } from './refresh-lock';
 
 export interface MeroJsConfig {
   /** Base URL for the Calimero node */
@@ -33,23 +39,19 @@ export interface TokenData {
   expires_at: number;
 }
 
-/** Try to extract `exp` (seconds) from a JWT, return ms timestamp or fallback. */
-function expiresAtFromJwt(token: string, fallbackMs: number): number {
-  try {
-    const parts = token.split('.');
-    if (parts.length === 3) {
-      // JWT uses base64url encoding: replace -/_ with +// and add padding
-      let b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-      while (b64.length % 4) b64 += '=';
-      const payload = JSON.parse(atob(b64));
-      if (typeof payload.exp === 'number') {
-        return payload.exp * 1000;
-      }
-    }
-  } catch {
-    // not a JWT or can't parse
+/**
+ * Terminal error thrown when the node reports refresh-token REUSE (a consumed /
+ * rotated refresh token was replayed). On this error the SDK has already cleared
+ * its tokens and the token family is revoked server-side — the caller must force
+ * a fresh interactive authentication. Distinguishable via `instanceof` (and by
+ * `name === 'TokenReuseError'` across module/bundle boundaries).
+ */
+export class TokenReuseError extends Error {
+  name = 'TokenReuseError' as const;
+
+  constructor(message = 'Refresh token reuse detected; re-authentication required') {
+    super(message);
   }
-  return fallbackMs;
 }
 
 /**
@@ -63,6 +65,8 @@ export class MeroJs {
   private tokenData: TokenData | null = null;
   private refreshPromise: Promise<TokenData> | null = null;
   private tokenStore: TokenStore | null;
+  /** Cross-tab Web Locks name; same node URL => same lock across tabs. */
+  private readonly refreshLockName: string;
   private rpcClient: RpcClient | null = null;
   private sseClient: SseClient | null = null;
   private wsClient: WsClient | null = null;
@@ -75,6 +79,7 @@ export class MeroJs {
     };
 
     this.tokenStore = config.tokenStore ?? null;
+    this.refreshLockName = `mero-js:token-refresh:${this.config.baseUrl}`;
 
     // Restore tokens from store if available
     if (this.tokenStore) {
@@ -91,7 +96,7 @@ export class MeroJs {
         return token?.access_token || '';
       },
       refreshToken: async () => {
-        const refreshed = await this.performTokenRefresh();
+        const refreshed = await this.refreshToken();
         return refreshed.access_token;
       },
       onTokenRefresh: async (newToken: string) => {
@@ -237,34 +242,67 @@ export class MeroJs {
    * responses reactively via the refreshToken transport hook.
    */
   private async getValidToken(): Promise<TokenData | null> {
+    // Defense-in-depth (#1): never present a refresh token as a bearer. If a
+    // refresh token somehow landed in the access slot, treat as unauthenticated.
+    if (this.tokenData && isRefreshTokenInAccessSlot(this.tokenData.access_token)) {
+      return null;
+    }
     return this.tokenData;
   }
 
   /**
-   * Refresh the access token using the refresh token
+   * Refresh the access token. Dedups concurrent refreshes within this instance
+   * (single-flight) and, across tabs/instances, serializes through the Web Locks
+   * API when available so a server-rotation 401 wave does not stampede the
+   * refresh endpoint and replay consumed tokens.
    */
   private async refreshToken(): Promise<TokenData> {
     if (!this.tokenData?.refresh_token) {
       throw new Error('No refresh token available');
     }
 
-    // Prevent multiple simultaneous refresh attempts
+    // Per-instance single-flight: collapse concurrent refreshes in this tab.
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = this.performTokenRefresh();
+    this.refreshPromise = withRefreshLock(this.refreshLockName, () =>
+      this.refreshUnderCoordination(),
+    );
 
     try {
-      const newToken = await this.refreshPromise;
-      return newToken;
+      return await this.refreshPromise;
     } finally {
       this.refreshPromise = null;
     }
   }
 
   /**
-   * Perform the actual token refresh
+   * Runs inside the cross-tab lock (or jitter fallback). Re-reads the shared
+   * store first: if a peer already rotated the pair we ADOPT it instead of
+   * replaying our now-consumed refresh token (which would trip reuse detection).
+   */
+  private async refreshUnderCoordination(): Promise<TokenData> {
+    const startedWith = this.tokenData?.refresh_token;
+    const stored = this.tokenStore?.getTokens() ?? null;
+    if (stored?.refresh_token && stored.refresh_token !== startedWith) {
+      // A concurrent tab/instance already rotated; take its fresh tokens.
+      this.tokenData = stored;
+      return stored;
+    }
+    return this.performTokenRefresh();
+  }
+
+  /**
+   * Perform the actual token refresh against the node.
+   *
+   * On success the rotated pair is persisted to the store BEFORE it is returned,
+   * so no subsequent request can fire with the now-consumed refresh token.
+   *
+   * On failure the error is classified (see {@link isRefreshReuseError}):
+   *  - reuse / invalid-refresh (terminal): clear tokens + force re-auth, no retry.
+   *  - transient / network: keep tokens (the access token may still be valid),
+   *    surface to caller, never auto-retry the same refresh token.
    */
   private async performTokenRefresh(): Promise<TokenData> {
     if (!this.tokenData?.refresh_token) {
@@ -278,19 +316,27 @@ export class MeroJs {
       });
 
       const accessToken = response.data.access_token;
-      this.tokenData = {
+      const next: TokenData = {
         access_token: accessToken,
         refresh_token: response.data.refresh_token,
         expires_at: expiresAtFromJwt(accessToken, Date.now() + 3600_000),
       };
 
+      // Persist the rotated pair BEFORE handing the token back / releasing the
+      // lock, so a peer that wakes up next reads the new refresh token.
+      this.tokenData = next;
       this.tokenStore?.setTokens(this.tokenData);
 
       return this.tokenData;
     } catch (error) {
-      // Don't clear tokens on refresh failure — the access token may still be
-      // valid (server rejects refresh while access token hasn't expired yet).
-      // Let the caller handle the error.
+      if (isRefreshReuseError(error)) {
+        // Terminal: the node denylisted this refresh token and revoked the
+        // family. Retrying replays a consumed token — clear and force re-auth.
+        this.clearToken();
+        throw new TokenReuseError();
+      }
+      // Transient/network error — the access token may still be valid. Keep
+      // tokens and surface to the caller; never auto-retry the same refresh token.
       throw new Error(
         `Token refresh failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
@@ -328,6 +374,22 @@ export class MeroJs {
    */
   public getTokenData(): TokenData | null {
     return this.tokenData;
+  }
+
+  /**
+   * The EFFECTIVE permissions granted by the current access token (#10).
+   *
+   * Callers must NOT assume requested permissions == granted: core re-derives
+   * permissions from the live key at issue time and may grant FEWER than were
+   * requested. This decodes the issued access token's `permissions` claim so
+   * callers can read what they actually got. Returns `[]` when unauthenticated
+   * or the token carries no decodable permissions.
+   */
+  public getGrantedPermissions(): string[] {
+    if (!this.tokenData?.access_token) {
+      return [];
+    }
+    return permissionsFromJwt(this.tokenData.access_token);
   }
 
   /**

--- a/src/refresh-lock.test.ts
+++ b/src/refresh-lock.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getLockManager, withRefreshLock } from './refresh-lock';
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getLockManager', () => {
+  it('returns null when navigator is undefined (Node)', () => {
+    vi.stubGlobal('navigator', undefined);
+    expect(getLockManager()).toBeNull();
+  });
+
+  it('returns null when navigator has no locks', () => {
+    vi.stubGlobal('navigator', {});
+    expect(getLockManager()).toBeNull();
+  });
+
+  it('returns the manager when navigator.locks.request exists', () => {
+    const locks = { request: vi.fn() };
+    vi.stubGlobal('navigator', { locks });
+    expect(getLockManager()).toBe(locks);
+  });
+});
+
+describe('withRefreshLock', () => {
+  it('routes the task through navigator.locks.request when available', async () => {
+    const request = vi.fn((_name: string, cb: () => Promise<unknown>) => cb());
+    vi.stubGlobal('navigator', { locks: { request } });
+
+    const result = await withRefreshLock('lock-A', async () => 'done');
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls[0][0]).toBe('lock-A');
+    expect(result).toBe('done');
+  });
+
+  it('serializes tasks holding the same lock (winner runs to completion first)', async () => {
+    // Minimal in-memory mutual-exclusion mock of the Web Locks API.
+    const chains = new Map<string, Promise<unknown>>();
+    const request = vi.fn(async (name: string, cb: () => Promise<unknown>) => {
+      const prev = chains.get(name) ?? Promise.resolve();
+      const run = prev.then(() => cb());
+      chains.set(
+        name,
+        run.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+      return run;
+    });
+    vi.stubGlobal('navigator', { locks: { request } });
+
+    const order: string[] = [];
+    const a = withRefreshLock('same', async () => {
+      order.push('a-start');
+      await new Promise((r) => setTimeout(r, 20));
+      order.push('a-end');
+    });
+    const b = withRefreshLock('same', async () => {
+      order.push('b-start');
+      order.push('b-end');
+    });
+
+    await Promise.all([a, b]);
+    expect(order).toEqual(['a-start', 'a-end', 'b-start', 'b-end']);
+  });
+
+  it('falls back to running the task directly (with jitter) when no lock API exists', async () => {
+    vi.stubGlobal('navigator', undefined);
+    const task = vi.fn(async () => 'fallback');
+    const result = await withRefreshLock('lock-B', task, 0);
+    expect(result).toBe('fallback');
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/refresh-lock.ts
+++ b/src/refresh-lock.ts
@@ -1,0 +1,67 @@
+// Cross-tab/instance refresh coordination.
+//
+// Per-instance single-flight (the `refreshPromise` in mero-js / web-client) only
+// dedups within ONE MeroJs instance. With `LocalStorageTokenStore`, several
+// browser tabs share the same persisted token and each fires its own refresh on
+// a server-rotation 401 wave. Once refresh tokens rotate + reuse-detect on the
+// server, that stampede is actively dangerous (every loser of the race replays a
+// now-consumed token and trips family revocation).
+//
+// When the Web Locks API is available we serialize refresh across all same-origin
+// tabs through a named lock; the winner rotates and the others, re-reading the
+// store under the lock, simply adopt the freshly-rotated pair. Outside the
+// browser (Node, Tauri without locks, older browsers) we fall back to the
+// caller's per-instance single-flight plus a little jitter to de-correlate
+// independent instances.
+
+type LockTask<T> = () => Promise<T>;
+
+interface LockManagerLike {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+}
+
+/**
+ * Return the Web Locks manager if this runtime supports it, else `null`.
+ * Safe in non-browser/Node contexts where `navigator` is undefined.
+ */
+export function getLockManager(): LockManagerLike | null {
+  try {
+    const nav = (globalThis as { navigator?: { locks?: LockManagerLike } }).navigator;
+    if (nav && nav.locks && typeof nav.locks.request === 'function') {
+      return nav.locks;
+    }
+  } catch {
+    // Accessing navigator can throw in some sandboxes — treat as unavailable.
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Small random delay (ms) to de-correlate independent instances when no lock exists. */
+function jitterMs(maxMs: number): number {
+  return Math.floor(Math.random() * Math.max(0, maxMs));
+}
+
+/**
+ * Run `task` while holding the cross-tab refresh lock named `name` when the Web
+ * Locks API is available; otherwise run it after a small jitter. The task itself
+ * is responsible for re-reading shared token state so it can adopt a rotation a
+ * peer already performed.
+ */
+export async function withRefreshLock<T>(
+  name: string,
+  task: LockTask<T>,
+  jitterMaxMs = 50,
+): Promise<T> {
+  const locks = getLockManager();
+  if (locks) {
+    return locks.request(name, () => task());
+  }
+  if (jitterMaxMs > 0) {
+    await sleep(jitterMs(jitterMaxMs));
+  }
+  return task();
+}


### PR DESCRIPTION
Client-side counterpart to the node auth-hardening work. **BREAKING** — refresh semantics change; warrants a major (v8) release.

## What
- Classifies refresh failures: a terminal reuse/invalid-refresh error clears tokens and forces re-auth (never retries); a transient error keeps tokens.
- Single source of truth for the `x-auth-error` wire contract (`token_expired` recoverable, `token_reuse` terminal).
- Cross-tab refresh single-flight via the Web Locks API, with a Node fallback.
- Exposes the effective granted permissions decoded from the access token.
- Asserts a stored token is an access token before using it as a bearer.

## Tests
`pnpm test:unit` green (269 passed); `typecheck` + `lint` clean.
