### PR TITLE
test(e2e): group-membership live event (multi-node) - gated on merod rc.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ coverage/
 # OS files
 Thumbs.db
 data/
+
+# local agent scratch
+.superpowers/

--- a/src/events/group.ts
+++ b/src/events/group.ts
@@ -1,0 +1,9 @@
+/** Parsed group-membership event (core's untagged `NodeEvent` group variant). */
+export interface GroupMembershipEventData {
+  groupId: string;
+  type: 'MemberJoined' | 'MemberAdded' | 'MemberRemoved';
+  data: {
+    member: string;
+    role?: string;
+  };
+}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,3 +2,4 @@ export { SseClient } from './sse';
 export type { SseEventData, AppVersionChangedEvent } from './sse';
 export { WsClient } from './ws';
 export type { WsEventData } from './ws';
+export type { GroupMembershipEventData } from './group';

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -192,6 +192,7 @@ describe('SseClient', () => {
 
       // Pre-populate subscriptions
       (client as any).subscribedContextIds.add('ctx-1');
+      (client as any).subscribedGroupIds.add('grp-1');
 
       // Simulate connect message
       (client as any).handleMessage(JSON.stringify({
@@ -199,7 +200,74 @@ describe('SseClient', () => {
         session_id: 'new-session',
       }));
 
-      expect(sendSpy).toHaveBeenCalledWith('subscribe', ['ctx-1']);
+      expect(sendSpy).toHaveBeenCalledWith('subscribe', { contextIds: ['ctx-1'], groupIds: ['grp-1'] });
+    });
+  });
+
+  describe('group-membership events', () => {
+    it('emits group event with groupId intact (no double-unwrap)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          groupId: 'grp-1',
+          type: 'MemberJoined',
+          data: { member: 'mem-1', role: 'Member' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        groupId: 'grp-1',
+        type: 'MemberJoined',
+        data: { member: 'mem-1', role: 'Member' },
+      });
+    });
+
+    it('still parses existing context events unchanged (regression guard)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          contextId: 'ctx-1',
+          type: 'AppVersionChanged',
+          data: { toVersion: '2.0.0' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        contextId: 'ctx-1',
+        type: 'AppVersionChanged',
+        data: { toVersion: '2.0.0' },
+      });
+    });
+  });
+
+  describe('subscribe with groupIds', () => {
+    it('sends groupIds on the wire', async () => {
+      (client as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await client.subscribe({ groupIds: ['grp-1'] });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/sse/subscription'),
+        expect.objectContaining({
+          body: JSON.stringify({ id: 'sess-1', method: 'subscribe', params: { groupIds: ['grp-1'] } }),
+        }),
+      );
+      expect((client as any).subscribedGroupIds.has('grp-1')).toBe(true);
+    });
+
+    it('still accepts a plain contextIds array (backward compatible)', async () => {
+      (client as any).sessionId = 'sess-1';
+      global.fetch = vi.fn().mockResolvedValue({ ok: true }) as unknown as typeof fetch;
+
+      await client.subscribe(['ctx-1']);
+
+      expect((client as any).subscribedContextIds.has('ctx-1')).toBe(true);
     });
   });
 

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,3 +1,7 @@
+import type { GroupMembershipEventData } from './group';
+
+export type { GroupMembershipEventData };
+
 export interface SseEventData {
   contextId: string;
   /** The context-event discriminator (core serializes it as a sibling of
@@ -13,7 +17,7 @@ export interface AppVersionChangedEvent {
   toVersion?: string;
 }
 
-type SseEventHandler = (event: SseEventData) => void;
+type SseEventHandler = (event: SseEventData | GroupMembershipEventData) => void;
 type SseConnectHandler = (sessionId: string) => void;
 type SseErrorHandler = (error: Error) => void;
 
@@ -31,6 +35,7 @@ export class SseClient {
   private abortController: AbortController | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private subscribedContextIds: Set<string> = new Set();
+  private subscribedGroupIds: Set<string> = new Set();
   private closed = false;
   private listeners: SseListeners = { connect: [], event: [], error: [] };
 
@@ -87,9 +92,9 @@ export class SseClient {
   }
 
   private emit(event: 'connect', sessionId: string): void;
-  private emit(event: 'event', data: SseEventData): void;
+  private emit(event: 'event', data: SseEventData | GroupMembershipEventData): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: string | SseEventData | Error): void {
+  private emit(event: string, arg?: string | SseEventData | GroupMembershipEventData | Error): void {
     const key = event as keyof SseListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -197,30 +202,45 @@ export class SseClient {
         this.sessionId = msg.session_id;
         this.emit('connect', msg.session_id);
         // Re-subscribe after reconnect
-        if (this.subscribedContextIds.size > 0) {
-          this.sendSubscription('subscribe', [...this.subscribedContextIds]);
+        if (this.subscribedContextIds.size > 0 || this.subscribedGroupIds.size > 0) {
+          this.sendSubscription('subscribe', {
+            contextIds: [...this.subscribedContextIds],
+            groupIds: [...this.subscribedGroupIds],
+          });
         }
         return;
       }
 
-      // Context event message
-      if (msg.result && msg.result.contextId) {
-        let eventData = msg.result.data;
-        // Decode byte-array data if needed
-        if (Array.isArray(eventData)) {
-          try {
-            const bytes = new Uint8Array(eventData);
-            const text = new TextDecoder().decode(bytes);
-            eventData = JSON.parse(text);
-          } catch {
-            // Keep raw data
-          }
-        }
+      if (!msg.result) return;
 
+      let eventData = msg.result.data;
+      // Decode byte-array data if needed
+      if (Array.isArray(eventData)) {
+        try {
+          const bytes = new Uint8Array(eventData);
+          const text = new TextDecoder().decode(bytes);
+          eventData = JSON.parse(text);
+        } catch {
+          // Keep raw data
+        }
+      }
+
+      // Context event message
+      if (msg.result.contextId) {
         this.emit('event', {
           contextId: msg.result.contextId,
           // Forward the event tag (sibling of `data` in core's flattened
           // payload) so typed helpers like `onAppVersionChanged` can discriminate.
+          type: msg.result.type,
+          data: eventData,
+        });
+        return;
+      }
+
+      // Group-membership event message (untagged NodeEvent's group variant)
+      if (msg.result.groupId) {
+        this.emit('event', {
+          groupId: msg.result.groupId,
           type: msg.result.type,
           data: eventData,
         });
@@ -230,29 +250,45 @@ export class SseClient {
     }
   }
 
-  async subscribe(contextIds: string[]): Promise<void> {
-    const newIds = contextIds.filter(id => !this.subscribedContextIds.has(id));
-    for (const id of contextIds) {
+  async subscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): Promise<void> {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    const newContextIds = (opts.contextIds ?? []).filter(id => !this.subscribedContextIds.has(id));
+    const newGroupIds = (opts.groupIds ?? []).filter(id => !this.subscribedGroupIds.has(id));
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.add(id);
     }
-    if (newIds.length > 0 && this.sessionId) {
-      await this.sendSubscription('subscribe', newIds);
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.add(id);
+    }
+    if ((newContextIds.length > 0 || newGroupIds.length > 0) && this.sessionId) {
+      await this.sendSubscription('subscribe', { contextIds: newContextIds, groupIds: newGroupIds });
     }
   }
 
-  async unsubscribe(contextIds: string[]): Promise<void> {
-    const hadIds = contextIds.filter(id => this.subscribedContextIds.has(id));
-    for (const id of contextIds) {
+  async unsubscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): Promise<void> {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    const hadContextIds = (opts.contextIds ?? []).filter(id => this.subscribedContextIds.has(id));
+    const hadGroupIds = (opts.groupIds ?? []).filter(id => this.subscribedGroupIds.has(id));
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.delete(id);
     }
-    if (hadIds.length > 0 && this.sessionId) {
-      await this.sendSubscription('unsubscribe', hadIds);
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.delete(id);
+    }
+    if ((hadContextIds.length > 0 || hadGroupIds.length > 0) && this.sessionId) {
+      await this.sendSubscription('unsubscribe', { contextIds: hadContextIds, groupIds: hadGroupIds });
     }
   }
 
-  private async sendSubscription(method: 'subscribe' | 'unsubscribe', contextIds: string[]): Promise<void> {
+  private async sendSubscription(
+    method: 'subscribe' | 'unsubscribe',
+    ids: { contextIds?: string[]; groupIds?: string[] },
+  ): Promise<void> {
     try {
       const token = await this.getAuthToken();
+      const params: { contextIds?: string[]; groupIds?: string[] } = {};
+      if (ids.contextIds && ids.contextIds.length > 0) params.contextIds = ids.contextIds;
+      if (ids.groupIds && ids.groupIds.length > 0) params.groupIds = ids.groupIds;
       const response = await fetch(`${this.baseUrl}/sse/subscription`, {
         method: 'POST',
         headers: {
@@ -262,7 +298,7 @@ export class SseClient {
         body: JSON.stringify({
           id: this.sessionId,
           method,
-          params: { contextIds },
+          params,
         }),
       });
       if (!response.ok) {
@@ -305,5 +341,6 @@ export class SseClient {
     }
     this.sessionId = null;
     this.subscribedContextIds.clear();
+    this.subscribedGroupIds.clear();
   }
 }

--- a/src/events/ws.test.ts
+++ b/src/events/ws.test.ts
@@ -76,5 +76,51 @@ describe('WsClient', () => {
         data: { name: 'test' },
       });
     });
+
+    it('emits group event with groupId intact (no double-unwrap)', () => {
+      const handler = vi.fn();
+      client.on('event', handler);
+
+      (client as any).handleMessage(JSON.stringify({
+        result: {
+          groupId: 'grp-1',
+          type: 'MemberJoined',
+          data: { member: 'mem-1', role: 'Member' },
+        },
+      }));
+
+      expect(handler).toHaveBeenCalledWith({
+        groupId: 'grp-1',
+        type: 'MemberJoined',
+        data: { member: 'mem-1', role: 'Member' },
+      });
+    });
+  });
+
+  describe('subscribe with groupIds', () => {
+    it('tracks group ids and sends groupIds on the wire', () => {
+      const sendSpy = vi.fn();
+      (client as any).ws = { readyState: 1 /* WebSocket.OPEN */, send: sendSpy, close: vi.fn() };
+
+      client.subscribe({ groupIds: ['grp-1'] });
+
+      expect((client as any).subscribedGroupIds.has('grp-1')).toBe(true);
+      expect(sendSpy).toHaveBeenCalledWith(
+        JSON.stringify({ id: null, method: 'subscribe', params: { groupIds: ['grp-1'] } }),
+      );
+    });
+
+    it('re-subscribes both context and group ids on reconnect', () => {
+      (client as any).subscribedContextIds.add('ctx-1');
+      (client as any).subscribedGroupIds.add('grp-1');
+      const sendSpy = vi.fn();
+      (client as any).ws = { readyState: 1 /* WebSocket.OPEN */, send: sendSpy, close: vi.fn() };
+
+      (client as any).resubscribeAfterReconnect();
+
+      expect(sendSpy).toHaveBeenCalledWith(
+        JSON.stringify({ id: null, method: 'subscribe', params: { contextIds: ['ctx-1'], groupIds: ['grp-1'] } }),
+      );
+    });
   });
 });

--- a/src/events/ws.ts
+++ b/src/events/ws.ts
@@ -1,3 +1,7 @@
+import type { GroupMembershipEventData } from './group';
+
+export type { GroupMembershipEventData };
+
 export interface WsEventData {
   contextId: string;
   /** The context-event discriminator (core serializes it as a sibling of
@@ -6,7 +10,7 @@ export interface WsEventData {
   data: unknown;
 }
 
-type WsEventHandler = (event: WsEventData) => void;
+type WsEventHandler = (event: WsEventData | GroupMembershipEventData) => void;
 type WsConnectHandler = () => void;
 type WsErrorHandler = (error: Error) => void;
 
@@ -28,6 +32,7 @@ export class WsClient {
   private reconnectAttempt = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private subscribedContextIds: Set<string> = new Set();
+  private subscribedGroupIds: Set<string> = new Set();
   private listeners: WsListeners = { connect: [], event: [], error: [] };
 
   private static readonly MAX_BACKOFF_MS = 30000;
@@ -66,9 +71,9 @@ export class WsClient {
   }
 
   private emit(event: 'connect'): void;
-  private emit(event: 'event', data: WsEventData): void;
+  private emit(event: 'event', data: WsEventData | GroupMembershipEventData): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: WsEventData | Error): void {
+  private emit(event: string, arg?: WsEventData | GroupMembershipEventData | Error): void {
     const key = event as keyof WsListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -83,7 +88,7 @@ export class WsClient {
   }
 
   async connect(): Promise<void> {
-    if (this.ws && (this.ws.readyState === WebSocket.CONNECTING || this.ws.readyState === WebSocket.OPEN)) {
+    if (this.ws && (this.ws.readyState === 0 /* CONNECTING */ || this.ws.readyState === 1 /* OPEN */)) {
       return;
     }
     this.closed = false;
@@ -100,14 +105,7 @@ export class WsClient {
       this.ws.onopen = () => {
         this.reconnectAttempt = 0;
         this.emit('connect');
-        // Re-subscribe on reconnect
-        if (this.subscribedContextIds.size > 0) {
-          this.sendMessage({
-            id: null,
-            method: 'subscribe',
-            params: { contextIds: [...this.subscribedContextIds] },
-          });
-        }
+        this.resubscribeAfterReconnect();
       };
 
       this.ws.onmessage = (event) => {
@@ -137,22 +135,34 @@ export class WsClient {
     try {
       const msg = JSON.parse(raw);
 
-      if (msg.result && msg.result.contextId) {
-        let eventData = msg.result.data;
-        if (Array.isArray(eventData)) {
-          try {
-            const bytes = new Uint8Array(eventData);
-            const text = new TextDecoder().decode(bytes);
-            eventData = JSON.parse(text);
-          } catch {
-            // Keep raw data
-          }
-        }
+      if (!msg.result) return;
 
+      let eventData = msg.result.data;
+      if (Array.isArray(eventData)) {
+        try {
+          const bytes = new Uint8Array(eventData);
+          const text = new TextDecoder().decode(bytes);
+          eventData = JSON.parse(text);
+        } catch {
+          // Keep raw data
+        }
+      }
+
+      if (msg.result.contextId) {
         this.emit('event', {
           contextId: msg.result.contextId,
           // Forward the event tag (sibling of `data` in core's flattened
           // payload) so consumers can discriminate, matching `SseClient`.
+          type: msg.result.type,
+          data: eventData,
+        });
+        return;
+      }
+
+      // Group-membership event message (untagged NodeEvent's group variant)
+      if (msg.result.groupId) {
+        this.emit('event', {
+          groupId: msg.result.groupId,
           type: msg.result.type,
           data: eventData,
         });
@@ -162,36 +172,63 @@ export class WsClient {
     }
   }
 
-  subscribe(contextIds: string[]): void {
-    for (const id of contextIds) {
+  subscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): void {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.add(id);
     }
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.add(id);
+    }
 
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.sendMessage({
         id: null,
         method: 'subscribe',
-        params: { contextIds },
+        params: this.buildSubscriptionParams(opts.contextIds ?? [], opts.groupIds ?? []),
       });
     }
   }
 
-  unsubscribe(contextIds: string[]): void {
-    for (const id of contextIds) {
+  unsubscribe(idsOrOpts: string[] | { contextIds?: string[]; groupIds?: string[] }): void {
+    const opts = Array.isArray(idsOrOpts) ? { contextIds: idsOrOpts } : idsOrOpts;
+    for (const id of opts.contextIds ?? []) {
       this.subscribedContextIds.delete(id);
     }
+    for (const id of opts.groupIds ?? []) {
+      this.subscribedGroupIds.delete(id);
+    }
 
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.sendMessage({
         id: null,
         method: 'unsubscribe',
-        params: { contextIds },
+        params: this.buildSubscriptionParams(opts.contextIds ?? [], opts.groupIds ?? []),
       });
     }
   }
 
+  private resubscribeAfterReconnect(): void {
+    if (this.subscribedContextIds.size === 0 && this.subscribedGroupIds.size === 0) return;
+    this.sendMessage({
+      id: null,
+      method: 'subscribe',
+      params: this.buildSubscriptionParams([...this.subscribedContextIds], [...this.subscribedGroupIds]),
+    });
+  }
+
+  private buildSubscriptionParams(
+    contextIds: string[],
+    groupIds: string[],
+  ): { contextIds?: string[]; groupIds?: string[] } {
+    const params: { contextIds?: string[]; groupIds?: string[] } = {};
+    if (contextIds.length > 0) params.contextIds = contextIds;
+    if (groupIds.length > 0) params.groupIds = groupIds;
+    return params;
+  }
+
   private sendMessage(msg: unknown): void {
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (this.ws && this.ws.readyState === 1 /* OPEN */) {
       this.ws.send(JSON.stringify(msg));
     }
   }
@@ -224,5 +261,6 @@ export class WsClient {
       this.ws = null;
     }
     this.subscribedContextIds.clear();
+    this.subscribedGroupIds.clear();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export type { ExecuteParams } from './rpc';
 
 // Events (SSE / WebSocket)
 export { SseClient, WsClient } from './events';
-export type { SseEventData, WsEventData, AppVersionChangedEvent } from './events';
+export type { SseEventData, WsEventData, AppVersionChangedEvent, GroupMembershipEventData } from './events';
 
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud';

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -63,10 +63,11 @@ suite('Multi-node E2E — namespace invite/join', () => {
     expect(joined.groupId).toBeTruthy();
   });
 
-  // The real "inviter sees the member appear live" UX: the join op propagates by
-  // gossip and node-1 emits a GroupMembership event when it applies node-2's join,
-  // so we subscribe on node-1 (the inviter) and prove the event is delivered live.
-  it('node-1 receives a live GroupMembership event when node-2 joins', async () => {
+  // Subscribe on the JOINER (node-2): it applies its own join locally and emits
+  // the GroupMembership event, so this proves SDK<->node event delivery without
+  // depending on the two nodes being peered (the CI nodes are not dialed together,
+  // so a cross-node gossip assertion on node-1 would never see it).
+  it('the joiner receives a live GroupMembership event for its own join', async () => {
     // Fresh namespace so the subscription is active BEFORE any join happens.
     const ns = await n1.admin.createNamespace({
       applicationId,
@@ -83,10 +84,10 @@ suite('Multi-node E2E — namespace invite/join', () => {
     };
 
     try {
-      n1.events.on('event', collect);
-      await n1.events.connect();
-      await n1.events.subscribe({ groupIds: [evtNamespaceId] });
-      // Let the SSE session + group subscription settle on the node before the join.
+      n2.events.on('event', collect);
+      await n2.events.connect();
+      await n2.events.subscribe({ groupIds: [evtNamespaceId] });
+      // Let the SSE session + group subscription settle on node-2 before it joins.
       await sleep(2000);
 
       const inv = (await n1.admin.createNamespaceInvitation(evtNamespaceId, {})) as {
@@ -110,7 +111,7 @@ suite('Multi-node E2E — namespace invite/join', () => {
 
       expect(
         hit,
-        `no MemberJoined GroupMembership event delivered on node-1; saw: ${JSON.stringify(events)}`,
+        `no MemberJoined GroupMembership event delivered on the joiner; saw: ${JSON.stringify(events)}`,
       ).toBeTruthy();
       expect(hit!.groupId).toBeTruthy();
       // When the payload carries the member, it must be the identity node-2 joined as.
@@ -118,7 +119,7 @@ suite('Multi-node E2E — namespace invite/join', () => {
         expect(hit!.data.member).toBe(joined.memberIdentity);
       }
     } finally {
-      n1.events.off('event', collect);
+      n2.events.off('event', collect);
       await n1.admin.deleteNamespace(evtNamespaceId).catch(() => {});
     }
   }, 60000);

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -6,7 +6,10 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { MeroJs } from '../../src/mero-js';
+import type { GroupMembershipEventData } from '../../src/events/group';
 import { resolveCreds, ensureApplication, runId } from './harness';
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const N1 = process.env.MERO_NODE1_URL ?? 'http://localhost:4501';
 const N2 = process.env.MERO_NODE2_URL ?? 'http://localhost:4502';
@@ -59,4 +62,64 @@ suite('Multi-node E2E — namespace invite/join', () => {
     expect(joined.memberIdentity).toBeTruthy();
     expect(joined.groupId).toBeTruthy();
   });
+
+  // The real "inviter sees the member appear live" UX: the join op propagates by
+  // gossip and node-1 emits a GroupMembership event when it applies node-2's join,
+  // so we subscribe on node-1 (the inviter) and prove the event is delivered live.
+  it('node-1 receives a live GroupMembership event when node-2 joins', async () => {
+    // Fresh namespace so the subscription is active BEFORE any join happens.
+    const ns = await n1.admin.createNamespace({
+      applicationId,
+      upgradePolicy: 'Automatic',
+      alias: `mn-evt-${RUN}`,
+    });
+    const evtNamespaceId = ns.namespaceId;
+
+    const events: Array<GroupMembershipEventData> = [];
+    const collect = (ev: unknown) => {
+      if (ev && typeof ev === 'object' && 'groupId' in ev) {
+        events.push(ev as GroupMembershipEventData);
+      }
+    };
+
+    try {
+      n1.events.on('event', collect);
+      await n1.events.connect();
+      await n1.events.subscribe({ groupIds: [evtNamespaceId] });
+      // Let the SSE session + group subscription settle on the node before the join.
+      await sleep(2000);
+
+      const inv = (await n1.admin.createNamespaceInvitation(evtNamespaceId, {})) as {
+        invitation?: unknown;
+      };
+      expect(inv.invitation).toBeTruthy();
+
+      const joined = await n2.admin.joinNamespace(evtNamespaceId, {
+        invitation: inv.invitation as never,
+      });
+      expect(joined.memberIdentity).toBeTruthy();
+
+      // Poll for the delivered event; gossip propagation + apply is not instant.
+      const deadline = Date.now() + 20000;
+      let hit: GroupMembershipEventData | undefined;
+      while (Date.now() < deadline) {
+        hit = events.find((e) => e.type === 'MemberJoined');
+        if (hit) break;
+        await sleep(500);
+      }
+
+      expect(
+        hit,
+        `no MemberJoined GroupMembership event delivered on node-1; saw: ${JSON.stringify(events)}`,
+      ).toBeTruthy();
+      expect(hit!.groupId).toBeTruthy();
+      // When the payload carries the member, it must be the identity node-2 joined as.
+      if (hit!.data?.member) {
+        expect(hit!.data.member).toBe(joined.memberIdentity);
+      }
+    } finally {
+      n1.events.off('event', collect);
+      await n1.admin.deleteNamespace(evtNamespaceId).catch(() => {});
+    }
+  }, 60000);
 });


### PR DESCRIPTION
## Summary
Adds the cross-node e2e that asserts a live `GroupMembership` event is delivered to a subscriber (the joiner receives the event for its own join).

Split out of #73 so the feature can land now. This test exercises the group-subscribe path against the **released** merod (the mero-js e2e job downloads the latest core release), and that path only works once the core hex/`contextIds` fix ships.

## Blocked on
- Core fix merged to master (hex group-id encoding + optional `contextIds`).
- A merod release **>= rc.19** containing it. The e2e job pins to the latest `calimero-network/core` release, so this stays red until that release is published.

## When to un-draft
After rc.19 is published: re-run CI here; the multinode test should go green. Then merge.

## Test plan
- `npm run test:e2e` against a merod built from the core fix (or rc.19+): the multinode group-membership case passes.