### PR TITLE
fix(types): emit resolvable specifiers so NodeNext consumers get real types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - run: pnpm build
       - run: pnpm test:unit
       - run: pnpm typecheck
+      - run: pnpm typecheck:consumer
       - run: pnpm lint
 
   e2e:

--- a/package.json
+++ b/package.json
@@ -49,12 +49,13 @@
     "eslint": "eslint .",
     "typecheck": "tsc --noEmit",
     "typecheck:contract": "tsc --noEmit -p tsconfig.contract.json",
+    "typecheck:consumer": "tsc --noEmit -p tsconfig.consumer.json",
     "test:contract": "vitest run --config vitest.config.ts src/__contract__",
     "tsc": "tsc -b",
     "prettier": "prettier --check \"src/**/*.{ts,js,json,md}\"",
     "prettier:fix": "prettier --write \"src/**/*.{ts,js,json,md}\"",
     "clean": "pnpm rimraf dist",
-    "prepublishOnly": "pnpm clean && pnpm build && pnpm test:unit && pnpm lint && pnpm typecheck"
+    "prepublishOnly": "pnpm clean && pnpm build && pnpm test:unit && pnpm lint && pnpm typecheck && pnpm typecheck:consumer"
   },
   "files": [
     "dist"

--- a/src/__contract__/wire.contract.test.ts
+++ b/src/__contract__/wire.contract.test.ts
@@ -21,8 +21,8 @@ import type {
   CreateContextResponseData,
   ReparentGroupRequest,
   ReparentGroupResponseData,
-} from '../admin-api/admin-types';
-import type { ExecuteParams } from '../rpc';
+} from '../admin-api/admin-types.js';
+import type { ExecuteParams } from '../rpc/index.js';
 
 const CORE_DIR = process.env.CALIMERO_CORE_DIR;
 const WIRE_DIR = CORE_DIR

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AdminApiClient, compareSemver } from './admin-client';
-import { HttpClient } from '../http-client';
+import { AdminApiClient, compareSemver } from './admin-client.js';
+import { HttpClient } from '../http-client/index.js';
 
 // Mock HttpClient that stores expected responses and records request bodies
 class MockHttpClient implements HttpClient {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -1,4 +1,4 @@
-import { HttpClient, withRetry } from '../http-client';
+import { HttpClient, withRetry } from '../http-client/index.js';
 import type {
   HealthStatus,
   AdminAuthStatus,
@@ -107,7 +107,7 @@ import type {
   TeeAttestResponseData,
   TeeVerifyQuoteRequest,
   TeeVerifyQuoteResponseData,
-} from './admin-types';
+} from './admin-types.js';
 
 /**
  * Helper: server wraps most responses in `{ data: T }`.

--- a/src/admin-api/admin-factory.test.ts
+++ b/src/admin-api/admin-factory.test.ts
@@ -4,9 +4,9 @@ import {
   createNodeAdminApiClient,
   createAdminApiClient,
   createAdminApiClientFromHttpClient,
-} from './admin-factory';
-import { AdminApiClient } from './admin-client';
-import { HttpClient } from '../http-client';
+} from './admin-factory.js';
+import { AdminApiClient } from './admin-client.js';
+import { HttpClient } from '../http-client/index.js';
 
 // Mock HttpClient
 class MockHttpClient implements HttpClient {

--- a/src/admin-api/admin-factory.ts
+++ b/src/admin-api/admin-factory.ts
@@ -1,6 +1,6 @@
-import { AdminApiClient } from './admin-client';
-import { AdminApiClientConfig } from './admin-types';
-import { HttpClient } from '../http-client';
+import { AdminApiClient } from './admin-client.js';
+import { AdminApiClientConfig } from './admin-types.js';
+import { HttpClient } from '../http-client/index.js';
 
 // Mock HTTP client for testing
 class MockHttpClient implements HttpClient {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -2,7 +2,7 @@
 // All types use camelCase to match core's #[serde(rename_all = "camelCase")]
 
 // Re-export shared types
-export { ApiResponse } from '../http-client';
+export { ApiResponse } from '../http-client/index.js';
 
 // ---- Health and Status ----
 

--- a/src/admin-api/index.ts
+++ b/src/admin-api/index.ts
@@ -1,4 +1,4 @@
 // Admin API client
-export * from './admin-client';
-export * from './admin-types';
-export * from './admin-factory';
+export * from './admin-client.js';
+export * from './admin-types.js';
+export * from './admin-factory.js';

--- a/src/auth-api/auth-client.test.ts
+++ b/src/auth-api/auth-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AuthApiClient } from './auth-client';
-import { HttpClient } from '../http-client';
+import { AuthApiClient } from './auth-client.js';
+import { HttpClient } from '../http-client/index.js';
 
 // Mock HttpClient that records request bodies (mirrors admin-client.test.ts).
 class MockHttpClient implements HttpClient {

--- a/src/auth-api/auth-client.ts
+++ b/src/auth-api/auth-client.ts
@@ -1,4 +1,4 @@
-import { HttpClient } from '../http-client';
+import { HttpClient } from '../http-client/index.js';
 import {
   // Common types
   ApiResponse,
@@ -27,7 +27,7 @@ import {
   // Permissions
   PermissionResponse,
   UpdateKeyPermissionsRequest,
-} from './auth-types';
+} from './auth-types.js';
 
 export class AuthApiClient {
   constructor(private httpClient: HttpClient) {}

--- a/src/auth-api/auth-factory.ts
+++ b/src/auth-api/auth-factory.ts
@@ -1,6 +1,6 @@
-import { AuthApiClient } from './auth-client';
-import { AuthApiClientConfig } from './auth-types';
-import { HttpClient } from '../http-client';
+import { AuthApiClient } from './auth-client.js';
+import { AuthApiClientConfig } from './auth-types.js';
+import { HttpClient } from '../http-client/index.js';
 
 // Mock HTTP client for testing
 class MockHttpClient implements HttpClient {

--- a/src/auth-api/auth-types.ts
+++ b/src/auth-api/auth-types.ts
@@ -1,7 +1,7 @@
 // Auth API Types - Generated from OpenAPI 3.0.3 specification
 
 // Re-export shared types
-export { ApiResponse } from '../http-client';
+export { ApiResponse } from '../http-client/index.js';
 
 // Health and Status Types
 export interface HealthResponse {

--- a/src/auth-api/index.ts
+++ b/src/auth-api/index.ts
@@ -1,4 +1,4 @@
 // Auth API client
-export * from './auth-client';
-export * from './auth-types';
-export * from './auth-factory';
+export * from './auth-client.js';
+export * from './auth-types.js';
+export * from './auth-factory.js';

--- a/src/auth/auth.test.ts
+++ b/src/auth/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseAuthCallback, buildAuthLoginUrl } from './index';
+import { parseAuthCallback, buildAuthLoginUrl } from './index.js';
 
 describe('parseAuthCallback', () => {
   it('parses a valid callback URL', () => {

--- a/src/capabilities.test.ts
+++ b/src/capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { CAPABILITIES, hasCap, withCap, withoutCap } from './capabilities';
+import { CAPABILITIES, hasCap, withCap, withoutCap } from './capabilities.js';
 
 describe('capabilities', () => {
   it('exposes the expected capability bits as powers of two', () => {

--- a/src/cloud/index.ts
+++ b/src/cloud/index.ts
@@ -1,2 +1,2 @@
-export { CloudClient } from './cloud-client';
-export type { CloudClientConfig, EnableHAOptions, DisableHAOptions } from './cloud-client';
+export { CloudClient } from './cloud-client.js';
+export type { CloudClientConfig, EnableHAOptions, DisableHAOptions } from './cloud-client.js';

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -1,5 +1,5 @@
-export { SseClient } from './sse';
-export type { SseEventData, AppVersionChangedEvent } from './sse';
-export { WsClient } from './ws';
-export type { WsEventData } from './ws';
-export type { GroupMembershipEventData } from './group';
+export { SseClient } from './sse.js';
+export type { SseEventData, AppVersionChangedEvent } from './sse.js';
+export { WsClient } from './ws.js';
+export type { WsEventData } from './ws.js';
+export type { GroupMembershipEventData } from './group.js';

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { SseClient } from './sse';
+import { SseClient } from './sse.js';
 
 describe('SseClient', () => {
   let client: SseClient;

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,4 +1,4 @@
-import type { GroupMembershipEventData } from './group';
+import type { GroupMembershipEventData } from './group.js';
 
 export type { GroupMembershipEventData };
 

--- a/src/events/ws.test.ts
+++ b/src/events/ws.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { WsClient } from './ws';
+import { WsClient } from './ws.js';
 
 describe('WsClient', () => {
   let client: WsClient;

--- a/src/events/ws.ts
+++ b/src/events/ws.ts
@@ -1,4 +1,4 @@
-import type { GroupMembershipEventData } from './group';
+import type { GroupMembershipEventData } from './group.js';
 
 export type { GroupMembershipEventData };
 

--- a/src/http-client/http-factory.ts
+++ b/src/http-client/http-factory.ts
@@ -1,5 +1,5 @@
-import { WebHttpClient } from './web-client';
-import { Transport, HttpClient } from './http-types';
+import { WebHttpClient } from './web-client.js';
+import { Transport, HttpClient } from './http-types.js';
 
 // Factory function to create HTTP client with sensible defaults
 export function createHttpClient(transport: Transport): HttpClient {

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,9 +1,9 @@
 // HTTP client types and interfaces
-export * from './http-types';
-export * from './api-response';
+export * from './http-types.js';
+export * from './api-response.js';
 
 // Web Standards HTTP client implementation
-export { WebHttpClient, HTTPError, AuthRevokedError } from './web-client';
+export { WebHttpClient, HTTPError, AuthRevokedError } from './web-client.js';
 
 // Factory functions for easy client creation
 export {
@@ -11,11 +11,11 @@ export {
   createBrowserHttpClient,
   createNodeHttpClient,
   createUniversalHttpClient,
-} from './http-factory';
+} from './http-factory.js';
 
 // Retry functionality
-export { withRetry, createRetryableMethod } from './retry';
-export type { RetryOptions } from './retry';
+export { withRetry, createRetryableMethod } from './retry.js';
+export type { RetryOptions } from './retry.js';
 
 // Signal utilities
-export { combineSignals, createTimeoutSignal } from './signal-utils';
+export { combineSignals, createTimeoutSignal } from './signal-utils.js';

--- a/src/http-client/web-client.test.ts
+++ b/src/http-client/web-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { WebHttpClient, HTTPError, AuthRevokedError } from './web-client';
-import { Transport } from './http-types';
+import { WebHttpClient, HTTPError, AuthRevokedError } from './web-client.js';
+import { Transport } from './http-types.js';
 
 describe('WebHttpClient - Token Refresh', () => {
   let mockFetch: ReturnType<typeof vi.fn>;

--- a/src/http-client/web-client.ts
+++ b/src/http-client/web-client.ts
@@ -4,8 +4,8 @@ import {
   Transport,
   RequestOptions,
   ResponseParser,
-} from './http-types';
-import { combineSignals, createTimeoutSignal } from './signal-utils';
+} from './http-types.js';
+import { combineSignals, createTimeoutSignal } from './signal-utils.js';
 
 /**
  * `x-auth-error` reasons that mean the whole token family is gone.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,40 +2,40 @@
 // This will contain the pure JavaScript SDK without React dependencies
 
 // Main SDK class
-export { MeroJs, createMeroJs } from './mero-js';
-export type { MeroJsConfig, TokenData } from './mero-js';
+export { MeroJs, createMeroJs } from './mero-js.js';
+export type { MeroJsConfig, TokenData } from './mero-js.js';
 
 // HTTP client module (Web Standards based)
-export * from './http-client';
+export * from './http-client/index.js';
 
 // Auth API client
-export * from './auth-api';
+export * from './auth-api/index.js';
 
 // Admin API client
-export * from './admin-api';
+export * from './admin-api/index.js';
 
 // Auth utilities
-export { parseAuthCallback, buildAuthLoginUrl } from './auth';
-export type { AuthCallbackResult, AuthLoginOptions } from './auth';
+export { parseAuthCallback, buildAuthLoginUrl } from './auth/index.js';
+export type { AuthCallbackResult, AuthLoginOptions } from './auth/index.js';
 
 // Token store
-export { MemoryTokenStore, LocalStorageTokenStore } from './token-store';
-export type { TokenStore } from './token-store';
+export { MemoryTokenStore, LocalStorageTokenStore } from './token-store/index.js';
+export type { TokenStore } from './token-store/index.js';
 
 // RPC client
-export { RpcClient, RpcError } from './rpc';
-export type { MigrateMyEntriesSummary } from './rpc';
-export type { ExecuteParams } from './rpc';
+export { RpcClient, RpcError } from './rpc/index.js';
+export type { MigrateMyEntriesSummary } from './rpc/index.js';
+export type { ExecuteParams } from './rpc/index.js';
 
 // Events (SSE / WebSocket)
-export { SseClient, WsClient } from './events';
-export type { SseEventData, WsEventData, AppVersionChangedEvent, GroupMembershipEventData } from './events';
+export { SseClient, WsClient } from './events/index.js';
+export type { SseEventData, WsEventData, AppVersionChangedEvent, GroupMembershipEventData } from './events/index.js';
 
 // Cloud client (enable-HA, disable-HA)
-export * from './cloud';
+export * from './cloud/index.js';
 
 // Member capability bitmask constants & helpers
-export * from './capabilities';
+export * from './capabilities.js';
 
 // Utilities
 export {
@@ -44,5 +44,5 @@ export {
   nodeEndpoint,
   probeNodeHealth,
   discoverLocalNodes,
-} from './nodeDiscovery';
-export type { DiscoverLocalNodesOptions } from './nodeDiscovery';
+} from './nodeDiscovery.js';
+export type { DiscoverLocalNodesOptions } from './nodeDiscovery.js';

--- a/src/mero-js.test.ts
+++ b/src/mero-js.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MeroJs, createMeroJs } from './mero-js';
-import { MemoryTokenStore } from './token-store';
+import { MeroJs, createMeroJs } from './mero-js.js';
+import { MemoryTokenStore } from './token-store/index.js';
 
 // Mock the HTTP client and API clients
 const mockHttpClient = {
@@ -59,15 +59,15 @@ const mockAdminClient = {
   getApplication: vi.fn(),
 };
 
-vi.mock('./http-client', () => ({
+vi.mock('./http-client/index.js', () => ({
   createBrowserHttpClient: vi.fn(() => mockHttpClient),
 }));
 
-vi.mock('./auth-api', () => ({
+vi.mock('./auth-api/index.js', () => ({
   createAuthApiClientFromHttpClient: vi.fn(() => mockAuthClient),
 }));
 
-vi.mock('./admin-api', () => ({
+vi.mock('./admin-api/index.js', () => ({
   createAdminApiClientFromHttpClient: vi.fn(() => mockAdminClient),
 }));
 
@@ -324,7 +324,7 @@ describe('MeroJs SDK', () => {
 
   describe('HTTP Client Integration', () => {
     it('should pass auth token to HTTP client', async () => {
-      const { createBrowserHttpClient } = await import('./http-client');
+      const { createBrowserHttpClient } = await import('./http-client/index.js');
 
       meroJs = new MeroJs({
         baseUrl: 'http://localhost:3000',
@@ -415,7 +415,7 @@ describe('MeroJs SDK', () => {
 
   describe('Configuration', () => {
     it('should use default timeout when not provided', async () => {
-      const { createBrowserHttpClient } = await import('./http-client');
+      const { createBrowserHttpClient } = await import('./http-client/index.js');
 
       meroJs = new MeroJs({
         baseUrl: 'http://localhost:3000',
@@ -432,7 +432,7 @@ describe('MeroJs SDK', () => {
     });
 
     it('should use custom timeout when provided', async () => {
-      const { createBrowserHttpClient } = await import('./http-client');
+      const { createBrowserHttpClient } = await import('./http-client/index.js');
 
       meroJs = new MeroJs({
         baseUrl: 'http://localhost:3000',
@@ -453,7 +453,7 @@ describe('MeroJs SDK', () => {
     let store: MemoryTokenStore;
 
     const getTransportHooks = async (): Promise<any> => {
-      const { createBrowserHttpClient } = await import('./http-client');
+      const { createBrowserHttpClient } = await import('./http-client/index.js');
       return (createBrowserHttpClient as any).mock.calls[0][0];
     };
 

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -1,15 +1,15 @@
-import { createBrowserHttpClient } from './http-client';
-import { createAuthApiClientFromHttpClient } from './auth-api';
-import { createAdminApiClientFromHttpClient } from './admin-api';
-import type { AuthApiClient } from './auth-api';
-import type { AdminApiClient } from './admin-api';
-import type { HttpClient } from './http-client';
-import type { TokenStore } from './token-store';
-import { parseAuthCallback, buildAuthLoginUrl } from './auth';
-import type { AuthCallbackResult, AuthLoginOptions } from './auth';
-import { RpcClient } from './rpc';
-import { SseClient } from './events/sse';
-import { WsClient } from './events/ws';
+import { createBrowserHttpClient } from './http-client/index.js';
+import { createAuthApiClientFromHttpClient } from './auth-api/index.js';
+import { createAdminApiClientFromHttpClient } from './admin-api/index.js';
+import type { AuthApiClient } from './auth-api/index.js';
+import type { AdminApiClient } from './admin-api/index.js';
+import type { HttpClient } from './http-client/index.js';
+import type { TokenStore } from './token-store/index.js';
+import { parseAuthCallback, buildAuthLoginUrl } from './auth/index.js';
+import type { AuthCallbackResult, AuthLoginOptions } from './auth/index.js';
+import { RpcClient } from './rpc/index.js';
+import { SseClient } from './events/sse.js';
+import { WsClient } from './events/ws.js';
 
 export interface MeroJsConfig {
   /** Base URL for the Calimero node */

--- a/src/nodeDiscovery.test.ts
+++ b/src/nodeDiscovery.test.ts
@@ -5,7 +5,7 @@ import {
   localNodeUrl,
   nodeEndpoint,
   DEFAULT_LOCAL_NODE_PORTS,
-} from './nodeDiscovery';
+} from './nodeDiscovery.js';
 
 /**
  * Build a `fetch` stand-in where only the given base URLs answer their health

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -1,4 +1,4 @@
-import type { HttpClient } from '../http-client';
+import type { HttpClient } from '../http-client/index.js';
 
 /** Result of the owner-driven `migrate_my_entries` convert (counts are u32). */
 export interface MigrateMyEntriesSummary {

--- a/src/rpc/rpc.test.ts
+++ b/src/rpc/rpc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
-import { RpcClient, RpcError } from './index';
-import type { HttpClient } from '../http-client';
+import { RpcClient, RpcError } from './index.js';
+import type { HttpClient } from '../http-client/index.js';
 
 function createMockHttpClient(postResponse: unknown): HttpClient {
   return {

--- a/src/token-store/index.ts
+++ b/src/token-store/index.ts
@@ -1,4 +1,4 @@
-import type { TokenData } from '../mero-js';
+import type { TokenData } from '../mero-js.js';
 
 export interface TokenStore {
   getTokens(): TokenData | null;

--- a/src/token-store/token-store.test.ts
+++ b/src/token-store/token-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MemoryTokenStore, LocalStorageTokenStore } from './index';
-import type { TokenData } from '../mero-js';
+import { MemoryTokenStore, LocalStorageTokenStore } from './index.js';
+import type { TokenData } from '../mero-js.js';
 
 const sampleToken: TokenData = {
   access_token: 'abc123',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,1 +1,1 @@
-export * from './api-response';
+export * from './api-response.js';

--- a/tests/consumer/nodenext.ts
+++ b/tests/consumer/nodenext.ts
@@ -1,0 +1,15 @@
+// Compiled by tsconfig.consumer.json as an external NodeNext consumer of the built
+// dist/. The @ts-expect-error lines fail if unresolvable specifiers widen the API to any.
+import { MeroJs, RpcError } from '@calimero-network/mero-js';
+import type { MeroJsConfig } from '@calimero-network/mero-js';
+
+const config: MeroJsConfig = { baseUrl: 'http://localhost:2428' };
+
+export const client = new MeroJs(config);
+export const error = new RpcError(-32000, 'boom');
+
+// @ts-expect-error code is a number, not a string
+new RpcError('not-a-number', 'boom');
+
+// @ts-expect-error baseUrl is required
+new MeroJs({ totallyNotAnOption: true });

--- a/tests/e2e/admin-api.test.ts
+++ b/tests/e2e/admin-api.test.ts
@@ -8,8 +8,8 @@
  *   NODE_URL=http://localhost:4001 pnpm test:e2e:admin
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
 
 const NODE_URL = resolveBaseUrl();
 const { username: USERNAME, password: PASSWORD } = resolveCreds();

--- a/tests/e2e/auth-api.test.ts
+++ b/tests/e2e/auth-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { startNode, resolveBaseUrl, resolveCreds, type StartedNode } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { startNode, resolveBaseUrl, resolveCreds, type StartedNode } from './harness.js';
 
 // Test configuration
 const AUTH_CONFIG = {

--- a/tests/e2e/coverage-extra.test.ts
+++ b/tests/e2e/coverage-extra.test.ts
@@ -4,8 +4,8 @@
  * SDK<->node contract), not deep behaviour. Self-provisioning + self-cleaning.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
 
 const NODE_URL = resolveBaseUrl();
 const { username: USERNAME, password: PASSWORD } = resolveCreds();

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -10,8 +10,8 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { fileURLToPath } from 'node:url';
-import { MeroJs } from '../../src/mero-js';
-import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
 
 const NODE_URL = resolveBaseUrl();
 const CREDS = resolveCreds();

--- a/tests/e2e/full-api.test.ts
+++ b/tests/e2e/full-api.test.ts
@@ -11,9 +11,9 @@
  *   NODE_URL=http://localhost:4001 pnpm test:e2e
  */
 import { describe, it, expect, beforeAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness';
-import { parseAuthCallback, buildAuthLoginUrl } from '../../src/auth';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
+import { parseAuthCallback, buildAuthLoginUrl } from '../../src/auth/index.js';
 
 const NODE_URL = resolveBaseUrl();
 const { username: USERNAME, password: PASSWORD } = resolveCreds();

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -14,7 +14,7 @@
  */
 import type { ChildProcess } from 'child_process';
 import { fileURLToPath } from 'node:url';
-import type { MeroJs } from '../../src/mero-js';
+import type { MeroJs } from '../../src/mero-js.js';
 
 /** The demo app the e2e suite exercises (bundled at ./assets/kv-store.mpk). */
 export const KV_STORE_PACKAGE = 'com.calimero.kv-store';

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -5,8 +5,8 @@
  * job boots two embedded-auth merod nodes and sets MERO_NODE1_URL/MERO_NODE2_URL.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { resolveCreds, ensureApplication, runId } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveCreds, ensureApplication, runId } from './harness.js';
 
 const N1 = process.env.MERO_NODE1_URL ?? 'http://localhost:4501';
 const N2 = process.env.MERO_NODE2_URL ?? 'http://localhost:4502';

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -6,8 +6,8 @@
  * Single-node tier. Multi-node flows (join/invite) live in multinode.test.ts.
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { MeroJs } from '../../src/mero-js';
-import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
 
 const NODE_URL = resolveBaseUrl();
 const CREDS = resolveCreds();

--- a/tsconfig.consumer.json
+++ b/tsconfig.consumer.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "skipLibCheck": false,
+    "noEmit": true
+  },
+  "include": ["tests/consumer/**/*.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ESNext",
+    "module": "NodeNext",
     "lib": ["ES2020", "DOM", "ES2019.Object"],
-    "moduleResolution": "node",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Summary

The published typings do not resolve under `moduleResolution: "NodeNext"`. `dist/index.d.ts` re-exports through extensionless, directory-style specifiers:

```ts
export * from './admin-api';            // dist/admin-api is a directory
export { RpcClient, RpcError } from './rpc';
```

Under NodeNext these are not resolvable, so a Node-native TypeScript consumer must set `skipLibCheck: true` to build at all - which suppresses the diagnostic and **silently widens the package's public API to `any`**. Star-exported names (`HTTPError`, `Application`, …) contribute nothing and are unimportable; named re-exports keep their names but resolve to `any`.

Reproduced from a consumer before this change - five deliberately-wrong lines, one error:

```ts
const a: number = mero.admin;                             // no error: `admin` is any
const b = mero.admin.thisMethodDoesNotExist(1, 2, 3);     // no error
const c = new RpcError('str', 123, 'x', 'y', 'extra');    // no error: wrong types, 5 args
```

Bundler-based consumers (`moduleResolution: "bundler"`) are unaffected, which is why this went unnoticed.

**Root cause:** plain `tsc` emits `dist/**/*.d.ts` (esbuild only produces the JS bundles), and `tsc` never rewrites specifiers. With `moduleResolution: "node"` the CJS-style extensionless imports in `src/` were accepted and copied verbatim into the declarations.

**Fix:** set `module`/`moduleResolution` to `NodeNext` so this is a build error in-repo, and add explicit extensions to relative specifiers across `src/` and `tests/` (specifier lines only; 44 files). Bundle sizes are unchanged - esbuild and Vite both map `./x.js` back to `x.ts`.

Also fixed incidentally: `dist/index.js` (tsc's own ESM output) was `ERR_MODULE_NOT_FOUND` under Node. Only the `exports` map pointing at the esbuild bundles hid it.

## Test plan

- New `tsconfig.consumer.json`: standalone, NodeNext, **`skipLibCheck: false`**, typechecking `tests/consumer/nodenext.ts`, which imports the package **by its own name** so TypeScript resolves through the real `exports` map into `dist/index.d.ts`. Two `@ts-expect-error` misuses mean it catches silent `any`-widening as well as outright resolution failure. Wired into CI after `pnpm typecheck`, and into `prepublishOnly`.
- Guard verified to fail without the fix: stashing it produces 18 resolution errors **plus** two `TS2578: Unused '@ts-expect-error' directive`.
- After the fix, both deliberate misuses produce real errors (`TS2345`, excess property and missing `baseUrl`).
- `build`, `test:unit` (274 passed / 1 skipped), `typecheck`, `typecheck:consumer`, `typecheck:contract`, `lint` all pass from a clean tree.
