### PR TITLE
feat(utils): add local node discovery helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,11 @@ export * from './cloud';
 export * from './capabilities';
 
 // Utilities
+export {
+  DEFAULT_LOCAL_NODE_PORTS,
+  localNodeUrl,
+  nodeEndpoint,
+  probeNodeHealth,
+  discoverLocalNodes,
+} from './nodeDiscovery';
+export type { DiscoverLocalNodesOptions } from './nodeDiscovery';

--- a/src/nodeDiscovery.test.ts
+++ b/src/nodeDiscovery.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  discoverLocalNodes,
+  probeNodeHealth,
+  localNodeUrl,
+  nodeEndpoint,
+  DEFAULT_LOCAL_NODE_PORTS,
+} from './nodeDiscovery';
+
+/**
+ * Build a `fetch` stand-in where only the given base URLs answer their health
+ * endpoint with `{ data: { status: "alive" } }`. Everything else rejects, the
+ * way a closed local port does.
+ */
+function fetchRespondingFor(
+  healthy: string[],
+  opts: { status?: string; ok?: boolean } = {},
+) {
+  const healthySet = new Set(healthy);
+  return vi.fn(async (input: string) => {
+    const url = String(input);
+    const base = url.replace(/\/admin-api\/.*$/, '');
+    if (url.includes('/admin-api/health') && healthySet.has(base)) {
+      return {
+        ok: opts.ok ?? true,
+        status: 200,
+        json: async () => ({ data: { status: opts.status ?? 'alive' } }),
+      } as Response;
+    }
+    throw new TypeError('Failed to fetch');
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('localNodeUrl', () => {
+  it('builds a localhost base URL for a port', () => {
+    expect(localNodeUrl(2428)).toBe('http://localhost:2428');
+  });
+});
+
+describe('nodeEndpoint', () => {
+  it('appends the path to a root base URL', () => {
+    expect(nodeEndpoint('http://localhost:2428', 'admin-api/health')).toBe(
+      'http://localhost:2428/admin-api/health',
+    );
+  });
+
+  it('preserves a path prefix on the base URL (NODE_PATH_PREFIX)', () => {
+    expect(nodeEndpoint('http://host/node1', 'admin-api/health')).toBe(
+      'http://host/node1/admin-api/health',
+    );
+  });
+
+  it('does not double up the slash when the base already ends with one', () => {
+    expect(nodeEndpoint('http://host/node1/', 'admin-api/health')).toBe(
+      'http://host/node1/admin-api/health',
+    );
+  });
+});
+
+describe('probeNodeHealth', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  it('returns true for a 2xx + status "alive"', async () => {
+    vi.stubGlobal('fetch', fetchRespondingFor(['http://localhost:2428']));
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(true);
+  });
+
+  it('treats a 2xx with a non-JSON body as alive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw new SyntaxError('not json');
+        },
+      })),
+    );
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(true);
+  });
+
+  it('returns false when the reported status is not alive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      fetchRespondingFor(['http://localhost:2428'], { status: 'not_alive' }),
+    );
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(false);
+  });
+
+  it('returns false for an explicit null status', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: { status: null } }),
+      })),
+    );
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(false);
+  });
+
+  it('treats a 2xx with no status field as alive', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })),
+    );
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(true);
+  });
+
+  it('returns false without fetching when the signal is already aborted', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      await probeNodeHealth('http://localhost:2428', {
+        signal: controller.signal,
+      }),
+    ).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false on a non-ok response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 503, json: async () => ({}) })),
+    );
+    expect(await probeNodeHealth('http://localhost:2428')).toBe(false);
+  });
+
+  it('returns false on a network error (closed port)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('Failed to fetch');
+      }),
+    );
+    expect(await probeNodeHealth('http://localhost:9999')).toBe(false);
+  });
+
+  it('hits the admin-api/health path of the base URL', async () => {
+    const fetchMock = fetchRespondingFor(['http://localhost:2428']);
+    vi.stubGlobal('fetch', fetchMock);
+    await probeNodeHealth('http://localhost:2428');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:2428/admin-api/health',
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+});
+
+describe('discoverLocalNodes', () => {
+  it('returns only the healthy nodes, in ascending port order', async () => {
+    vi.stubGlobal(
+      'fetch',
+      fetchRespondingFor(['http://localhost:2528', 'http://localhost:2428']),
+    );
+    const nodes = await discoverLocalNodes();
+    expect(nodes).toEqual([
+      'http://localhost:2428',
+      'http://localhost:2528',
+    ]);
+  });
+
+  it('returns an empty array when nothing local is running', async () => {
+    vi.stubGlobal('fetch', fetchRespondingFor([]));
+    expect(await discoverLocalNodes()).toEqual([]);
+  });
+
+  it('probes exactly the default ports', async () => {
+    const fetchMock = fetchRespondingFor([]);
+    vi.stubGlobal('fetch', fetchMock);
+    await discoverLocalNodes();
+    const probed = fetchMock.mock.calls.map((c) => String(c[0]));
+    for (const port of DEFAULT_LOCAL_NODE_PORTS) {
+      expect(probed).toContain(`http://localhost:${port}/admin-api/health`);
+    }
+    expect(fetchMock).toHaveBeenCalledTimes(DEFAULT_LOCAL_NODE_PORTS.length);
+  });
+
+  it('respects a custom port list', async () => {
+    const fetchMock = fetchRespondingFor(['http://localhost:3000']);
+    vi.stubGlobal('fetch', fetchMock);
+    const nodes = await discoverLocalNodes({ ports: [3000, 3001] });
+    expect(nodes).toEqual(['http://localhost:3000']);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/nodeDiscovery.ts
+++ b/src/nodeDiscovery.ts
@@ -1,0 +1,126 @@
+/**
+ * Local-node discovery.
+ *
+ * Calimero dev/desktop nodes expose a public, unauthenticated health endpoint
+ * at `GET {nodeUrl}/admin-api/health` that returns `{ "data": { "status":
+ * "alive" } }`. The most common local layouts run on a small, well-known set of
+ * ports, so instead of forcing the user to type a URL we probe those ports and
+ * offer whatever is actually running.
+ */
+
+/**
+ * Default ports probed when discovering local nodes. Covers the two-node dev
+ * stacks used across the Calimero apps (RPC + alt ports for node1 / node2).
+ */
+export const DEFAULT_LOCAL_NODE_PORTS = [2428, 2429, 2528, 2529] as const;
+
+/** Host used to build local candidate URLs. */
+const LOCAL_HOST = 'localhost';
+
+/** Per-probe timeout. A reachable local node answers almost instantly; a
+ * closed port rejects fast, but a firewalled/black-holed one can hang, so we
+ * cap each probe. */
+const DEFAULT_PROBE_TIMEOUT_MS = 2000;
+
+export interface DiscoverLocalNodesOptions {
+  /** Ports to probe. Defaults to {@link DEFAULT_LOCAL_NODE_PORTS}. */
+  ports?: readonly number[];
+  /** Per-probe timeout in ms. Defaults to 2000. */
+  timeoutMs?: number;
+  /** Abort the whole discovery (e.g. when the modal closes). */
+  signal?: AbortSignal;
+}
+
+/** Build the canonical base URL for a local node on the given port. */
+export function localNodeUrl(port: number): string {
+  return `http://${LOCAL_HOST}:${port}`;
+}
+
+/**
+ * Resolve an API `path` against a node `baseUrl`. Ensures the base ends with a
+ * slash first, so a base that carries a path prefix (e.g. a `NODE_PATH_PREFIX`
+ * deployment like `http://host/node1`) keeps that segment instead of having it
+ * stripped by relative URL resolution.
+ */
+export function nodeEndpoint(baseUrl: string, path: string): string {
+  const base = baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`;
+  return new URL(path, base).toString();
+}
+
+/**
+ * Probe a single node's health endpoint. Resolves `true` only when the node
+ * answers with a 2xx and (when the body is JSON) reports a non-dead status.
+ * Any network error, timeout, or non-ok response resolves `false` — never
+ * throws (except on an external abort, which is swallowed as `false`).
+ */
+export async function probeNodeHealth(
+  baseUrl: string,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {},
+): Promise<boolean> {
+  const { timeoutMs = DEFAULT_PROBE_TIMEOUT_MS, signal } = options;
+
+  // Already cancelled before we start — don't fetch, and don't register a
+  // timer or listener that would then need cleanup.
+  if (signal?.aborted) return false;
+
+  // Per-probe timeout, also linked to the caller's abort signal so closing the
+  // modal cancels every in-flight probe. Track whether the listener was added
+  // so cleanup stays symmetric with registration.
+  const controller = new AbortController();
+  const onAbort = () => controller.abort();
+  const listenerAdded = !!signal;
+  if (listenerAdded) signal!.addEventListener('abort', onAbort, { once: true });
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const url = nodeEndpoint(baseUrl, 'admin-api/health');
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+    });
+
+    if (!res.ok) return false;
+
+    // Health body is `{ data: { status: "alive" } }`, but tolerate plain
+    // `{ status }` and non-JSON 2xx responses. A *missing* status is treated as
+    // alive (the 2xx is enough); a status that is present but not "alive"
+    // (including an explicit `null`) is treated as unhealthy.
+    try {
+      const body = (await res.json()) as
+        | { data?: { status?: string | null }; status?: string | null }
+        | undefined;
+      const status =
+        body?.data?.status !== undefined ? body?.data?.status : body?.status;
+      if (status === undefined) return true;
+      return typeof status === 'string' && status.toLowerCase() === 'alive';
+    } catch {
+      return true;
+    }
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+    if (listenerAdded) signal!.removeEventListener('abort', onAbort);
+  }
+}
+
+/**
+ * Probe the configured local ports in parallel and return the base URLs that
+ * responded as healthy, in the same order as the `ports` argument (which
+ * defaults to ascending). Returns an empty array when nothing local is running.
+ */
+export async function discoverLocalNodes(
+  options: DiscoverLocalNodesOptions = {},
+): Promise<string[]> {
+  const { ports = DEFAULT_LOCAL_NODE_PORTS, timeoutMs, signal } = options;
+
+  const results = await Promise.all(
+    ports.map(async (port) => {
+      const url = localNodeUrl(port);
+      const ok = await probeNodeHealth(url, { timeoutMs, signal });
+      return ok ? url : null;
+    }),
+  );
+
+  return results.filter((url): url is string => url !== null);
+}

--- a/src/nodeDiscovery.ts
+++ b/src/nodeDiscovery.ts
@@ -64,12 +64,12 @@ export async function probeNodeHealth(
   if (signal?.aborted) return false;
 
   // Per-probe timeout, also linked to the caller's abort signal so closing the
-  // modal cancels every in-flight probe. Track whether the listener was added
-  // so cleanup stays symmetric with registration.
+  // modal cancels every in-flight probe. Bind the signal to a local so the
+  // cleanup below stays symmetric with registration without re-narrowing.
   const controller = new AbortController();
   const onAbort = () => controller.abort();
-  const listenerAdded = !!signal;
-  if (listenerAdded) signal!.addEventListener('abort', onAbort, { once: true });
+  const abortSignal = signal;
+  if (abortSignal) abortSignal.addEventListener('abort', onAbort, { once: true });
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
@@ -100,7 +100,7 @@ export async function probeNodeHealth(
     return false;
   } finally {
     clearTimeout(timer);
-    if (listenerAdded) signal!.removeEventListener('abort', onAbort);
+    if (abortSignal) abortSignal.removeEventListener('abort', onAbort);
   }
 }
 


### PR DESCRIPTION
## Summary

Moves the local node-discovery helpers into mero-js, where they belong: they are pure `fetch` with zero React coupling, and non-React consumers (a Node CLI, an MCP server) need them without pulling React in as a peer dependency.

Adds, exported from the package root:

- `DEFAULT_LOCAL_NODE_PORTS`, `localNodeUrl(port)`, `nodeEndpoint(baseUrl, path)`
- `probeNodeHealth(baseUrl, {timeoutMs, signal})` - `GET {baseUrl}/admin-api/health`, tolerant of `{data:{status}}`, bare `{status}`, and non-JSON 2xx
- `discoverLocalNodes({ports, timeoutMs, signal})` - probes the candidate ports in parallel and returns the healthy base URLs
- the `DiscoverLocalNodesOptions` type

The implementation and its tests are carried over unchanged from mero-react; the paired mero-react PR deletes its copy and re-exports these instead, so there is one implementation rather than two.

## Test plan

- Unit: 274 passed (17 new, covering probe timeouts, abort linking, tolerant health-body parsing, and parallel discovery).
- Typecheck, lint, and build green.
