### PR TITLE
fix(types): match core's wire format and surface node errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - run: pnpm test:unit
       - run: pnpm typecheck
       - run: pnpm typecheck:consumer
+      # Binds each contract spec's field names to the declared types; the live
+      # half of the same suites runs in the e2e job below.
+      - run: pnpm typecheck:contract
       - run: pnpm lint
 
   e2e:

--- a/package.json
+++ b/package.json
@@ -52,8 +52,6 @@
     "typecheck:consumer": "tsc --noEmit -p tsconfig.consumer.json",
     "test:contract": "vitest run --config vitest.config.ts src/__contract__",
     "tsc": "tsc -b",
-    "prettier": "prettier --check \"src/**/*.{ts,js,json,md}\"",
-    "prettier:fix": "prettier --write \"src/**/*.{ts,js,json,md}\"",
     "clean": "pnpm rimraf dist",
     "prepublishOnly": "pnpm clean && pnpm build && pnpm test:unit && pnpm lint && pnpm typecheck && pnpm typecheck:consumer && pnpm typecheck:contract"
   },

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "prettier --check \"src/**/*.{ts,js,json,md}\"",
     "prettier:fix": "prettier --write \"src/**/*.{ts,js,json,md}\"",
     "clean": "pnpm rimraf dist",
-    "prepublishOnly": "pnpm clean && pnpm build && pnpm test:unit && pnpm lint && pnpm typecheck && pnpm typecheck:consumer"
+    "prepublishOnly": "pnpm clean && pnpm build && pnpm test:unit && pnpm lint && pnpm typecheck && pnpm typecheck:consumer && pnpm typecheck:contract"
   },
   "files": [
     "dist"

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AdminApiClient, compareSemver } from './admin-client.js';
+import type { SignedGroupOpenInvitation } from './admin-types.js';
 import { HttpClient } from '../http-client/index.js';
+
+// A signed invitation exactly as merod emits it: the signed core primitive is
+// snake_case, with two unsigned bootstrap fields alongside the signature. Cast
+// because the type is opaque — only the node can mint one.
+const SIGNED_INVITATION = {
+  invitation: {
+    inviter_identity: [1],
+    group_id: [2],
+    expiration_timestamp: 999,
+    secret_salt: [3],
+    invited_role: 1,
+  },
+  inviter_signature: 'sig-1',
+  application_id: [4],
+  app_key: [5],
+} as unknown as SignedGroupOpenInvitation;
 
 // Mock HttpClient that stores expected responses and records request bodies
 class MockHttpClient implements HttpClient {
@@ -563,24 +580,24 @@ describe('AdminApiClient', () => {
       expect(result).toEqual({});
     });
 
-    it('listContextAliases unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/alias/list/context', { data: { aliases: [{ name: 'a', value: 'ctx-1' }] } });
+    it('listContextAliases unwraps the alias -> id map', async () => {
+      mock.setMockResponse('GET', '/admin-api/alias/list/context', { data: { a: 'ctx-1' } });
       const result = await client.listContextAliases();
-      expect(result).toEqual({ aliases: [{ name: 'a', value: 'ctx-1' }] });
+      expect(result).toEqual({ a: 'ctx-1' });
     });
 
-    it('listApplicationAliases unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/alias/list/application', { data: { aliases: [] } });
+    it('listApplicationAliases unwraps the alias -> id map', async () => {
+      mock.setMockResponse('GET', '/admin-api/alias/list/application', { data: {} });
       const result = await client.listApplicationAliases();
-      expect(result).toEqual({ aliases: [] });
+      expect(result).toEqual({});
     });
   });
 
   describe('Context Identity Aliases', () => {
-    it('listContextIdentityAliases unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/alias/list/identity/ctx-1', { data: { aliases: [{ name: 'alice', value: 'pk-1' }] } });
+    it('listContextIdentityAliases unwraps the alias -> identity map', async () => {
+      mock.setMockResponse('GET', '/admin-api/alias/list/identity/ctx-1', { data: { alice: 'pk-1' } });
       const result = await client.listContextIdentityAliases('ctx-1');
-      expect(result).toEqual({ aliases: [{ name: 'alice', value: 'pk-1' }] });
+      expect(result).toEqual({ alice: 'pk-1' });
     });
 
     it('createContextIdentityAlias sends { alias, identity } with context in the path', async () => {
@@ -662,20 +679,14 @@ describe('AdminApiClient', () => {
     });
 
     it('createNamespaceInvitation sends structured request', async () => {
-      const invitation = {
-        invitation: { inviterIdentity: [1], groupId: [2], expirationTimestamp: 999, secretSalt: [3], invitedRole: 1 },
-        inviterSignature: 'sig-1',
-      };
+      const invitation = SIGNED_INVITATION;
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/invite', { data: { invitation, groupName: 'NS' } });
       const result = await client.createNamespaceInvitation('ns-1', { expirationTimestamp: 999 });
       expect(result).toEqual({ invitation, groupName: 'NS' });
     });
 
     it('joinNamespace sends structured invitation', async () => {
-      const invitation = {
-        invitation: { inviterIdentity: [1], groupId: [2], expirationTimestamp: 999, secretSalt: [3] },
-        inviterSignature: 'sig-1',
-      };
+      const invitation = SIGNED_INVITATION;
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
         data: { groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' },
       });
@@ -1171,10 +1182,7 @@ describe('AdminApiClient', () => {
   });
 
   describe('Group Invitation & Join', () => {
-    const mockInvitation = {
-      invitation: { inviterIdentity: [1], groupId: [2], expirationTimestamp: 999, secretSalt: [3] },
-      inviterSignature: 'sig-1',
-    };
+    const mockInvitation = SIGNED_INVITATION;
 
     it('createGroupInvitation returns structured invitation', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/invite', {

--- a/src/admin-api/admin-factory.test.ts
+++ b/src/admin-api/admin-factory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import {
   createBrowserAdminApiClient,
   createNodeAdminApiClient,
@@ -128,5 +128,49 @@ describe('Admin API Factory Functions', () => {
       const client = createAdminApiClientFromHttpClient(mockHttpClient, config);
       expect(client).toBeInstanceOf(AdminApiClient);
     });
+  });
+
+  // These three used to hand the client a stub whose every method threw, so the
+  // obvious-looking entry points were unusable. Prove they now reach the wire.
+  describe('the config-only factories issue real requests', () => {
+    const realFetch = globalThis.fetch;
+    afterEach(() => {
+      globalThis.fetch = realFetch;
+    });
+
+    const factories = {
+      createAdminApiClient,
+      createBrowserAdminApiClient,
+      createNodeAdminApiClient,
+    };
+
+    for (const [name, factory] of Object.entries(factories)) {
+      it(`${name} calls the node`, async () => {
+        const fetchMock = vi.fn(
+          async () =>
+            new Response(JSON.stringify({ data: { status: 'alive' } }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+        const client = factory({
+          baseUrl: 'http://localhost:2428',
+          getAuthToken: async () => 'test-token',
+        });
+
+        await expect(client.healthCheck()).resolves.toEqual({ status: 'alive' });
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0] as unknown as [
+          string,
+          RequestInit,
+        ];
+        expect(url).toBe('http://localhost:2428/admin-api/health');
+        expect((init.headers as Record<string, string>).Authorization).toBe(
+          'Bearer test-token',
+        );
+      });
+    }
   });
 });

--- a/src/admin-api/admin-factory.ts
+++ b/src/admin-api/admin-factory.ts
@@ -1,68 +1,39 @@
 import { AdminApiClient } from './admin-client.js';
 import { AdminApiClientConfig } from './admin-types.js';
-import { HttpClient } from '../http-client/index.js';
-
-// Mock HTTP client for testing
-class MockHttpClient implements HttpClient {
-  async get<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async post<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async put<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async delete<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async patch<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async head(): Promise<{ headers: Record<string, string>; status: number }> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-  async request<T>(): Promise<T> {
-    throw new Error(
-      'HTTP client not implemented - use createAdminApiClientFromHttpClient with a real HTTP client',
-    );
-  }
-}
+import {
+  HttpClient,
+  createBrowserHttpClient,
+  createNodeHttpClient,
+  createUniversalHttpClient,
+} from '../http-client/index.js';
 
 // Factory functions for creating Admin API clients
+
+/** Admin client over a browser HTTP transport (global `fetch`). */
 export function createBrowserAdminApiClient(
-  _config: AdminApiClientConfig,
+  config: AdminApiClientConfig,
 ): AdminApiClient {
-  const httpClient = new MockHttpClient();
-  return new AdminApiClient(httpClient);
+  return new AdminApiClient(createBrowserHttpClient(config));
 }
 
+/** Admin client over a Node HTTP transport (Node 18+ `fetch`). */
 export function createNodeAdminApiClient(
-  _config: AdminApiClientConfig,
+  config: AdminApiClientConfig,
 ): AdminApiClient {
-  const httpClient = new MockHttpClient();
-  return new AdminApiClient(httpClient);
+  return new AdminApiClient(createNodeHttpClient(config));
 }
 
+/** Admin client over whichever transport suits the current runtime. */
 export function createAdminApiClient(
-  _config: AdminApiClientConfig,
+  config: AdminApiClientConfig,
 ): AdminApiClient {
-  const httpClient = new MockHttpClient();
-  return new AdminApiClient(httpClient);
+  return new AdminApiClient(createUniversalHttpClient(config));
 }
 
+/**
+ * Admin client over a caller-supplied HTTP client — use this to share one
+ * transport (and its token handling) with the other API clients.
+ */
 export function createAdminApiClientFromHttpClient(
   httpClient: HttpClient,
   _config: AdminApiClientConfig,

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -39,15 +39,25 @@ export interface UninstallApplicationResponseData {
   applicationId: string;
 }
 
+export interface ApplicationBlob {
+  bytecode: string;
+  compiled: string;
+}
+
 export interface Application {
   id: string;
-  blob: { bytecode: string; compiled: string };
+  blob: ApplicationBlob;
   size: number;
   source: string;
   metadata: number[];
-  signer_id: string;
-  package: string;
-  version: string;
+  /** Absent for a raw-wasm install (no signed bundle) and for bootstrap stubs. */
+  signer_id?: string;
+  /** Absent on a bootstrap stub row, written before the app's blob arrives. */
+  package?: string;
+  /** Absent when the stored version is empty or not valid semver. */
+  version?: string;
+  /** Named services of a multi-service bundle; absent for single-service apps. */
+  services?: Record<string, ApplicationBlob>;
 }
 
 export interface ListApplicationsResponseData {
@@ -153,7 +163,8 @@ export interface Context {
    * namespaceStateHash). Renamed from `rootHash`, which never populated.
    */
   contextStateHash: string;
-  dagHeads: number[][];
+  /** Absent while the context has no deltas yet (core omits an empty list). */
+  dagHeads?: number[][];
   /** Bundle semver of the installed application (skew #2). Absent on older nodes. */
   applicationVersion?: string;
 }
@@ -300,14 +311,12 @@ export interface CreateContextIdentityAliasRequest {
   identity: string;
 }
 
-export interface AliasEntry {
-  name: string;
-  value: string;
-}
-
-export interface ListAliasesResponseData {
-  aliases: AliasEntry[];
-}
+/**
+ * Core's `ListAliasesResponse` is `{ data: BTreeMap<Alias<T>, T> }`, so once the
+ * `data` envelope is stripped the payload is a flat `{ alias: id }` map — not a
+ * list of entries. Applies to context, application and context-identity aliases.
+ */
+export type ListAliasesResponseData = Record<string, string>;
 
 // Create/delete alias returns empty
 export type CreateAliasResponseData = Record<string, never>;
@@ -330,17 +339,45 @@ export type DeleteContextIdentityAliasResponseData = Record<string, never>;
 
 // ---- Shared invitation types ----
 
+/**
+ * The signed half of an invitation. Wire keys are snake_case: this type mirrors
+ * a core primitive (`calimero_context_config::types`), which carries no
+ * camelCase rename — unlike the admin DTOs that wrap it.
+ */
 export interface GroupInvitationFromAdmin {
-  inviterIdentity: number[];
-  groupId: number[];
-  expirationTimestamp: number;
-  secretSalt: number[];
-  invitedRole?: number;
+  readonly inviter_identity: number[];
+  readonly group_id: number[];
+  readonly expiration_timestamp: number;
+  /** Per-invitation nonce; core keeps the legacy `secret_salt` wire name. */
+  readonly secret_salt: number[];
+  readonly invited_role: number;
 }
 
+/**
+ * An invitation blob the node signed. **Opaque: pass it through unchanged.**
+ *
+ * `inviter_signature` covers `invitation`, and the trailing bootstrap fields
+ * (`application_id`, `app_key`) are needed by the joiner even though they sit
+ * outside the signature — so a value that has been rebuilt field-by-field is
+ * not the value the node signed. Rebuilding is what a schema derived from these
+ * declarations does: an object schema drops the keys it wasn't told about, and
+ * core may add more (both trailing fields were added this way). Carry the value
+ * verbatim from the call that produced it to {@link JoinGroupRequest}, and treat
+ * the fields below as read-only detail for display.
+ *
+ * The `never`-typed brand makes that structural: an object literal or a schema
+ * result cannot satisfy this type, while a value the SDK returned — or one
+ * recovered with `JSON.parse` after transport — still does.
+ */
 export interface SignedGroupOpenInvitation {
-  invitation: GroupInvitationFromAdmin;
-  inviterSignature: string;
+  readonly invitation: GroupInvitationFromAdmin;
+  readonly inviter_signature: string;
+  /** Unsigned bootstrap field; absent on invitations from older nodes. */
+  readonly application_id?: number[];
+  /** Unsigned bootstrap field; absent on invitations from older nodes. */
+  readonly app_key?: number[];
+  /** @internal Brand — never present at runtime, never write it. */
+  readonly __nodeSigned: never;
 }
 
 export interface RecursiveInvitationEntry {
@@ -361,6 +398,12 @@ export interface Namespace {
   memberCount: number;
   contextCount: number;
   subgroupCount: number;
+  /**
+   * Bundle version of this namespace's `appKey` blob — the per-namespace truth,
+   * where the application row only says "latest fetched". Absent when core
+   * cannot resolve it (raw-wasm app, legacy key, blob not retained locally).
+   */
+  appVersion?: string;
 }
 
 export type ListNamespacesResponseData = Namespace[];

--- a/src/http-client/web-client.test.ts
+++ b/src/http-client/web-client.test.ts
@@ -565,4 +565,77 @@ describe('WebHttpClient - Token Refresh', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe("HTTPError.message carries the node's explanation", () => {
+    it("includes core's error envelope and keeps every field intact", async () => {
+      const body = JSON.stringify({
+        error: 'Invalid group id format: expected hex-encoded 32 bytes',
+      });
+      mockFetch.mockResolvedValueOnce(
+        new Response(body, { status: 400, statusText: 'Bad Request' }),
+      );
+
+      try {
+        await client.post('/admin-api/groups/nope/invite', {});
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toBe(
+          'HTTP 400 Bad Request: Invalid group id format: expected hex-encoded 32 bytes',
+        );
+        expect(error.status).toBe(400);
+        expect(error.statusText).toBe('Bad Request');
+        expect(error.url).toBe('https://api.example.com/admin-api/groups/nope/invite');
+        expect(error.bodyText).toBe(body);
+        expect(error.headers).toBeInstanceOf(Headers);
+      }
+    });
+
+    it('falls back to the status line for bodies without an envelope', () => {
+      const line = 'HTTP 500 Internal Server Error';
+      const cases = [
+        undefined,
+        '',
+        '<html>gateway exploded</html>',
+        JSON.stringify({ data: null }),
+        JSON.stringify({ error: '   ' }),
+        JSON.stringify({ error: null }),
+      ];
+      for (const bodyText of cases) {
+        const error = new HTTPError(
+          500,
+          'Internal Server Error',
+          'https://api.example.com/x',
+          new Headers(),
+          bodyText,
+        );
+        expect(error.message, `body: ${String(bodyText)}`).toBe(line);
+        expect(error.bodyText).toBe(bodyText);
+      }
+    });
+
+    it('reads a nested { error: { message } } envelope', () => {
+      const error = new HTTPError(
+        502,
+        'Bad Gateway',
+        'https://api.example.com/x',
+        new Headers(),
+        JSON.stringify({ error: { message: 'upstream refused' } }),
+      );
+      expect(error.message).toBe('HTTP 502 Bad Gateway: upstream refused');
+    });
+
+    it('leaves AuthRevokedError with its own message', () => {
+      const error = new AuthRevokedError(
+        'token_revoked',
+        401,
+        'Unauthorized',
+        'https://api.example.com/x',
+        new Headers(),
+        JSON.stringify({ error: 'token revoked' }),
+      );
+      expect(error.message).toBe(
+        'Authentication revoked (token_revoked): HTTP 401 Unauthorized',
+      );
+    });
+  });
 });

--- a/src/http-client/web-client.ts
+++ b/src/http-client/web-client.ts
@@ -17,6 +17,25 @@ import { combineSignals, createTimeoutSignal } from './signal-utils.js';
  */
 const TERMINAL_AUTH_ERRORS = new Set(['token_reuse', 'token_revoked']);
 
+/**
+ * Pull the node's explanation out of an error body. Core answers every handled
+ * failure with `{"error": "<message>"}` (`ApiError::into_response`); the nested
+ * `{"error": {"message": ...}}` form is what proxies in front of a node emit.
+ * Returns undefined for a non-JSON, empty, or envelope-less body.
+ */
+function extractErrorMessage(bodyText?: string): string | undefined {
+  if (!bodyText) return undefined;
+  try {
+    const error = (JSON.parse(bodyText) as { error?: unknown })?.error;
+    if (typeof error === 'string' && error.trim() !== '') return error;
+    const nested = (error as { message?: unknown } | null)?.message;
+    if (typeof nested === 'string' && nested.trim() !== '') return nested;
+  } catch {
+    // Not JSON — the status line is all we can honestly report.
+  }
+  return undefined;
+}
+
 // Custom error class for HTTP errors
 export class HTTPError extends Error {
   name = 'HTTPError';
@@ -28,7 +47,12 @@ export class HTTPError extends Error {
     public headers: Headers,
     public bodyText?: string, // cap at ~64KB
   ) {
-    super(`HTTP ${status} ${statusText}`);
+    const explanation = extractErrorMessage(bodyText);
+    super(
+      explanation
+        ? `HTTP ${status} ${statusText}: ${explanation}`
+        : `HTTP ${status} ${statusText}`,
+    );
   }
 
   toJSON(): {

--- a/src/mero-js.test.ts
+++ b/src/mero-js.test.ts
@@ -579,5 +579,34 @@ describe('MeroJs SDK', () => {
       expect(meroJs.getTokenData()).toBeNull();
       expect(store.getTokens()).toBeNull();
     });
+
+    it('should notify the app hook after clearing, and survive it throwing', async () => {
+      // Assert on the recorded state, not inside the callback: the SDK swallows
+      // whatever the callback throws, including a failed expect().
+      let authenticatedWhenCalled: boolean | null = null;
+      const onAuthRevoked = vi.fn(() => {
+        authenticatedWhenCalled = app.isAuthenticated();
+        throw new Error('re-login screen exploded');
+      });
+      const app = new MeroJs({
+        baseUrl: 'http://localhost:3000',
+        tokenStore: new MemoryTokenStore(),
+        onAuthRevoked,
+      });
+      app.setTokenData({
+        access_token: 'a',
+        refresh_token: 'r',
+        expires_at: Date.now() + 3600_000,
+      });
+
+      const { createBrowserHttpClient } = await import('./http-client/index.js');
+      const hooks = (createBrowserHttpClient as any).mock.calls.at(-1)[0];
+      await hooks.onAuthRevoked();
+
+      expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+      // The tokens are gone before the app hears about it.
+      expect(authenticatedWhenCalled).toBe(false);
+      expect(app.isAuthenticated()).toBe(false);
+    });
   });
 });

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -25,6 +25,14 @@ export interface MeroJsConfig {
   requestCredentials?: RequestCredentials;
   /** Optional token store for persistence */
   tokenStore?: TokenStore;
+  /**
+   * Called when the node reports that the credential family is gone
+   * (`x-auth-error: token_reuse` / `token_revoked`). Terminal: the tokens have
+   * already been cleared by the time this runs and nothing is retried, so use it
+   * to send the user back through login. Errors thrown here are swallowed —
+   * never let a UI failure mask the auth error.
+   */
+  onAuthRevoked?: () => Promise<void> | void;
 }
 
 export interface TokenData {
@@ -115,11 +123,16 @@ export class MeroJs {
           this.tokenStore?.setTokens(this.tokenData);
         }
       },
-      onAuthRevoked: () => {
+      onAuthRevoked: async () => {
         // The refresh-token family is gone (a single-use refresh token was
         // replayed, or the token was revoked). Nothing left to refresh with —
-        // drop the bundle so the app can force a re-login.
+        // drop the bundle so the app can force a re-login, then let the app react.
         this.clearToken();
+        try {
+          await this.config.onAuthRevoked?.();
+        } catch {
+          // A failing app callback must not mask the auth error.
+        }
       },
       timeoutMs: this.config.timeoutMs,
       credentials: this.config.requestCredentials ?? (isTauri ? 'omit' : undefined),

--- a/tests/consumer/nodenext.ts
+++ b/tests/consumer/nodenext.ts
@@ -3,7 +3,10 @@
 import { MeroJs, RpcError } from '@calimero-network/mero-js';
 import type { MeroJsConfig } from '@calimero-network/mero-js';
 
-const config: MeroJsConfig = { baseUrl: 'http://localhost:2428' };
+const config: MeroJsConfig = {
+  baseUrl: 'http://localhost:2428',
+  onAuthRevoked: () => {},
+};
 
 export const client = new MeroJs(config);
 export const error = new RpcError(-32000, 'boom');

--- a/tests/e2e/wire.contract.test.ts
+++ b/tests/e2e/wire.contract.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Live wire contract: do a real node's responses satisfy the types the SDK
+ * declares? The declared types are hand-written, so they drift from core the
+ * moment a field is renamed, added, or made conditional — and every consumer
+ * finds out at runtime. This suite provisions real resources on a booted merod
+ * and checks, for each covered method:
+ *
+ *   (a) every key the node emits is one the SDK declares — a field core added
+ *       (or renamed) is not silently dropped by a consumer that models it, and
+ *   (b) every key the SDK marks required is actually present.
+ *
+ * Two gates, both needed. `key<T>()` makes each string in a spec a compile-time
+ * reference to the declared type, so `pnpm typecheck:contract` fails on a
+ * renamed or removed field; this suite then binds those same strings to what the
+ * node really sent. A rename that only edits the type breaks the first gate; one
+ * that edits type *and* spec breaks the second.
+ *
+ * Adding a method: append one entry to SPECS with a `sample()` that returns the
+ * object(s) to check, and list its keys through the method's own `key<T>()`
+ * binder. Nothing else. Do not list a brand field (`__nodeSigned`) in
+ * `required` — it is a type-level marker with no wire presence.
+ *
+ * The fixture-only sibling (`src/__contract__/wire.contract.test.ts`) checks the
+ * same two directions against core's committed fixtures with no node running.
+ *
+ * Run:
+ *   NODE_URL=http://localhost:4801 pnpm vitest run --config vitest.e2e.config.ts \
+ *     tests/e2e/wire.contract.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MeroJs } from '../../src/mero-js.js';
+import { ensureApplication, resolveBaseUrl, resolveCreds, runId } from './harness.js';
+import type {
+  Application,
+  ContextWithGroup,
+  CreateGroupInvitationResponseData,
+  GroupInvitationFromAdmin,
+  Namespace,
+  SignedGroupOpenInvitation,
+} from '../../src/admin-api/admin-types.js';
+
+const RUN = runId();
+
+/** `key<T>()('x')` is a compile-time assertion that `x` is a field of `T`. */
+function key<T>() {
+  return (k: keyof T & string): string => k;
+}
+
+const app = key<Application>();
+const ctx = key<ContextWithGroup>();
+const ns = key<Namespace>();
+const invitationRes = key<CreateGroupInvitationResponseData>();
+const signed = key<SignedGroupOpenInvitation>();
+const inv = key<GroupInvitationFromAdmin>();
+
+interface Spec {
+  /** The declared type under test, for failure messages. */
+  type: string;
+  /** SDK method(s) that produce it, for failure messages. */
+  via: string;
+  /** Live objects to key-check. Empty means "nothing provisioned" and fails. */
+  sample: () => Record<string, unknown>[];
+  /** SDK-required keys — must be present in every sample. */
+  required: string[];
+  /** SDK-optional keys — allowed, not required. */
+  optional: string[];
+}
+
+let mero: MeroJs;
+let applicationId: string;
+let namespaceId: string;
+let contextId: string;
+let memberPublicKey: string;
+const contextAlias = `wc-ctx-${RUN}`;
+const applicationAlias = `wc-app-${RUN}`;
+const identityAlias = `wc-id-${RUN}`;
+
+let applications: Application[] = [];
+let contexts: ContextWithGroup[] = [];
+let namespaces: Namespace[] = [];
+let invitation: CreateGroupInvitationResponseData;
+
+const SPECS: Spec[] = [
+  {
+    type: 'Application',
+    via: 'listApplications',
+    sample: () => applications as unknown as Record<string, unknown>[],
+    required: [app('id'), app('blob'), app('size'), app('source'), app('metadata')],
+    optional: [app('signer_id'), app('package'), app('version'), app('services')],
+  },
+  {
+    type: 'ContextWithGroup',
+    via: 'getContexts',
+    sample: () => contexts as unknown as Record<string, unknown>[],
+    required: [ctx('id'), ctx('applicationId'), ctx('contextStateHash')],
+    optional: [
+      ctx('serviceName'),
+      ctx('dagHeads'),
+      ctx('applicationVersion'),
+      ctx('groupId'),
+    ],
+  },
+  {
+    type: 'Namespace',
+    via: 'listNamespaces',
+    sample: () => namespaces as unknown as Record<string, unknown>[],
+    required: [
+      ns('namespaceId'),
+      ns('appKey'),
+      ns('targetApplicationId'),
+      ns('upgradePolicy'),
+      ns('createdAt'),
+      ns('memberCount'),
+      ns('contextCount'),
+      ns('subgroupCount'),
+    ],
+    optional: [ns('name'), ns('appVersion')],
+  },
+  {
+    type: 'CreateGroupInvitationResponseData',
+    via: 'createGroupInvitation',
+    sample: () => [invitation as unknown as Record<string, unknown>],
+    required: [invitationRes('invitation')],
+    optional: [invitationRes('groupName')],
+  },
+  {
+    type: 'SignedGroupOpenInvitation',
+    via: 'createGroupInvitation',
+    sample: () => [invitation.invitation as unknown as Record<string, unknown>],
+    required: [signed('invitation'), signed('inviter_signature')],
+    optional: [signed('application_id'), signed('app_key')],
+  },
+  {
+    type: 'GroupInvitationFromAdmin',
+    via: 'createGroupInvitation',
+    sample: () => [
+      invitation.invitation.invitation as unknown as Record<string, unknown>,
+    ],
+    required: [
+      inv('inviter_identity'),
+      inv('group_id'),
+      inv('expiration_timestamp'),
+      inv('secret_salt'),
+      inv('invited_role'),
+    ],
+    optional: [],
+  },
+];
+
+describe('live wire contract (merod responses ↔ SDK types)', () => {
+  beforeAll(async () => {
+    mero = new MeroJs({ baseUrl: resolveBaseUrl() });
+    const { username, password } = resolveCreds();
+    await mero.authenticate({ username, password });
+
+    applicationId = await ensureApplication(mero);
+    // A namespace's root group id is the namespace id, so this one call gives us
+    // both a namespace to list and a group to invite into.
+    namespaceId = (
+      await mero.admin.createNamespace({
+        applicationId,
+        upgradePolicy: 'Automatic',
+        name: `wire-contract-${RUN}`,
+      })
+    ).namespaceId;
+
+    const created = await mero.admin.createContext({
+      applicationId,
+      groupId: namespaceId,
+    });
+    contextId = created.contextId;
+    memberPublicKey = created.memberPublicKey;
+
+    await mero.admin.createContextAlias({ alias: contextAlias, contextId });
+    await mero.admin.createApplicationAlias({ alias: applicationAlias, applicationId });
+    await mero.admin.createContextIdentityAlias(contextId, {
+      alias: identityAlias,
+      identity: memberPublicKey,
+    });
+
+    applications = (await mero.admin.listApplications()).apps;
+    contexts = (await mero.admin.getContexts()).contexts;
+    namespaces = await mero.admin.listNamespaces();
+
+    const invited = await mero.admin.createGroupInvitation(namespaceId, {});
+    if (!('invitation' in invited)) {
+      throw new Error('createGroupInvitation returned a recursive payload');
+    }
+    invitation = invited;
+  }, 120000);
+
+  afterAll(() => {
+    mero?.close();
+  });
+
+  for (const spec of SPECS) {
+    it(`${spec.type} (via ${spec.via})`, () => {
+      const samples = spec.sample();
+      // A spec that provisioned nothing proves nothing.
+      expect(
+        samples.length,
+        `no live ${spec.type} to check — provisioning in beforeAll did not produce one`,
+      ).toBeGreaterThan(0);
+
+      const declared = new Set([...spec.required, ...spec.optional]);
+      for (const sample of samples) {
+        for (const wireKey of Object.keys(sample)) {
+          expect(
+            declared.has(wireKey),
+            `node sent '${wireKey}' but SDK type ${spec.type} does not declare it (${spec.via})`,
+          ).toBe(true);
+        }
+        for (const requiredKey of spec.required) {
+          expect(
+            Object.prototype.hasOwnProperty.call(sample, requiredKey),
+            `SDK ${spec.type} requires '${requiredKey}' but the node omitted it (${spec.via})`,
+          ).toBe(true);
+        }
+      }
+    });
+  }
+
+  // The three alias listings share one declared type, and it is not a keyed
+  // record but a flat map — so it gets a shape check rather than a key table.
+  it('ListAliasesResponseData is a flat { alias: id } map (via listContextAliases, listApplicationAliases, listContextIdentityAliases)', async () => {
+    // The annotation is the compile-time half: the declared type has to *be* the
+    // map core sends. It stops compiling if it goes back to a list of entries.
+    const listings: Record<string, Record<string, string>> = {
+      listContextAliases: await mero.admin.listContextAliases(),
+      listApplicationAliases: await mero.admin.listApplicationAliases(),
+      listContextIdentityAliases: await mero.admin.listContextIdentityAliases(contextId),
+    };
+
+    for (const [via, listing] of Object.entries(listings)) {
+      expect(Array.isArray(listing), `${via} returned an array, not a map`).toBe(false);
+      for (const [alias, id] of Object.entries(listing)) {
+        expect(typeof id, `${via}: value of '${alias}' must be an id string`).toBe(
+          'string',
+        );
+      }
+    }
+
+    // Indexing by alias only compiles — and only resolves — if the declared type
+    // is the map core actually sends.
+    expect(listings.listContextAliases[contextAlias]).toBe(contextId);
+    expect(listings.listApplicationAliases[applicationAlias]).toBe(applicationId);
+    expect(listings.listContextIdentityAliases[identityAlias]).toBe(memberPublicKey);
+  });
+});

--- a/tsconfig.contract.json
+++ b/tsconfig.contract.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    // The contract suites live outside src/, which the build's rootDir pins.
+    "rootDir": "."
   },
-  "include": ["src/**/*.contract.test.ts"],
+  "include": ["src/**/*.contract.test.ts", "tests/**/*.contract.test.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,9 @@
     "lib": ["ES2020", "DOM", "ES2019.Object"],
     "moduleResolution": "NodeNext",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
+    // No declarationMap/sourceMap: the published package is `dist` only, so any
+    // map tsc emits points at a `../src` that never ships. The esbuild bundles
+    // carry their own maps with sourcesContent inlined.
     "outDir": "./dist",
     "rootDir": "./src",
     "noEmit": false,


### PR DESCRIPTION
## Summary

Several declared admin types did not match what a node actually sends, and `HTTPError` discarded the node's explanation. Both classes were found by consumers hitting runtime failures — one of them broke multi-node onboarding entirely — so this also adds a contract test so the next drift fails in CI instead of in a consumer.

- **`HTTPError.message` now carries the node's message.** It was `HTTP ${status} ${statusText}` and never looked at `bodyText`, while `unwrap()` on the success path already understands core's envelope. Core emits `{"error": "..."}` for every handled failure, so consumers saw `HTTP 400 Bad Request` where the node had said something specific — and at least three of them wrote their own extraction. Non-JSON and empty bodies still get the status line; `AuthRevokedError` is unchanged.
- **Type corrections.** Alias listings are a `Record<string, string>`, not `{aliases: AliasEntry[]}`. The group invitation is snake_case with `application_id`/`app_key`, not camelCase. Also corrected while verifying against a live node: `Application.signer_id` / `version` / `services`, `Context.dagHeads`, `Namespace.appVersion`.
- **The invitation is opaque.** It is signed, so it must round-trip byte-identically. A consumer built an object schema from the declared fields and the undeclared keys were silently *stripped* — corrupting the payload rather than erroring. It is now branded so it cannot be reconstructed field by field.
- **The admin factories build a real client.** `createAdminApiClient`, `createNodeAdminApiClient` and `createBrowserAdminApiClient` returned a `MockHttpClient` whose every method threw, while being the obvious-looking entry points. They now wire the existing transports.
- **`onAuthRevoked` is exposed on `MeroJsConfig`.** The transport supported it but no consumer could reach it, so reacting to a revoked credential was impossible. `refreshToken`/`onTokenRefresh` are deliberately not exposed — MeroJs owns the single-use rotation invariant.
- **Contract test.** `tests/e2e/wire.contract.test.ts` checks a live node's responses against the declared types, in the existing e2e job; `typecheck:contract` now covers `tests/` and runs in CI and on prepublish.
- Stops emitting sourcemaps that pointed at excluded sources, and drops the `prettier` scripts (prettier was never a dependency).

**Breaking:** `AliasEntry` is removed and `ListAliasesResponseData` is now a `Record<string, string>`; the invitation type is opaque. Consumers reading `.aliases` or constructing an invitation literal need updating.

## Test plan

- `test:unit` — 282 passed, 1 skipped.
- `typecheck`, `typecheck:consumer`, `typecheck:contract` — clean.
- `test:e2e` against a live merod `0.11.0-rc.18` — 113 passed, 3 skipped.
- `lint` — 0 errors.
- **Contract test verified to catch drift, three ways:** deleting `Namespace.appVersion` fails the live run (`node sent 'appVersion' but SDK type Namespace does not declare it`); reverting `ListAliasesResponseData` to the old shape fails `typecheck:contract`; reverting an invitation key to camelCase fails it too.

Note for reviewers: the first version of the alias check passed *with the type reverted*, because `strict` is off and the index expression degraded to `any`. That is fixed with an explicit annotation, and it is worth knowing that any contract assertion in this repo needs one for the same reason.
