### PR TITLE
fix(auth): single-use refresh token rotation — single-flight refresh, cross-tab lock, token_reuse handling

### DIFF
--- a/src/http-client/http-factory.ts
+++ b/src/http-client/http-factory.ts
@@ -17,6 +17,12 @@ export function createBrowserHttpClient(options: {
    * If provided, the client will automatically retry the request after a successful refresh.
    */
   refreshToken?: () => Promise<string>;
+  /**
+   * Callback invoked when the server reports a revoked token family
+   * (`x-auth-error: token_reuse` / `token_revoked`). Terminal — the request is
+   * never retried; clear stored tokens and force a re-login.
+   */
+  onAuthRevoked?: () => Promise<void> | void;
   defaultHeaders?: Record<string, string>;
   timeoutMs?: number;
   credentials?: RequestCredentials;
@@ -30,6 +36,7 @@ export function createBrowserHttpClient(options: {
     getAuthToken: options.getAuthToken,
     onTokenRefresh: options.onTokenRefresh,
     refreshToken: options.refreshToken,
+    onAuthRevoked: options.onAuthRevoked,
     defaultHeaders: options.defaultHeaders,
     timeoutMs: options.timeoutMs,
     credentials: options.credentials, // No default credentials
@@ -51,6 +58,12 @@ export function createNodeHttpClient(options: {
    * If provided, the client will automatically retry the request after a successful refresh.
    */
   refreshToken?: () => Promise<string>;
+  /**
+   * Callback invoked when the server reports a revoked token family
+   * (`x-auth-error: token_reuse` / `token_revoked`). Terminal — the request is
+   * never retried; clear stored tokens and force a re-login.
+   */
+  onAuthRevoked?: () => Promise<void> | void;
   defaultHeaders?: Record<string, string>;
   timeoutMs?: number;
   credentials?: RequestCredentials;
@@ -82,6 +95,7 @@ export function createNodeHttpClient(options: {
     getAuthToken: options.getAuthToken,
     onTokenRefresh: options.onTokenRefresh,
     refreshToken: options.refreshToken,
+    onAuthRevoked: options.onAuthRevoked,
     defaultHeaders: options.defaultHeaders,
     timeoutMs: options.timeoutMs,
     credentials: options.credentials, // Node.js doesn't have default credentials
@@ -103,6 +117,12 @@ export function createUniversalHttpClient(options: {
    * If provided, the client will automatically retry the request after a successful refresh.
    */
   refreshToken?: () => Promise<string>;
+  /**
+   * Callback invoked when the server reports a revoked token family
+   * (`x-auth-error: token_reuse` / `token_revoked`). Terminal — the request is
+   * never retried; clear stored tokens and force a re-login.
+   */
+  onAuthRevoked?: () => Promise<void> | void;
   defaultHeaders?: Record<string, string>;
   timeoutMs?: number;
   credentials?: RequestCredentials;

--- a/src/http-client/http-types.ts
+++ b/src/http-client/http-types.ts
@@ -16,6 +16,13 @@ export interface Transport {
    * If provided, the client will automatically retry the request after a successful refresh.
    */
   refreshToken?: () => Promise<string>;
+  /**
+   * Callback invoked when the server reports that the token family is gone
+   * (`x-auth-error: token_reuse` on 401, or `token_revoked`). Refresh tokens are
+   * single-use, so this is terminal: the stored tokens must be dropped and the
+   * user re-authenticated. The client never retries such a request.
+   */
+  onAuthRevoked?: () => Promise<void> | void;
   timeoutMs?: number;
   credentials?: RequestCredentials;
   defaultAbortSignal?: AbortSignal;

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -3,7 +3,7 @@ export * from './http-types';
 export * from './api-response';
 
 // Web Standards HTTP client implementation
-export { WebHttpClient, HTTPError } from './web-client';
+export { WebHttpClient, HTTPError, AuthRevokedError } from './web-client';
 
 // Factory functions for easy client creation
 export {

--- a/src/http-client/web-client.test.ts
+++ b/src/http-client/web-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { WebHttpClient, HTTPError } from './web-client';
+import { WebHttpClient, HTTPError, AuthRevokedError } from './web-client';
 import { Transport } from './http-types';
 
 describe('WebHttpClient - Token Refresh', () => {
@@ -473,6 +473,96 @@ describe('WebHttpClient - Token Refresh', () => {
 
       expect(refreshToken).toHaveBeenCalledTimes(1);
       expect(result).toEqual({ patched: true });
+    });
+  });
+  describe('Revoked Token Family (single-use refresh tokens)', () => {
+    it('should not refresh or retry on 401 with x-auth-error: token_reuse', async () => {
+      const refreshToken = vi.fn().mockResolvedValue('new-token');
+      const onTokenRefresh = vi.fn();
+      const onAuthRevoked = vi.fn();
+
+      transport.refreshToken = refreshToken;
+      transport.onTokenRefresh = onTokenRefresh;
+      transport.onAuthRevoked = onAuthRevoked;
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'x-auth-error': 'token_reuse' },
+        }),
+      );
+
+      await expect(client.get('/protected-endpoint')).rejects.toBeInstanceOf(
+        AuthRevokedError,
+      );
+
+      // The refresh token was consumed and the family revoked - refreshing again
+      // would only burn another token, and the retry would 401 anyway
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(onTokenRefresh).not.toHaveBeenCalled();
+      expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should expose the auth error reason and stay an HTTPError', async () => {
+      transport.onAuthRevoked = vi.fn();
+
+      mockFetch.mockResolvedValueOnce(
+        new Response('reuse detected', {
+          status: 401,
+          statusText: 'Unauthorized',
+          headers: { 'x-auth-error': 'token_reuse' },
+        }),
+      );
+
+      try {
+        await client.get('/protected-endpoint');
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(HTTPError);
+        expect(error.name).toBe('AuthRevokedError');
+        expect(error.reason).toBe('token_reuse');
+        expect(error.status).toBe(401);
+      }
+    });
+
+    it('should treat 403 token_revoked as terminal', async () => {
+      const refreshToken = vi.fn();
+      const onAuthRevoked = vi.fn();
+      transport.refreshToken = refreshToken;
+      transport.onAuthRevoked = onAuthRevoked;
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 403,
+          headers: { 'x-auth-error': 'token_revoked' },
+        }),
+      );
+
+      await expect(client.get('/protected-endpoint')).rejects.toBeInstanceOf(
+        AuthRevokedError,
+      );
+
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should surface the terminal error even without an onAuthRevoked hook', async () => {
+      transport.refreshToken = vi.fn();
+
+      mockFetch.mockResolvedValueOnce(
+        new Response(null, {
+          status: 401,
+          headers: { 'x-auth-error': 'token_reuse' },
+        }),
+      );
+
+      await expect(client.get('/protected-endpoint')).rejects.toBeInstanceOf(
+        AuthRevokedError,
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/http-client/web-client.ts
+++ b/src/http-client/web-client.ts
@@ -7,9 +7,19 @@ import {
 } from './http-types';
 import { combineSignals, createTimeoutSignal } from './signal-utils';
 
+/**
+ * `x-auth-error` reasons that mean the whole token family is gone.
+ *
+ * Refresh tokens are single-use (calimero-network/core#3083): presenting a
+ * consumed refresh token is treated as token theft and the server revokes the
+ * family. Refreshing or retrying afterwards is pointless — the only way out is
+ * a fresh login.
+ */
+const TERMINAL_AUTH_ERRORS = new Set(['token_reuse', 'token_revoked']);
+
 // Custom error class for HTTP errors
 export class HTTPError extends Error {
-  name = 'HTTPError' as const;
+  name = 'HTTPError';
 
   constructor(
     public status: number,
@@ -35,6 +45,30 @@ export class HTTPError extends Error {
       headers: headersToRecord(this.headers),
       bodyText: this.bodyText,
     };
+  }
+}
+
+/**
+ * Terminal authentication error: the refresh-token family was revoked (single-use
+ * refresh token replayed, or the token was explicitly revoked). Never retried and
+ * never refreshed — apps should catch this and force a re-login.
+ *
+ * Extends {@link HTTPError} so existing `instanceof HTTPError` handling keeps working.
+ */
+export class AuthRevokedError extends HTTPError {
+  name = 'AuthRevokedError';
+
+  constructor(
+    /** Value of the `x-auth-error` header, e.g. `token_reuse` or `token_revoked`. */
+    public reason: string,
+    status: number,
+    statusText: string,
+    url: string,
+    headers: Headers,
+    bodyText?: string,
+  ) {
+    super(status, statusText, url, headers, bodyText);
+    this.message = `Authentication revoked (${reason}): HTTP ${status} ${statusText}`;
   }
 }
 
@@ -239,12 +273,44 @@ export class WebHttpClient implements HttpClient {
           bodyText,
         );
 
+        // Handle a revoked token family (single-use refresh token replayed, or an
+        // explicitly revoked token). This is terminal: refreshing would only burn
+        // another token and retrying would 401 again, so clear the tokens via the
+        // onAuthRevoked hook and surface a distinguishable error.
+        const authError = response.headers.get('x-auth-error');
+        if (
+          (response.status === 401 || response.status === 403) &&
+          authError &&
+          TERMINAL_AUTH_ERRORS.has(authError)
+        ) {
+          // Any in-flight refresh is based on a now-dead family — drop the caches.
+          this.refreshTokenPromise = null;
+          this.onTokenRefreshPromise = null;
+
+          if (this.transport.onAuthRevoked) {
+            try {
+              await this.transport.onAuthRevoked();
+            } catch {
+              // Never mask the auth error with a cleanup failure.
+            }
+          }
+
+          throw new AuthRevokedError(
+            authError,
+            response.status,
+            response.statusText,
+            url,
+            response.headers,
+            bodyText,
+          );
+        }
+
         // Handle 401 with token_expired - attempt automatic token refresh
         const userAborted = init?.signal?.aborted === true;
         if (
           response.status === 401 &&
           this.transport.refreshToken &&
-          response.headers.get('x-auth-error') === 'token_expired' &&
+          authError === 'token_expired' &&
           retryCount < MAX_RETRY_ATTEMPTS &&
           !isStreamBody &&
           !userAborted

--- a/src/mero-js.test.ts
+++ b/src/mero-js.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { MeroJs, createMeroJs } from './mero-js';
+import { MemoryTokenStore } from './token-store';
 
 // Mock the HTTP client and API clients
 const mockHttpClient = {
@@ -350,6 +351,7 @@ describe('MeroJs SDK', () => {
         getAuthToken: expect.any(Function),
         refreshToken: expect.any(Function),
         onTokenRefresh: expect.any(Function),
+        onAuthRevoked: expect.any(Function),
         timeoutMs: 10000,
       });
 
@@ -424,6 +426,7 @@ describe('MeroJs SDK', () => {
         getAuthToken: expect.any(Function),
         refreshToken: expect.any(Function),
         onTokenRefresh: expect.any(Function),
+        onAuthRevoked: expect.any(Function),
         timeoutMs: 10000,
       });
     });
@@ -441,8 +444,140 @@ describe('MeroJs SDK', () => {
         getAuthToken: expect.any(Function),
         refreshToken: expect.any(Function),
         onTokenRefresh: expect.any(Function),
+        onAuthRevoked: expect.any(Function),
         timeoutMs: 30000,
       });
+    });
+  });
+  describe('Single-use refresh token rotation (core#3083)', () => {
+    let store: MemoryTokenStore;
+
+    const getTransportHooks = async (): Promise<any> => {
+      const { createBrowserHttpClient } = await import('./http-client');
+      return (createBrowserHttpClient as any).mock.calls[0][0];
+    };
+
+    beforeEach(async () => {
+      store = new MemoryTokenStore();
+      meroJs = new MeroJs({
+        baseUrl: 'http://localhost:3000',
+        credentials: {
+          username: 'admin',
+          password: 'admin123',
+        },
+        tokenStore: store,
+      });
+
+      mockAuthClient.generateTokens.mockResolvedValue({
+        data: { access_token: 'access-1', refresh_token: 'refresh-1' },
+      });
+      await meroJs.authenticate();
+    });
+
+    it('should issue exactly one /auth/refresh call for concurrent 401 refreshes', async () => {
+      let resolveRefresh: (value: unknown) => void = () => {};
+      mockAuthClient.refreshToken.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+      const { refreshToken } = await getTransportHooks();
+
+      // Two in-flight requests both 401 and both ask the transport to refresh
+      const first = refreshToken();
+      const second = refreshToken();
+
+      resolveRefresh({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+      const [firstToken, secondToken] = await Promise.all([first, second]);
+
+      // Replaying the consumed refresh token would revoke the whole family
+      expect(mockAuthClient.refreshToken).toHaveBeenCalledTimes(1);
+      expect(firstToken).toBe('access-2');
+      expect(secondToken).toBe('access-2');
+    });
+
+    it('should persist the rotated refresh token to the token store', async () => {
+      mockAuthClient.refreshToken.mockResolvedValue({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+
+      await (meroJs as any).performTokenRefresh();
+
+      expect(mockAuthClient.refreshToken).toHaveBeenCalledWith({
+        access_token: 'access-1',
+        refresh_token: 'refresh-1',
+      });
+      expect(meroJs.getTokenData()?.refresh_token).toBe('refresh-2');
+      expect(store.getTokens()?.refresh_token).toBe('refresh-2');
+    });
+
+    it('should prefer the stored refresh token over a stale in-memory one', async () => {
+      // Another instance sharing this store rotated the refresh token
+      store.setTokens({
+        access_token: 'access-1',
+        refresh_token: 'refresh-1b',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      mockAuthClient.refreshToken.mockResolvedValue({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+
+      await (meroJs as any).performTokenRefresh();
+
+      expect(mockAuthClient.refreshToken).toHaveBeenCalledWith({
+        access_token: 'access-1',
+        refresh_token: 'refresh-1b',
+      });
+    });
+
+    it('should adopt a bundle another tab already rotated without calling /auth/refresh', async () => {
+      store.setTokens({
+        access_token: 'access-2',
+        refresh_token: 'refresh-2',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      const tokens = await (meroJs as any).performTokenRefresh();
+
+      expect(mockAuthClient.refreshToken).not.toHaveBeenCalled();
+      expect(tokens.access_token).toBe('access-2');
+      expect(meroJs.getTokenData()?.refresh_token).toBe('refresh-2');
+    });
+
+    it('should serialize the refresh through navigator.locks when available', async () => {
+      const request = vi.fn((_name: string, cb: () => Promise<unknown>) => cb());
+      vi.stubGlobal('navigator', { locks: { request } });
+
+      mockAuthClient.refreshToken.mockResolvedValue({
+        data: { access_token: 'access-2', refresh_token: 'refresh-2' },
+      });
+
+      try {
+        await (meroJs as any).performTokenRefresh();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+
+      expect(request).toHaveBeenCalledWith(
+        'mero-js:token-refresh',
+        expect.any(Function),
+      );
+      expect(mockAuthClient.refreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('should clear tokens when the transport reports a revoked token family', async () => {
+      const { onAuthRevoked } = await getTransportHooks();
+
+      await onAuthRevoked();
+
+      expect(meroJs.isAuthenticated()).toBe(false);
+      expect(meroJs.getTokenData()).toBeNull();
+      expect(store.getTokens()).toBeNull();
     });
   });
 });

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -33,6 +33,21 @@ export interface TokenData {
   expires_at: number;
 }
 
+/** Name of the Web Lock that serializes token refresh across tabs / webviews. */
+const REFRESH_LOCK_NAME = 'mero-js:token-refresh';
+
+/** Minimal structural view of the Web Locks API (not available in every runtime). */
+interface LockManagerLike {
+  request<T>(name: string, callback: () => Promise<T>): Promise<T>;
+}
+
+/** Returns `navigator.locks` when the runtime supports the Web Locks API. */
+function getLockManager(): LockManagerLike | null {
+  const nav = (globalThis as unknown as { navigator?: { locks?: LockManagerLike } }).navigator;
+  const locks = nav?.locks;
+  return locks && typeof locks.request === 'function' ? locks : null;
+}
+
 /** Try to extract `exp` (seconds) from a JWT, return ms timestamp or fallback. */
 function expiresAtFromJwt(token: string, fallbackMs: number): number {
   try {
@@ -99,6 +114,12 @@ export class MeroJs {
           this.tokenData.access_token = newToken;
           this.tokenStore?.setTokens(this.tokenData);
         }
+      },
+      onAuthRevoked: () => {
+        // The refresh-token family is gone (a single-use refresh token was
+        // replayed, or the token was revoked). Nothing left to refresh with —
+        // drop the bundle so the app can force a re-login.
+        this.clearToken();
       },
       timeoutMs: this.config.timeoutMs,
       credentials: this.config.requestCredentials ?? (isTauri ? 'omit' : undefined),
@@ -241,32 +262,67 @@ export class MeroJs {
   }
 
   /**
-   * Refresh the access token using the refresh token
+   * Refresh the access token. Single-flight: every caller (including the HTTP
+   * transport's 401 hook) goes through here.
+   *
+   * Refresh tokens are single-use (calimero-network/core#3083): each refresh
+   * consumes the presented token and returns a new one, and replaying a consumed
+   * token makes the server revoke the whole family. A refresh must therefore
+   * happen exactly once per rotation, which needs three layers:
+   *  - an in-process promise, so concurrent 401s in this instance share one call;
+   *  - a Web Lock (when available), so other tabs/webviews don't refresh at the
+   *    same time on the same stored token;
+   *  - a re-read of the token store inside the lock, so a bundle that another
+   *    instance already rotated is adopted instead of replaying a stale token.
    */
-  private async refreshToken(): Promise<TokenData> {
-    if (!this.tokenData?.refresh_token) {
-      throw new Error('No refresh token available');
-    }
-
-    // Prevent multiple simultaneous refresh attempts
+  private async performTokenRefresh(): Promise<TokenData> {
     if (this.refreshPromise) {
       return this.refreshPromise;
     }
 
-    this.refreshPromise = this.performTokenRefresh();
+    // The access token that triggered this refresh. If the store holds a different
+    // one by the time we get the lock, someone else already rotated for us.
+    const triggeringAccessToken = this.tokenData?.access_token;
+
+    const promise = this.withRefreshLock(() =>
+      this.performTokenRefreshLocked(triggeringAccessToken),
+    );
+    this.refreshPromise = promise;
 
     try {
-      const newToken = await this.refreshPromise;
-      return newToken;
+      return await promise;
     } finally {
-      this.refreshPromise = null;
+      if (this.refreshPromise === promise) {
+        this.refreshPromise = null;
+      }
     }
   }
 
+  /** Run `fn` under the cross-tab refresh lock, or directly if Web Locks are unavailable. */
+  private withRefreshLock<T>(fn: () => Promise<T>): Promise<T> {
+    const locks = getLockManager();
+    return locks ? locks.request(REFRESH_LOCK_NAME, fn) : fn();
+  }
+
   /**
-   * Perform the actual token refresh
+   * Perform the actual token refresh. Runs with the refresh lock held.
    */
-  private async performTokenRefresh(): Promise<TokenData> {
+  private async performTokenRefreshLocked(
+    triggeringAccessToken?: string,
+  ): Promise<TokenData> {
+    // Another instance/tab may have rotated the bundle while we were queued behind
+    // the lock — the store, not our in-memory copy, is the source of truth.
+    const stored = this.tokenStore?.getTokens() ?? null;
+    if (stored?.refresh_token) {
+      this.tokenData = stored;
+
+      if (triggeringAccessToken && stored.access_token !== triggeringAccessToken) {
+        // Someone else already refreshed. Reuse their bundle rather than replaying
+        // our (now consumed) refresh token, which would revoke the family.
+        return stored;
+      }
+    }
+
     if (!this.tokenData?.refresh_token) {
       throw new Error('No refresh token available');
     }
@@ -280,6 +336,8 @@ export class MeroJs {
       const accessToken = response.data.access_token;
       this.tokenData = {
         access_token: accessToken,
+        // The refresh token is rotated on every refresh — persist the new one or
+        // the next refresh replays a consumed token.
         refresh_token: response.data.refresh_token,
         expires_at: expiresAtFromJwt(accessToken, Date.now() + 3600_000),
       };
@@ -290,7 +348,8 @@ export class MeroJs {
     } catch (error) {
       // Don't clear tokens on refresh failure — the access token may still be
       // valid (server rejects refresh while access token hasn't expired yet).
-      // Let the caller handle the error.
+      // A genuinely dead family arrives as `x-auth-error: token_reuse` and is
+      // handled by the onAuthRevoked transport hook. Let the caller handle this.
       throw new Error(
         `Token refresh failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
@@ -301,6 +360,7 @@ export class MeroJs {
    * Clear the current token
    */
   public clearToken(): void {
+    this.refreshPromise = null;
     this.tokenData = null;
     this.tokenStore?.clear();
   }

--- a/tests/mocks/generated-handlers.ts
+++ b/tests/mocks/generated-handlers.ts
@@ -608,17 +608,7 @@ export const generatedHandlers = [
     });
   }),
 
-  // Get Signing Challenge
-  http.get('*/auth/challenge', () => {
-    return HttpResponse.json({
-      "data": {
-        "challenge": "challenge_string_to_sign",
-        "nonce": "random_nonce_xyz"
-      }
-    });
-  }),
-
-  // Exchange Challenge for Token
+  // Generate Token
   http.post('*/auth/token', () => {
     return HttpResponse.json({
       "data": {


### PR DESCRIPTION
## Why

[calimero-network/core#3083](https://github.com/calimero-network/core/pull/3083) makes refresh tokens **single-use**: every `POST /auth/refresh` consumes the presented refresh token and returns a new one. Re-presenting a consumed refresh token is treated as token theft — the server revokes the entire token family and replies `401` with header `x-auth-error: token_reuse`.

mero-js was not safe under that rule:

- `performTokenRefresh()` (the only path the HTTP transport actually calls on a 401) had **no** single-flight guard. The `refreshToken()` wrapper that held the `refreshPromise` mutex was dead code — nothing called it. `WebHttpClient` deduped concurrent 401s, but only *per client instance*, so two `MeroJs` instances / tabs / webviews sharing a token store could each POST the same refresh token → one of them gets `token_reuse` → family revoked → hard logout.
- Nothing anywhere handled `x-auth-error: token_reuse`. A revoked family surfaced as a generic `HTTPError`, indistinguishable from a transient 401, with stale tokens left in the store.

Also removes the last reference to `GET /auth/challenge`, whose route is deleted in [calimero-network/core#3229](https://github.com/calimero-network/core/pull/3229).

## Before → After

| | Before | After |
|---|---|---|
| Concurrent 401s in one instance | Deduped by `WebHttpClient` only | Deduped in `performTokenRefresh()` — every caller shares one in-flight refresh |
| `MeroJs.refreshToken()` mutex | Dead code; transport hook bypassed it | Removed; one guard, in `performTokenRefresh()` |
| Two instances / tabs / webviews | Each POSTs the same refresh token → `token_reuse` → family revoked | Serialized by `navigator.locks` (`mero-js:token-refresh`) when available; in-process promise otherwise |
| Token store vs. in-memory tokens | In-memory refresh token always used, even if stale | Store re-read **inside the lock**; a bundle another instance already rotated is adopted, and no `/auth/refresh` call is made at all |
| Rotated refresh token | Already persisted (kept) | Kept, plus persisted after the store re-read so the newest token always wins |
| `401 x-auth-error: token_reuse` | Unhandled — generic `HTTPError`, tokens kept | Terminal: no refresh, no retry, `onAuthRevoked` clears `tokenData` + token store, throws `AuthRevokedError` (`reason: 'token_reuse'`) |
| `403 / 401 x-auth-error: token_revoked` | 401 case fell through as a plain `HTTPError` | Same terminal path as `token_reuse` |
| `GET /auth/challenge` mock | Present in MSW handlers | Removed (route gone in core#3229) |

`AuthRevokedError extends HTTPError`, so existing `instanceof HTTPError` / `err.status` handling in apps keeps working; apps that want to force a re-login can now check `instanceof AuthRevokedError` (or `err.name === 'AuthRevokedError'` / `err.reason`).

### Changes

- `src/mero-js.ts` — `performTokenRefresh()` owns the single-flight promise, wraps the refresh in `withRefreshLock()` (`navigator.locks` when present, straight call otherwise), and `performTokenRefreshLocked()` re-reads the token store before POSTing: newer stored bundle → return it without calling `/auth/refresh`; otherwise POST with the freshest refresh token. Dead `refreshToken()` wrapper removed. New `onAuthRevoked` transport hook clears the bundle. Safe with no `tokenStore` configured (in-memory only).
- `src/http-client/web-client.ts` — new `AuthRevokedError`; `401`/`403` with `x-auth-error` in `{token_reuse, token_revoked}` short-circuits before the refresh path, drops the refresh caches, awaits `onAuthRevoked`, and throws.
- `src/http-client/http-types.ts`, `http-factory.ts`, `index.ts` — `onAuthRevoked?: () => Promise<void> | void` on `Transport` + all three factories; `AuthRevokedError` exported.
- `tests/mocks/generated-handlers.ts` — `GET /auth/challenge` mock removed. (`getChallenge()` / `ChallengeResponse` were already gone from `src/` as of the 7.0.0 auth-client rewrite.)

## How to test

```bash
pnpm install
pnpm build
pnpm test:unit   # 241 passed | 1 skipped
pnpm typecheck
pnpm lint
```

New tests:

`src/mero-js.test.ts` → `Single-use refresh token rotation (core#3083)`
- `should issue exactly one /auth/refresh call for concurrent 401 refreshes` (fails on `master`: two POSTs)
- `should persist the rotated refresh token to the token store`
- `should prefer the stored refresh token over a stale in-memory one`
- `should adopt a bundle another tab already rotated without calling /auth/refresh`
- `should serialize the refresh through navigator.locks when available`
- `should clear tokens when the transport reports a revoked token family`

`src/http-client/web-client.test.ts` → `Revoked Token Family (single-use refresh tokens)`
- `should not refresh or retry on 401 with x-auth-error: token_reuse`
- `should expose the auth error reason and stay an HTTPError`
- `should treat 403 token_revoked as terminal`
- `should surface the terminal error even without an onAuthRevoked hook`

No existing test was weakened or removed; the three `createBrowserHttpClient` call assertions were extended with the new `onAuthRevoked` hook.

## Compatibility

- **Apps must stop re-seeding tokens from a stale SSO hash.** With single-use refresh tokens, the stored bundle is the source of truth *after* the first rotation. An app that calls `setTokenData(...)` / writes the store from a URL hash (or any cached copy) captured at load time will overwrite a rotated bundle with a consumed refresh token — the next refresh then trips `token_reuse` and the family is revoked. Consume the SSO hash exactly once, on first load, and never re-apply it.
- Multiple `MeroJs` instances in one app should **share one `TokenStore`** — that's what lets the store re-read and the Web Lock keep them from racing each other.
- `navigator.locks` is only available in secure contexts; where it isn't (plain-http webviews, Node), the in-process promise still dedupes within the instance and the store re-read still prevents replaying a stale token in the common case.
- Purely additive API: `onAuthRevoked` is optional on the transport, and `AuthRevokedError` extends `HTTPError`.

Refs: calimero-network/core#3083, calimero-network/core#3229

🤖 Generated with [Claude Code](https://claude.com/claude-code)