### PR TITLE
feat(admin-api)!: drop UpgradePolicy, updateGroupSettings, and residueIdentity

### DIFF
--- a/docs/src/content/docs/reference/admin-api.mdx
+++ b/docs/src/content/docs/reference/admin-api.mdx
@@ -133,7 +133,6 @@ A standalone helper `compareSemver(a, b): number` sorts version strings ascendin
 | `createGroup(request): Promise<{ groupId: string }>` | `POST /groups` |
 | `getGroupInfo(groupId): Promise<GroupInfoResponseData>` | `GET /groups/{groupId}` |
 | `deleteGroup(groupId, request?): Promise<DeleteGroupResponseData>` | `DELETE /groups/{groupId}` |
-| `updateGroupSettings(groupId, request): Promise<void>` | `PATCH /groups/{groupId}` |
 | `listGroupMembers(groupId): Promise<ListGroupMembersResponseData>` | `GET /groups/{groupId}/members` |
 | `listGroupContexts(groupId): Promise<ListGroupContextsResponseData>` | `GET /groups/{groupId}/contexts` |
 | `addGroupMembers(groupId, request): Promise<void>` | `POST /groups/{groupId}/members` |

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1076,7 +1076,6 @@ describe('AdminApiClient', () => {
             report: {
               schemaVersion: 2,
               residueAuto: 0,
-              residueIdentity: 0,
               syncedUpToHlc: 0,
               reportedAt: 0,
               authoredRemaining: 0,
@@ -1088,7 +1087,6 @@ describe('AdminApiClient', () => {
             report: {
               schemaVersion: 1,
               residueAuto: 0,
-              residueIdentity: 0,
               syncedUpToHlc: 0,
               reportedAt: 0,
               authoredRemaining: 2,

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -895,11 +895,6 @@ describe('AdminApiClient', () => {
       expect(mock.getRequestBody('PUT', '/admin-api/groups/g-1/settings/tee-admission-policy')).toEqual(policy);
     });
 
-    it('updateGroupSettings sends PATCH with upgradePolicy', async () => {
-      mock.setMockResponse('PATCH', '/admin-api/groups/g-1', {});
-      await client.updateGroupSettings('g-1', { upgradePolicy: 'automatic' });
-      expect(mock.getRequestBody('PATCH', '/admin-api/groups/g-1')).toEqual({ upgradePolicy: 'automatic' });
-    });
   });
 
   describe('Group / member / context metadata', () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -77,7 +77,6 @@ import type {
   SetSubgroupVisibilityRequest,
   SetTeeAdmissionPolicyRequest,
   GetTeeAdmissionPolicyResponseData,
-  UpdateGroupSettingsRequest,
   SetGroupMetadataRequest,
   SetMemberMetadataRequest,
   SetContextMetadataRequest,
@@ -851,13 +850,6 @@ export class AdminApiClient {
       GetTeeAdmissionPolicyResponseData & { data?: GetTeeAdmissionPolicyResponseData }
     >(`/admin-api/groups/${groupId}/settings/tee-admission-policy`);
     return response.data ?? response;
-  }
-
-  async updateGroupSettings(
-    groupId: string,
-    request: UpdateGroupSettingsRequest,
-  ): Promise<void> {
-    await this.httpClient.patch(`/admin-api/groups/${groupId}`, request);
   }
 
   // ---- Group / member / context metadata ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -520,7 +520,6 @@ export type MigrationFailureReason =
 export interface MemberMigrationReport {
   schemaVersion: number;
   residueAuto: number;
-  residueIdentity: number;
   syncedUpToHlc: number;
   reportedAt: number;
   /** Member's self-reported pending-authored count (best-effort; skew #1). */

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -704,14 +704,6 @@ export interface GetTeeAdmissionPolicyResponseData {
   acceptMock: boolean;
 }
 
-export interface UpdateGroupSettingsRequest {
-  upgradePolicy: string;
-  requester?: string;
-}
-
-// Returns empty
-export type UpdateGroupSettingsResponseData = Record<string, never>;
-
 // ---- Group / member / context metadata ----
 
 /**

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -103,9 +103,9 @@ export interface ListVersionsResponseData {
 /**
  * Per-service migration descriptor carried in a multi-service bundle manifest,
  * emitted from the app's `#[app::migrate]` declaration. `toSchemaVersion` is the
- * CRDT schema version the migrate targets (the engine's gate); `toVersion` is
- * the user-facing bundle semver an admin matches on; `method` is the migrate
- * entrypoint.
+ * ABI state version the migrate targets (from `#[app::state(version = N)]`,
+ * the engine's gate) — NOT the bundle semver, which is `toVersion`, the
+ * user-facing string an admin matches on; `method` is the migrate entrypoint.
  */
 export interface BundleMigration {
   method: string;

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -93,7 +93,7 @@ describe('Admin API E2E — Route coverage sweep', () => {
   });
 
   // NOTE: the full member lifecycle (add/list/role/capabilities/metadata/auto-follow/
-  // remove) + updateGroupSettings are deeply asserted in round-trip.test.ts.
+  // remove) is deeply asserted in round-trip.test.ts.
   it('group proofs + signing key + updateApp + app uninstall', async () => {
     await cover('signingKey', () => mero.admin.registerGroupSigningKey(groupId, {} as never));
     await cover('updateApp', () =>

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -136,16 +136,6 @@ describe('Round-trip E2E — Member lifecycle [Tier 2]', () => {
   });
 });
 
-describe('Round-trip E2E — Group settings [Tier 2]', () => {
-  it('updateGroupSettings(upgradePolicy) succeeds', async () => {
-    await mero.admin.updateGroupSettings(groupId, { upgradePolicy: 'Automatic' } as never);
-    expect(true).toBe(true);
-  });
-  // ponytail: uninstall stays in the tolerant sweep — only one app asset exists and
-  // install-dev is idempotent (returns the shared appId), so a real uninstall here
-  // would nuke shared test state. add a throwaway-app round-trip when one exists.
-});
-
 describe('Round-trip E2E — Groups', () => {
   it('TEE admission policy: set then get returns it', async () => {
     const policy = {


### PR DESCRIPTION
## Summary

Removes migration-related fields and types that core is dropping, and corrects a misleading doc comment.

- `Namespace.upgradePolicy`, `CreateNamespaceRequest.upgradePolicy`, and the `UpgradePolicy` type are removed.
- `UpdateGroupSettingsRequest`, `UpdateGroupSettingsResponseData`, and `AdminClient.updateGroupSettings()` are removed (the only field that endpoint ever set was `upgradePolicy`).
- `MemberMigrationReport.residueIdentity` is removed. It was hardwired to `0` in production; `authoredRemaining` measures the same fact and is self-reported.
- `BundleMigration.toSchemaVersion`'s doc comment now correctly describes it as the bundle's ABI state version (from `#[app::state(version = N)]`), not a CRDT schema version.

This is a breaking release: the first three changes are `BREAKING CHANGE:` commits, so the next published version is a major bump under this repo's `breaking: true -> major` release rule.

## Test plan

- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:contract`
- `pnpm typecheck:consumer`
- `pnpm test:unit`
