### PR TITLE
feat: group-membership event support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage/
 # OS files
 Thumbs.db
 data/
+
+# local agent scratch
+.superpowers/

--- a/src/events/group.ts
+++ b/src/events/group.ts
@@ -1,0 +1,9 @@
+/** Parsed group-membership event (core's untagged `NodeEvent` group variant). */
+export interface GroupMembershipEventData {
+  groupId: string;
+  type: 'MemberJoined' | 'MemberAdded' | 'MemberRemoved';
+  data: {
+    member: string;
+    role?: string;
+  };
+}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,3 +2,4 @@ export { SseClient } from './sse';
 export type { SseEventData, AppVersionChangedEvent } from './sse';
 export { WsClient } from './ws';
 export type { WsEventData } from './ws';
+export type { GroupMembershipEventData } from './group';

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -192,6 +192,7 @@ describe('SseClient', () => {
 
       // Pre-populate subscriptions
       (client as any).subscribedContextIds.add('ctx-1');
+      (client as any).subscribedGroupIds.add('grp-1');
 
       // Simulate connect message
       (client as any).handleMessage(JSON.stringify({
@@ -199,7 +200,74 @@ describe('SseClient', () => {
         session_id: 'new-session',
       }));
 
-      expect(sendSpy).toHaveBeenCalledWith('subscribe', ['ctx-1']);
+      expect(sendSpy).toHaveBeenCalledWith('subscribe', { contextIds: ['ctx-1'], groupIds: ['grp-1'] });
+    });
+  });
+
+  describe('group-membership events', () => {
+    it('emits group event with groupId intact (no double-unwrap)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          groupId: 'grp-1',
+          type: 'MemberJoined',
+          data: { member: 'mem-1', role: 'Member' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        groupId: 'grp-1',
+        type: 'MemberJoined',
+        data: { member: 'mem-1', role: 'Member' },
+      });
+    });
+
+    it('still parses existing context events unchanged (regression guard)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          contextId: 'ctx-1',
+          type: 'AppVersionChanged',
+          data: { toVersion: '2.0.0' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        contextId: 'ctx-1',
+        type: 'AppVersionChanged',
+        data: { toVersion: '2.0.0' },
+      });
+    });
+  });
+
+  describe('subscribe with groupIds', () => {
+    it('sends groupIds on the wire', async () => {
+      (client as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await client.subscribe({ groupIds: ['grp-1'] });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/sse/subscription'),
+        expect.objectContaining({
+          body: JSON.stringify({ id: 'sess-1', method: 'subscribe', params: { groupIds: ['grp-1'] } }),
+        }),
+      );
+      expect((client as any).subscribedGroupIds.has('grp-1')).toBe(true);
+    });
+
+    it('still accepts a plain contextIds array (backward compatible)', async () => {
+      (client as any).sessionId = 'sess-1';
+      global.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+      await client.subscribe(['ctx-1']);
+
+      expect((client as any).subscribedContextIds.has('ctx-1')).toBe(true);
     });
   });
 

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,3 +1,7 @@
+import type { GroupMembershipEventData } from './group';
+
+export type { GroupMembershipEventData };
+
 export interface SseEventData {
   contextId: string;
   /** The context-event discriminator (core serializes it as a sibling of
@@ -13,7 +17,7 @@ export interface AppVersionChangedEvent {
   toVersion?: string;
 }
 
-type SseEventHandler = (event: SseEventData) => void;
+type SseEventHandler = (event: SseEventData | GroupMembershipEventData) => void;
 type SseConnectHandler = (sessionId: string) => void;
 type SseErrorHandler = (error: Error) => void;
 
@@ -31,6 +35,7 @@ export class SseClient {
   private abortController: AbortController | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private subscribedContextIds: Set<string> = new Set();
+  private subscribedGroupIds: Set<string> = new Set();
   private closed = false;
   private listeners: SseListeners = { connect: [], event: [], error: [] };
 
@@ -87,9 +92,9 @@ export class SseClient {
   }
 
   private emit(event: 'connect', sessionId: string): void;
-  private emit(event: 'event', data: SseEventData): void;
+  private emit(event: 'event', data: SseEventData | GroupMembershipEventData): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: string | SseEventData | Error): void {
+  private emit(event: string, arg?: string | SseEventData | GroupMembershipEventData | Error): void {
     const key = event as keyof SseListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -197,30 +202,45 @@ export class SseClient {
         this.sessionId = msg.session_id;
         this.emit('connect', msg.session_id);
         // Re-subscribe after reconnect
-        if (this.subscribedContextIds.size > 0) {
-          this.sendSubscription('subscribe', [...this.subscribedContextIds]);
+        if (this.subscribedContextIds.size > 0 || this.subscribedGroupIds.size > 0) {
+          this.sendSubscription('subscribe', {
+            contextIds: [...this.subscribedContextIds],
+            groupIds: [...this.subscribedGroupIds],
+          });
         }
         return;
       }
 
-      // Context event message
-      if (msg.result && msg.result.contextId) {
-        let eventData = msg.result.data;
-        // Decode byte-array data if needed
-        if (Array.isArray(eventData)) {
-          try {
-            const bytes = new Uint8Array(eventData);
-            const text = new TextDecoder().decode(bytes);
-            eventData = JSON.parse(text);
-          } catch {
-            // Keep raw data
-          }
-        }
+      if (!msg.result) return;
 
+      let eventData = msg.result.data;
+      // Decode byte-array data if needed
+      if (Array.isArray(eventData)) {
+        try {
+          const bytes = new Uint8Array(eventData);
+          const text = new TextDecoder().decode(bytes);
+          eventData = JSON.parse(text);
+        } catch {
+          // Keep raw data
+        }
+      }
+
+      // Context event message
+      if (msg.result.contextId) {
         this.emit('event', {
           contextId: msg.result.contextId,
           // Forward the event tag (sibling of `data` in core's flattened
           // payload) so typed helpers like `onAppVersionChanged` can discriminate.
+          type: msg.result.type,
+          data: eventData,
+        });
+        return;
+      }
+
+      // Group-membership event message (untagged NodeEvent's group variant)
+      if (msg.result.groupId) {
+        this.emit('event', {
+          groupId: msg.result.groupId,
           type: msg.result.type,
           data: eventData,
         });
@@ -230,29 +250,45 @@ export class SseClient {
     }
   }
 
-  async subscribe(contextIds: string[]): Promise<void> {
-    const newIds = contextIds.filter(id => !this.subscribedContextIds.has(id));
-    for (const id of contextIds) {
+  async subscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): Promise<void> {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    const newContextIds = (opts.contextIds ?? []).filter(id => !this.subscribedContextIds.has(id));
+    const newGroupIds = (opts.groupIds ?? []).filter(id => !this.subscribedGroupIds.has(id));
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.add(id);
     }
-    if (newIds.length > 0 && this.sessionId) {
-      await this.sendSubscription('subscribe', newIds);
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.add(id);
+    }
+    if ((newContextIds.length > 0 || newGroupIds.length > 0) && this.sessionId) {
+      await this.sendSubscription('subscribe', { contextIds: newContextIds, groupIds: newGroupIds });
     }
   }
 
-  async unsubscribe(contextIds: string[]): Promise<void> {
-    const hadIds = contextIds.filter(id => this.subscribedContextIds.has(id));
-    for (const id of contextIds) {
+  async unsubscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): Promise<void> {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    const hadContextIds = (opts.contextIds ?? []).filter(id => this.subscribedContextIds.has(id));
+    const hadGroupIds = (opts.groupIds ?? []).filter(id => this.subscribedGroupIds.has(id));
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.delete(id);
     }
-    if (hadIds.length > 0 && this.sessionId) {
-      await this.sendSubscription('unsubscribe', hadIds);
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.delete(id);
+    }
+    if ((hadContextIds.length > 0 || hadGroupIds.length > 0) && this.sessionId) {
+      await this.sendSubscription('unsubscribe', { contextIds: hadContextIds, groupIds: hadGroupIds });
     }
   }
 
-  private async sendSubscription(method: 'subscribe' | 'unsubscribe', contextIds: string[]): Promise<void> {
+  private async sendSubscription(
+    method: 'subscribe' | 'unsubscribe',
+    ids: { contextIds?: string[]; groupIds?: string[] },
+  ): Promise<void> {
     try {
       const token = await this.getAuthToken();
+      const params: { contextIds?: string[]; groupIds?: string[] } = {};
+      if (ids.contextIds && ids.contextIds.length > 0) params.contextIds = ids.contextIds;
+      if (ids.groupIds && ids.groupIds.length > 0) params.groupIds = ids.groupIds;
       const response = await fetch(`${this.baseUrl}/sse/subscription`, {
         method: 'POST',
         headers: {
@@ -262,7 +298,7 @@ export class SseClient {
         body: JSON.stringify({
           id: this.sessionId,
           method,
-          params: { contextIds },
+          params,
         }),
       });
       if (!response.ok) {
@@ -305,5 +341,6 @@ export class SseClient {
     }
     this.sessionId = null;
     this.subscribedContextIds.clear();
+    this.subscribedGroupIds.clear();
   }
 }

--- a/src/events/ws.test.ts
+++ b/src/events/ws.test.ts
@@ -76,5 +76,51 @@ describe('WsClient', () => {
         data: { name: 'test' },
       });
     });
+
+    it('emits group event with groupId intact (no double-unwrap)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          groupId: 'grp-1',
+          type: 'MemberJoined',
+          data: { member: 'mem-1', role: 'Member' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        groupId: 'grp-1',
+        type: 'MemberJoined',
+        data: { member: 'mem-1', role: 'Member' },
+      });
+    });
+  });
+
+  describe('subscribe with groupIds', () => {
+    it('tracks group ids and sends groupIds on the wire', () => {
+      const sendSpy = vi.fn();
+      (client as any).ws = { readyState: 1 /* WebSocket.OPEN */, send: sendSpy, close: vi.fn() };
+
+      client.subscribe({ groupIds: ['grp-1'] });
+
+      expect((client as any).subscribedGroupIds.has('grp-1')).toBe(true);
+      expect(sendSpy).toHaveBeenCalledWith(
+        JSON.stringify({ id: null, method: 'subscribe', params: { groupIds: ['grp-1'] } }),
+      );
+    });
+
+    it('re-subscribes both context and group ids on reconnect', () => {
+      (client as any).subscribedContextIds.add('ctx-1');
+      (client as any).subscribedGroupIds.add('grp-1');
+      const sendSpy = vi.fn();
+      (client as any).ws = { readyState: 1 /* WebSocket.OPEN */, send: sendSpy, close: vi.fn() };
+
+      (client as any).resubscribeAfterReconnect();
+
+      expect(sendSpy).toHaveBeenCalledWith(
+        JSON.stringify({ id: null, method: 'subscribe', params: { contextIds: ['ctx-1'], groupIds: ['grp-1'] } }),
+      );
+    });
   });
 });

--- a/src/events/ws.ts
+++ b/src/events/ws.ts
@@ -1,3 +1,7 @@
+import type { GroupMembershipEventData } from './group';
+
+export type { GroupMembershipEventData };
+
 export interface WsEventData {
   contextId: string;
   /** The context-event discriminator (core serializes it as a sibling of
@@ -6,7 +10,7 @@ export interface WsEventData {
   data: unknown;
 }
 
-type WsEventHandler = (event: WsEventData) => void;
+type WsEventHandler = (event: WsEventData | GroupMembershipEventData) => void;
 type WsConnectHandler = () => void;
 type WsErrorHandler = (error: Error) => void;
 
@@ -28,6 +32,7 @@ export class WsClient {
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private subscribedContextIds: Set<string> = new Set();
+  private subscribedGroupIds: Set<string> = new Set();
   private listeners: WsListeners = { connect: [], event: [], error: [] };
 
   private static readonly MAX_BACKOFF_MS = 30000;
@@ -66,9 +71,9 @@ export class WsClient {
   }
 
   private emit(event: 'connect'): void;
-  private emit(event: 'event', data: WsEventData): void;
+  private emit(event: 'event', data: WsEventData | GroupMembershipEventData): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: WsEventData | Error): void {
+  private emit(event: string, arg?: WsEventData | GroupMembershipEventData | Error): void {
     const key = event as keyof WsListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -83,7 +88,7 @@ export class WsClient {
   }
 
   async connect(): Promise<void> {
-    if (this.ws && (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)) {
+    if (this.ws && (this.ws.readyState === 0 /* CONNECTING */ || this.ws.readyState === 1 /* OPEN */)) {
       return;
     }
     this.closed = false;
@@ -100,14 +105,7 @@ export class WsClient {
       this.ws.onopen = () => {
         this.reconnectAttempt = 0;
         this.emit('connect');
-        // Re-subscribe on reconnect
-        if (this.subscribedContextIds.size > 0) {
-          this.sendMessage({
-            id: null,
-            method: 'subscribe',
-            params: { contextIds: [...this.subscribedContextIds] },
-          });
-        }
+        this.resubscribeAfterReconnect();
       };
 
       this.ws.onmessage = (event) => {
@@ -137,22 +135,34 @@ export class WsClient {
     try {
       const msg = JSON.parse(raw);
 
-      if (msg.result && msg.result.contextId) {
-        let eventData = msg.result.data;
-        if (Array.isArray(eventData)) {
-          try {
-            const bytes = new Uint8Array(eventData);
-            const text = new TextDecoder().decode(bytes);
-            eventData = JSON.parse(text);
-          } catch {
-            // Keep raw data
-          }
-        }
+      if (!msg.result) return;
 
+      let eventData = msg.result.data;
+      if (Array.isArray(eventData)) {
+        try {
+          const bytes = new Uint8Array(eventData);
+          const text = new TextDecoder().decode(bytes);
+          eventData = JSON.parse(text);
+        } catch {
+          // Keep raw data
+        }
+      }
+
+      if (msg.result.contextId) {
         this.emit('event', {
           contextId: msg.result.contextId,
           // Forward the event tag (sibling of `data` in core's flattened
           // payload) so consumers can discriminate, matching `SseClient`.
+          type: msg.result.type,
+          data: eventData,
+        });
+        return;
+      }
+
+      // Group-membership event message (untagged NodeEvent's group variant)
+      if (msg.result.groupId) {
+        this.emit('event', {
+          groupId: msg.result.groupId,
           type: msg.result.type,
           data: eventData,
         });
@@ -162,36 +172,63 @@ export class WsClient {
     }
   }
 
-  subscribe(contextIds: string[]): void {
-    for (const id of contextIds) {
+  subscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): void {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.add(id);
     }
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.add(id);
+    }
 
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.sendMessage({
         id: null,
         method: 'subscribe',
-        params: { contextIds },
+        params: this.buildSubscriptionParams(opts.contextIds ?? [], opts.groupIds ?? []),
       });
     }
   }
 
-  unsubscribe(contextIds: string[]): void {
-    for (const id of contextIds) {
+  unsubscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): void {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.delete(id);
     }
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.delete(id);
+    }
 
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.sendMessage({
         id: null,
         method: 'unsubscribe',
-        params: { contextIds },
+        params: this.buildSubscriptionParams(opts.contextIds ?? [], opts.groupIds ?? []),
       });
     }
   }
 
+  private resubscribeAfterReconnect(): void {
+    if (this.subscribedContextIds.size === 0 && this.subscribedGroupIds.size === 0) return;
+    this.sendMessage({
+      id: null,
+      method: 'subscribe',
+      params: this.buildSubscriptionParams([...this.subscribedContextIds], [...this.subscribedGroupIds]),
+    });
+  }
+
+  private buildSubscriptionParams(
+    contextIds: string[],
+    groupIds: string[],
+  ): { contextIds?: string[]; groupIds?: string[] } {
+    const params: { contextIds?: string[]; groupIds?: string[] } = {};
+    if (contextIds.length > 0) params.contextIds = contextIds;
+    if (groupIds.length > 0) params.groupIds = groupIds;
+    return params;
+  }
+
   private sendMessage(msg: unknown): void {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.ws.send(JSON.stringify(msg));
     }
   }
@@ -224,5 +261,6 @@ export class WsClient {
       this.ws = null;
     }
     this.subscribedContextIds.clear();
+    this.subscribedGroupIds.clear();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export type { ExecuteParams } from './rpc';
 
 // Events (SSE / WebSocket)
 export { SseClient, WsClient } from './events';
-export type { SseEventData, WsEventData, AppVersionChangedEvent } from './events';
+export type { SseEventData, WsEventData, AppVersionChangedEvent, GroupMembershipEventData } from './events';
 
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud';


### PR DESCRIPTION
## Summary

Adds SDK support for the node's group-membership events (core `NodeEvent::GroupMembership`), so a client can subscribe to a namespace/group and react to member joins/leaves in real time. Previously the event clients (SSE and WS) only understood per-context events and could only subscribe by context id.

### What changed

- **New event type** `GroupMembershipEventData` (`src/events/group.ts`): `{ groupId, type: 'MemberJoined' | 'MemberAdded' | 'MemberRemoved', data: { member, role? } }`, exported from `src/events` and the package root.
- **Parsing** (`sse.ts`, `ws.ts`): an incoming frame carrying `groupId` (rather than `contextId`) is delivered to the same `'event'` listeners; consumers discriminate on which id is present. The payload is decoded once (no double-unwrap).
- **Subscription** (`sse.ts`, `ws.ts`): `subscribe` now accepts group ids as well as context ids, via `subscribe({ contextIds?, groupIds? })`; the legacy `subscribe(contextIds: string[])` form is unchanged. Group ids are sent on the wire as `groupIds` (matching what the node deserializes) and are re-sent on reconnect alongside context ids.

Backward compatible: the context-event shape and the `subscribe(string[])` signature are untouched, and clients that never pass group ids never receive the new event.

## Test plan

- `pnpm test`: 255 passed, 1 skipped (the skip is a pre-existing core-fixture-gated contract test, unrelated). New tests cover: a group frame parses and is delivered with `groupId` intact and not double-unwrapped; an existing context frame still parses unchanged; `subscribe` with group ids emits the `groupIds` wire field; reconnect re-subscribes group ids.
- `tsc --noEmit` clean; lint clean.

---
**Note:** the multi-node live-event e2e was split into #74 (draft), gated on a merod release >= rc.19 that carries the core hex/`contextIds` fix. The unit tests here cover the parse/subscribe contract; the cross-node delivery test lands via #74 once rc.19 is published.
