### PR TITLE
ci(release): escalate breaking changes to a major version

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,6 +7,10 @@
         "preset": "conventionalcommits",
         "releaseRules": [
           {
+            "breaking": true,
+            "release": "major"
+          },
+          {
             "type": "fix",
             "release": "patch"
           },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^18.19.34",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
-    "conventional-changelog-conventionalcommits": "^7.0.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "esbuild": "^0.28.1",
     "eslint": "^8.57.0",
     "rimraf": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: ^5.62.0
         version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
       conventional-changelog-conventionalcommits:
-        specifier: ^7.0.0
-        version: 7.0.2
+        specifier: ^9.3.1
+        version: 9.3.1
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -1022,9 +1022,9 @@ packages:
     resolution: {integrity: sha512-GGf2Nipn1RUCAktxuVauVr1e3r8QrLP/B0lEUsFktmGqc3ddbQkhoJZHJctVU829U1c6mTSWftrVOCHaL85Q3w==}
     engines: {node: '>=18'}
 
-  conventional-changelog-conventionalcommits@7.0.2:
-    resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
-    engines: {node: '>=16'}
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@7.0.1:
     resolution: {integrity: sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==}
@@ -3346,7 +3346,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@7.0.2:
+  conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary

Breaking changes have been publishing as patch releases, and `fix!:` commits have been publishing nothing at all. Two independent causes, both in the release config.

**Custom `releaseRules` made the default breaking rule unreachable.** `@semantic-release/commit-analyzer` evaluates the custom array on its own and only falls back to the defaults when *nothing* matched. Every commit type had a custom rule, so `{ breaking: true, release: "major" }` — which lives in the defaults — was never consulted. A `fix(...)` commit carrying a `BREAKING CHANGE:` footer resolved to a patch, while the breaking text still appeared in the release notes because a different plugin writes those.

This shipped: **7.3.2 was published as a patch** carrying the removal of `AliasEntry` and the reshaped invitation types. A consumer pinning `^7.3.1` picked it up and failed to compile.

**`fix!:` produced no release at all.** `conventional-changelog-conventionalcommits@^7` exports `{parserOpts}`, but commit-analyzer 13 reads `loadedConfig.parser` — so the preset silently fell back to a default parser that cannot see the `!` marker. There are four `!:` commits in this repo's history that contributed nothing to its version, including `fix!: metadata getters return the full MetadataRecord (#65)`.

Fixed by adding the breaking rule to the custom array and bumping the preset.

## Test plan

Verified by dry run rather than by reading the config — against the current `7.3.2` baseline, a `fix:` commit with a `BREAKING CHANGE:` footer computes:

| | version |
|---|---|
| before | **7.3.3** |
| after | **8.0.0** |

A `fix!:` commit went from *no release* to a major on the same check.

This commit is typed `ci(release):` deliberately: it maps to no release, so merging it does not publish a no-op version of a change that alters nothing shipped.

The same fix is going to `mero-mcp` and `mero-issue-tracker`, which carry the same copied config.