### PR TITLE
fix(admin): SemVer 2.0 compareSemver, hardened registry fetches, forceCodeOnly passthrough

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -125,14 +125,67 @@ describe('AdminApiClient', () => {
       }
     });
 
-    it('installFromRegistry throws on a registry error', async () => {
+    it('installFromRegistry throws on a registry error and does not retry a 4xx', async () => {
       const origFetch = globalThis.fetch;
-      globalThis.fetch = (async () =>
-        ({ ok: false, status: 404, json: async () => ({}) }) as Response) as typeof fetch;
+      let calls = 0;
+      globalThis.fetch = (async () => {
+        calls++;
+        return { ok: false, status: 404, json: async () => ({}) } as Response;
+      }) as typeof fetch;
       try {
         await expect(
           client.installFromRegistry('https://registry.example.com', 'missing', '9.9.9'),
         ).rejects.toThrow(/registry manifest fetch failed \(404\)/);
+        // A 4xx is a definitive answer — no retry.
+        expect(calls).toBe(1);
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
+    it('getRegistryVersions retries a 5xx then succeeds', async () => {
+      const origFetch = globalThis.fetch;
+      let calls = 0;
+      globalThis.fetch = (async () => {
+        calls++;
+        if (calls === 1) {
+          return { ok: false, status: 503, json: async () => ({}) } as Response;
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [{ package: 'com.acme.app', appVersion: '1.0.0' }],
+        } as Response;
+      }) as typeof fetch;
+      try {
+        const versions = await client.getRegistryVersions(
+          'https://registry.example.com',
+          'com.acme.app',
+        );
+        expect(versions).toEqual(['1.0.0']);
+        expect(calls).toBe(2);
+      } finally {
+        globalThis.fetch = origFetch;
+      }
+    });
+
+    it('getRegistryVersions passes an abort signal and surfaces a timeout', async () => {
+      const origFetch = globalThis.fetch;
+      let calls = 0;
+      let sawSignal = false;
+      globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+        calls++;
+        sawSignal = init?.signal instanceof AbortSignal;
+        // A per-attempt timeout aborts the fetch with a TimeoutError; simulate it.
+        throw new DOMException('The operation timed out', 'TimeoutError');
+      }) as typeof fetch;
+      try {
+        await expect(
+          client.getRegistryVersions('https://registry.example.com', 'com.acme.app'),
+        ).rejects.toThrow(/timed out/i);
+        expect(sawSignal).toBe(true);
+        // A timeout is transient — retried up to the 3-attempt ceiling.
+        expect(calls).toBe(3);
       } finally {
         globalThis.fetch = origFetch;
       }

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1206,4 +1206,40 @@ describe('compareSemver', () => {
     expect(compareSemver('1.2.3', '1.2.3')).toBe(0);
     expect(compareSemver('1.2', '1.2.0')).toBe(0);
   });
+
+  it('ranks a pre-release below its release', () => {
+    expect(compareSemver('1.0.0-rc.1', '1.0.0')).toBeLessThan(0);
+    expect(compareSemver('1.0.0', '1.0.0-rc.1')).toBeGreaterThan(0);
+    // Core ships versions like 0.11.0-rc.17 — these must sort below 0.11.0.
+    expect(compareSemver('0.11.0-rc.17', '0.11.0')).toBeLessThan(0);
+  });
+
+  it('orders the SemVer 2.0 pre-release precedence chain', () => {
+    const chain = [
+      '1.0.0-alpha',
+      '1.0.0-alpha.1',
+      '1.0.0-alpha.beta',
+      '1.0.0-beta',
+      '1.0.0-beta.2',
+      '1.0.0-beta.11',
+      '1.0.0-rc.1',
+      '1.0.0',
+    ];
+    for (let i = 0; i < chain.length - 1; i++) {
+      expect(compareSemver(chain[i], chain[i + 1])).toBeLessThan(0);
+      expect(compareSemver(chain[i + 1], chain[i])).toBeGreaterThan(0);
+    }
+  });
+
+  it('ignores build metadata for precedence', () => {
+    expect(compareSemver('1.0.0+build', '1.0.0')).toBe(0);
+    expect(compareSemver('1.0.0+build.1', '1.0.0+build.2')).toBe(0);
+    expect(compareSemver('1.0.0-rc.1+build', '1.0.0-rc.1')).toBe(0);
+  });
+
+  it('does not throw on loose/malformed input', () => {
+    expect(() => compareSemver('latest', '1.0.0')).not.toThrow();
+    expect(() => compareSemver('', '')).not.toThrow();
+    expect(compareSemver('', '')).toBe(0);
+  });
 });

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -998,6 +998,21 @@ describe('AdminApiClient', () => {
       });
     });
 
+    it('upgradeGroup forwards forceCodeOnly for an ABI-less code-only upgrade', async () => {
+      mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
+        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+      });
+      await client.upgradeGroup('g-1', {
+        targetApplicationId: 'app-2',
+        forceCodeOnly: true,
+      });
+      // camelCase passthrough — the field reaches the wire body verbatim.
+      expect(mock.getRequestBody('POST', '/admin-api/groups/g-1/upgrade')).toEqual({
+        targetApplicationId: 'app-2',
+        forceCodeOnly: true,
+      });
+    });
+
     it('getGroupUpgradeStatus returns status', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g-1/upgrade/status', {
         data: { fromVersion: '1.0', toVersion: '2.0', initiatedAt: 123, initiatedBy: 'pk-1', status: 'completed', total: 3, completed: 3, failed: 0, completedAt: 456 },

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '../http-client';
+import { HttpClient, withRetry } from '../http-client';
 import type {
   HealthStatus,
   AdminAuthStatus,
@@ -181,6 +181,33 @@ function compareSemverId(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+/**
+ * Fetch a URL from the (foreign-origin) registry with a per-attempt timeout and
+ * retry on transient failures. Deliberately NOT routed through the node
+ * `HttpClient`: that client attaches the node's bearer token to every request,
+ * which must never leak to the registry's origin. Each attempt times out after
+ * ~10s; network errors and 5xx are retried (2 retries, short backoff via the
+ * shared `withRetry`), while a 4xx is a definitive answer and is not retried.
+ * `kind`/`context` shape the error message so failures stay debuggable in logs.
+ */
+async function fetchRegistry(url: string, kind: string, context: string): Promise<Response> {
+  return withRetry(
+    async () => {
+      const resp = await fetch(url, { signal: AbortSignal.timeout(10000) });
+      if (!resp.ok) {
+        // Carry `status` so withRetry retries 5xx but leaves 4xx to throw.
+        const err = new Error(
+          `registry ${kind} fetch failed (${resp.status}) for ${context}`,
+        ) as Error & { status: number };
+        err.status = resp.status;
+        throw err;
+      }
+      return resp;
+    },
+    { attempts: 3 },
+  );
+}
+
 export class AdminApiClient {
   constructor(private httpClient: HttpClient) {}
 
@@ -218,12 +245,7 @@ export class AdminApiClient {
       `/api/v2/bundles/${encodeURIComponent(packageName)}/${encodeURIComponent(version)}`,
       base,
     ).toString();
-    const resp = await fetch(manifestUrl);
-    if (!resp.ok) {
-      throw new Error(
-        `registry manifest fetch failed (${resp.status}) for ${packageName}@${version}`,
-      );
-    }
+    const resp = await fetchRegistry(manifestUrl, 'manifest', `${packageName}@${version}`);
     const bundle = (await resp.json()) as RegistryBundleManifest;
     // Encode the path segments — the package/version come from a (best-effort
     // trusted) registry response, so guard against odd characters breaking or
@@ -250,12 +272,7 @@ export class AdminApiClient {
   async getRegistryVersions(registryUrl: string, packageName: string): Promise<string[]> {
     const url = new URL('/api/v2/bundles', new URL(registryUrl).origin);
     url.searchParams.set('package', packageName);
-    const resp = await fetch(url.toString());
-    if (!resp.ok) {
-      throw new Error(
-        `registry versions fetch failed (${resp.status}) for ${packageName}`,
-      );
-    }
+    const resp = await fetchRegistry(url.toString(), 'versions', packageName);
     const bundles = (await resp.json()) as RegistryBundleManifest[];
     return (Array.isArray(bundles) ? bundles : [])
       .map((b) => b.appVersion)

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -118,28 +118,67 @@ function unwrap<T>(response: { data: T }): T {
 }
 
 /**
- * Compare two dotted version strings, ascending: negative if `a < b`, positive
- * if `a > b`, `0` if equal. Components are compared numerically when both parse
- * as integers (so `1.10.0 > 1.9.0`), else lexically; a missing component is `0`.
- * Minimal by design — sufficient for the `major.minor.patch` registry versions.
+ * Compare two version strings by SemVer 2.0 precedence, ascending: negative if
+ * `a < b`, positive if `a > b`, `0` if equal. Build metadata (`+...`) is stripped
+ * and ignored. The numeric `major.minor.patch` core is compared field-by-field
+ * (numerically when both parse, so `1.10.0 > 1.9.0`; a missing field is `0`). A
+ * version WITH a pre-release ranks below the same core without one, and
+ * pre-release identifiers compare per spec: dot-separated, numeric identifiers
+ * numerically, alphanumeric lexically by ASCII, numeric below alphanumeric, and a
+ * shorter set of identifiers loses when all preceding fields are equal.
  */
 export function compareSemver(a: string, b: string): number {
-  const pa = a.split('.');
-  const pb = b.split('.');
-  const n = Math.max(pa.length, pb.length);
+  const [coreA, preA] = splitVersion(a);
+  const [coreB, preB] = splitVersion(b);
+
+  const na = coreA.split('.');
+  const nb = coreB.split('.');
+  const n = Math.max(na.length, nb.length);
   for (let i = 0; i < n; i++) {
-    const sa = pa[i] ?? '0';
-    const sb = pb[i] ?? '0';
-    const na = Number.parseInt(sa, 10);
-    const nb = Number.parseInt(sb, 10);
-    if (Number.isNaN(na) || Number.isNaN(nb)) {
-      const c = sa.localeCompare(sb);
-      if (c !== 0) return c;
-    } else if (na !== nb) {
-      return na - nb;
-    }
+    const c = compareSemverId(na[i] ?? '0', nb[i] ?? '0');
+    if (c !== 0) return c;
+  }
+
+  // A pre-release ranks below the same core version with no pre-release.
+  if (preA === undefined && preB === undefined) return 0;
+  if (preA === undefined) return 1;
+  if (preB === undefined) return -1;
+
+  const pa = preA.split('.');
+  const pb = preB.split('.');
+  const m = Math.max(pa.length, pb.length);
+  for (let i = 0; i < m; i++) {
+    if (i >= pa.length) return -1; // shorter set loses when all preceding equal
+    if (i >= pb.length) return 1;
+    const c = compareSemverId(pa[i], pb[i]);
+    if (c !== 0) return c;
   }
   return 0;
+}
+
+/** Drop build metadata and split the pre-release tail: `1.2.3-rc.1+b` -> `['1.2.3', 'rc.1']`. */
+function splitVersion(v: string): [string, string | undefined] {
+  const core = v.split('+', 1)[0];
+  const dash = core.indexOf('-');
+  return dash === -1 ? [core, undefined] : [core.slice(0, dash), core.slice(dash + 1)];
+}
+
+/**
+ * Compare one identifier: numerically when both are all-digits, else lexically by
+ * ASCII with a numeric identifier ranking below an alphanumeric one. Fallback: a
+ * non-numeric core component (loose/malformed input) is treated as a string, so
+ * comparison never throws.
+ */
+function compareSemverId(a: string, b: string): number {
+  const na = /^\d+$/.test(a);
+  const nb = /^\d+$/.test(b);
+  if (na && nb) {
+    const d = Number(a) - Number(b);
+    return d < 0 ? -1 : d > 0 ? 1 : 0;
+  }
+  if (na) return -1;
+  if (nb) return 1;
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 export class AdminApiClient {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -739,9 +739,15 @@ export interface UpgradeGroupRequest {
   requester?: string;
   /** Fan the upgrade out to every descendant subgroup running the same app
    *  (one atomic cascade op). Without it the upgrade applies to the target
-   *  group only — members' subgroups never learn the migration. Server
+   *  group only - members' subgroups never learn the migration. Server
    *  default: false. */
   cascade?: boolean;
+  /** Proceed code-only when the target build embeds no ABI. Core refuses such an
+   *  upgrade by default; setting this asserts the new code is layout-compatible
+   *  with the running state so the upgrade goes ahead. It never bypasses a
+   *  declared-migration or downgrade refusal. Wire name is camelCase passthrough;
+   *  older nodes ignore the unknown field. Server default: false. */
+  forceCodeOnly?: boolean;
 }
 
 export interface UpgradeGroupResponseData {


### PR DESCRIPTION
## Summary

Three fixes to the app-update surface, found while rebuilding mero-drive's Updates admin panel on this SDK.

1. **`compareSemver` now implements SemVer 2.0 precedence.**
   The previous minimal comparator mis-ranked pre-releases: `parseInt('0-rc', 10)` parses as `0`, so `1.0.0-rc.1` compared *greater* than `1.0.0`, inverting `updateAvailable` logic downstream.
   Core currently publishes `0.11.0-rc.N` versions, so this was live.
   Build metadata (`+...`) is stripped and ignored; pre-release identifier chains compare per spec (numeric vs alphanumeric, shorter-set-loses); malformed input falls back to string comparison and never throws.

2. **Registry fetches get a bounded timeout and retry.**
   `getRegistryVersions` and `installFromRegistry` used bare `fetch` with no timeout or retry.
   They now go through a small helper using the shared `withRetry` (10s per-attempt `AbortSignal.timeout`, retries on timeout/5xx/network errors, never on 4xx).
   Deliberately NOT routed through the node `HttpClient`: that client attaches the node's bearer token to every request, which must not leak to the registry's separate origin.

3. **`UpgradeGroupRequest.forceCodeOnly` passthrough (optional).**
   Matches the field core adds in calimero-network/core#3286: proceed code-only when the target build embeds no ABI (the operator asserts layout compatibility).
   Older nodes ignore the unknown field.

## Test plan

- New/extended unit tests: the SemVer spec precedence chain (`1.0.0-alpha < ... < 1.0.0-rc.1 < 1.0.0`), build-metadata equality, existing numeric cases; registry fetch timeout aborts, 5xx retries then succeeds, 4xx does not retry.
- Full suite: 248 passed, 1 skipped. Lint clean. Build clean.
