### PR TITLE
fix(auth): adapt e2e/CI to core rc.17 admin-creds-at-init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,14 @@ permissions:
 
 env:
   NODE_VERSION: '20'
-  # core >= 0.11.0-rc.14 gates the FIRST root-key bootstrap behind an
-  # out-of-band secret (core#3221) and enforces an 8-char minimum password at
-  # creation (core#3081). The merod processes below inherit this env, and the
-  # SDK's authenticate() picks the same value up from the environment, so the
-  # first e2e login mints the root key transparently. CI-only value for
-  # ephemeral nodes.
-  MERO_AUTH_BOOTSTRAP_SECRET: mero-js-e2e-bootstrap
+  # core >= 0.11.0-rc.17 removed the first-login bootstrap secret: a node mints
+  # its admin root key at `merod init` (or at startup when unbootstrapped) from
+  # these env vars, and enforces an 8-char minimum password at creation
+  # (core#3081). The `merod init` steps below inherit this env, so the admin
+  # account exists before the node listens, and the e2e login (same creds, via
+  # MERO_E2E_USER/PASS) signs straight in. CI-only values for ephemeral nodes.
+  MERO_AUTH_ADMIN_USER: dev
+  MERO_AUTH_ADMIN_PASSWORD: dev-password
 
 jobs:
   build-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ permissions:
 
 env:
   NODE_VERSION: '20'
+  # core >= 0.11.0-rc.14 gates the FIRST root-key bootstrap behind an
+  # out-of-band secret (core#3221) and enforces an 8-char minimum password at
+  # creation (core#3081). The merod processes below inherit this env, and the
+  # SDK's authenticate() picks the same value up from the environment, so the
+  # first e2e login mints the root key transparently. CI-only value for
+  # ephemeral nodes.
+  MERO_AUTH_BOOTSTRAP_SECRET: mero-js-e2e-bootstrap
 
 jobs:
   build-and-test:
@@ -80,7 +87,7 @@ jobs:
         env:
           NODE_URL: http://localhost:4001
           MERO_E2E_USER: dev
-          MERO_E2E_PASS: dev
+          MERO_E2E_PASS: dev-password
           NO_COLOR: '1'
         run: |
           set -o pipefail
@@ -149,7 +156,7 @@ jobs:
           MERO_NODE1_URL: http://localhost:4501
           MERO_NODE2_URL: http://localhost:4502
           MERO_E2E_USER: dev
-          MERO_E2E_PASS: dev
+          MERO_E2E_PASS: dev-password
           NO_COLOR: '1'
         run: |
           set -o pipefail

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calimero-network/mero-js",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Pure JavaScript SDK for Calimero",
   "type": "module",
   "exports": {
@@ -16,7 +16,6 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "sideEffects": false,
-  "dependencies": {},
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.0",
@@ -25,10 +24,10 @@
     "@semantic-release/github": "^9.2.6",
     "@semantic-release/npm": "^12.0.1",
     "@semantic-release/release-notes-generator": "^12.1.0",
-    "conventional-changelog-conventionalcommits": "^7.0.0",
     "@types/node": "^18.19.34",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
+    "conventional-changelog-conventionalcommits": "^7.0.0",
     "esbuild": "^0.28.1",
     "eslint": "^8.57.0",
     "rimraf": "^3.0.0",

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -18,6 +18,15 @@ export interface MeroJsConfig {
   credentials?: {
     username: string;
     password: string;
+    /**
+     * First-login setup code (bootstrap secret, core#3221). Since core
+     * 0.11.0-rc.14 a fresh node only mints its first root key when the login
+     * presents this out-of-band secret — merod prints it at startup and
+     * stores it in the node's config.toml (core#3270). Only consulted on the
+     * very first login of a fresh node; once an account exists the node
+     * ignores it, so it is always safe to include.
+     */
+    bootstrap_secret?: string;
   };
   /** Custom HTTP client timeout in milliseconds */
   timeoutMs?: number;
@@ -213,11 +222,24 @@ export class MeroJs {
   async authenticate(credentials?: {
     username: string;
     password: string;
+    bootstrap_secret?: string;
   }): Promise<TokenData> {
     const creds = credentials || this.config.credentials;
     if (!creds) {
       throw new Error('No credentials provided for authentication');
     }
+
+    // First-login setup code (core#3221): explicit credential wins, then the
+    // MERO_AUTH_BOOTSTRAP_SECRET env var when running under Node (test
+    // harnesses launch merod with the same env, so the pair stays in sync).
+    // Omitted entirely when absent — the request is then byte-identical to
+    // the pre-rc.14 shape.
+    const bootstrapSecret =
+      creds.bootstrap_secret ||
+      (typeof process !== 'undefined'
+        ? process.env?.MERO_AUTH_BOOTSTRAP_SECRET
+        : undefined) ||
+      undefined;
 
     try {
       const requestBody = {
@@ -229,6 +251,7 @@ export class MeroJs {
         provider_data: {
           username: creds.username,
           password: creds.password,
+          ...(bootstrapSecret ? { bootstrap_secret: bootstrapSecret } : {}),
         },
       };
 

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -18,15 +18,6 @@ export interface MeroJsConfig {
   credentials?: {
     username: string;
     password: string;
-    /**
-     * First-login setup code (bootstrap secret, core#3221). Since core
-     * 0.11.0-rc.14 a fresh node only mints its first root key when the login
-     * presents this out-of-band secret — merod prints it at startup and
-     * stores it in the node's config.toml (core#3270). Only consulted on the
-     * very first login of a fresh node; once an account exists the node
-     * ignores it, so it is always safe to include.
-     */
-    bootstrap_secret?: string;
   };
   /** Custom HTTP client timeout in milliseconds */
   timeoutMs?: number;
@@ -222,24 +213,11 @@ export class MeroJs {
   async authenticate(credentials?: {
     username: string;
     password: string;
-    bootstrap_secret?: string;
   }): Promise<TokenData> {
     const creds = credentials || this.config.credentials;
     if (!creds) {
       throw new Error('No credentials provided for authentication');
     }
-
-    // First-login setup code (core#3221): explicit credential wins, then the
-    // MERO_AUTH_BOOTSTRAP_SECRET env var when running under Node (test
-    // harnesses launch merod with the same env, so the pair stays in sync).
-    // Omitted entirely when absent — the request is then byte-identical to
-    // the pre-rc.14 shape.
-    const bootstrapSecret =
-      creds.bootstrap_secret ||
-      (typeof process !== 'undefined'
-        ? process.env?.MERO_AUTH_BOOTSTRAP_SECRET
-        : undefined) ||
-      undefined;
 
     try {
       const requestBody = {
@@ -251,7 +229,6 @@ export class MeroJs {
         provider_data: {
           username: creds.username,
           password: creds.password,
-          ...(bootstrapSecret ? { bootstrap_secret: bootstrapSecret } : {}),
         },
       };
 

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -49,12 +49,30 @@ export function resolveBaseUrl(): string {
   );
 }
 
-/** Credentials for the e2e suite, overridable via env (default dev/dev). */
+/**
+ * Credentials for the e2e suite, overridable via env. The default password is
+ * 8+ chars because core >= 0.11.0-rc.14 enforces a minimum password length
+ * when the account is created (core#3081).
+ */
 export function resolveCreds(): { username: string; password: string } {
   return {
     username: process.env.MERO_E2E_USER || 'dev',
-    password: process.env.MERO_E2E_PASS || 'dev',
+    password: process.env.MERO_E2E_PASS || 'dev-password',
   };
+}
+
+/**
+ * First-login setup code for fresh nodes (core#3221, >= 0.11.0-rc.14). When
+ * the harness spawns the node itself, default a CI-grade throwaway value and
+ * export it so BOTH sides agree: the spawned merod/merobox child inherits
+ * process.env, and the SDK's authenticate() reads the same variable. When
+ * attaching to an injected node (NODE_BASE_URL), the caller controls the env
+ * and no default is forced — the operator's own value (or none) wins.
+ */
+export function ensureBootstrapSecretEnv(): void {
+  if (!usingInjectedNode() && !process.env.MERO_AUTH_BOOTSTRAP_SECRET) {
+    process.env.MERO_AUTH_BOOTSTRAP_SECRET = 'mero-js-e2e-local-bootstrap';
+  }
 }
 
 /** True when an external node is already running and the suite must not spawn one. */
@@ -78,6 +96,10 @@ export async function startNode(opts?: { waitMs?: number }): Promise<StartedNode
   if (usingInjectedNode()) {
     return { baseUrl, stop: async () => {} };
   }
+
+  // Spawned nodes inherit this env, and authenticate() reads the same
+  // variable — first login on the fresh node then bootstraps transparently.
+  ensureBootstrapSecretEnv();
 
   const { spawn } = await import('child_process');
   const merodBinary = process.env.MEROD_BINARY;

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -62,17 +62,19 @@ export function resolveCreds(): { username: string; password: string } {
 }
 
 /**
- * First-login setup code for fresh nodes (core#3221, >= 0.11.0-rc.14). When
- * the harness spawns the node itself, default a CI-grade throwaway value and
- * export it so BOTH sides agree: the spawned merod/merobox child inherits
- * process.env, and the SDK's authenticate() reads the same variable. When
- * attaching to an injected node (NODE_BASE_URL), the caller controls the env
- * and no default is forced — the operator's own value (or none) wins.
+ * Admin account provisioning for fresh nodes (core >= 0.11.0-rc.17). The
+ * bootstrap secret is gone: a node now mints its admin root key at startup from
+ * MERO_AUTH_ADMIN_USER/MERO_AUTH_ADMIN_PASSWORD when it has no account yet
+ * (provision-if-unbootstrapped). When the harness spawns the node itself,
+ * default these to the e2e credentials so the fresh node provisions exactly the
+ * account authenticate() will log in with. When attaching to an injected node
+ * (NODE_BASE_URL), the caller controls provisioning and no default is forced.
  */
-export function ensureBootstrapSecretEnv(): void {
-  if (!usingInjectedNode() && !process.env.MERO_AUTH_BOOTSTRAP_SECRET) {
-    process.env.MERO_AUTH_BOOTSTRAP_SECRET = 'mero-js-e2e-local-bootstrap';
-  }
+export function ensureAdminCredsEnv(): void {
+  if (usingInjectedNode()) return;
+  const { username, password } = resolveCreds();
+  process.env.MERO_AUTH_ADMIN_USER ??= username;
+  process.env.MERO_AUTH_ADMIN_PASSWORD ??= password;
 }
 
 /** True when an external node is already running and the suite must not spawn one. */
@@ -97,9 +99,9 @@ export async function startNode(opts?: { waitMs?: number }): Promise<StartedNode
     return { baseUrl, stop: async () => {} };
   }
 
-  // Spawned nodes inherit this env, and authenticate() reads the same
-  // variable — first login on the fresh node then bootstraps transparently.
-  ensureBootstrapSecretEnv();
+  // Spawned nodes inherit this env; a fresh rc.17 node mints its admin from it
+  // at startup, so the first authenticate() with the same creds succeeds.
+  ensureAdminCredsEnv();
 
   const { spawn } = await import('child_process');
   const merodBinary = process.env.MEROD_BINARY;


### PR DESCRIPTION
## Problem

core **rc.17** (calimero-network/core#3276) removed the first-login bootstrap secret entirely. A fresh node now mints its admin root key at `merod init` (or at startup when unbootstrapped) from `MERO_AUTH_ADMIN_USER`/`MERO_AUTH_ADMIN_PASSWORD`, and the login path is plain username/password again. This PR was originally the rc.14 bootstrap-secret support; it is now reworked to the rc.17 model so this repo's e2e/multinode CI (which downloads the latest released merod, now rc.17) is green.

## Change

- **src/mero-js.ts**: drop the now-dead `bootstrap_secret` from `MeroJsConfig.credentials` and `authenticate()`. The login request is back to the plain pre-rc.14 shape.
- **tests/e2e/harness.ts**: `ensureBootstrapSecretEnv` → `ensureAdminCredsEnv`. When the harness spawns the node, default `MERO_AUTH_ADMIN_USER`/`MERO_AUTH_ADMIN_PASSWORD` to the e2e creds so the fresh node provisions exactly the account `authenticate()` logs in with. Injected nodes (`NODE_BASE_URL`) are the caller's responsibility.
- **ci.yml**: swap `MERO_AUTH_BOOTSTRAP_SECRET` for `MERO_AUTH_ADMIN_USER`/`MERO_AUTH_ADMIN_PASSWORD` so the `merod init --auth-mode embedded` steps mint the admin before the node listens. The download step already pulls the latest core release (now rc.17). Kept the 8-char `dev-password`.
- bump `7.0.1 → 7.0.2`.

## Verified

Local: `pnpm build`, `typecheck`, `lint`, `test:unit` all green. e2e + multinode run in CI against the released rc.17 merod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)