### PR TITLE
feat(admin-api)!: drop upgradePolicy from the create requests

### DIFF
--- a/docs/src/content/docs/guides/groups-and-governance.mdx
+++ b/docs/src/content/docs/guides/groups-and-governance.mdx
@@ -14,12 +14,11 @@ The exhaustive method list is in the [admin API reference](/reference/admin-api/
 
 ## Namespaces
 
-A namespace groups contexts and members under a shared upgrade policy.
+A namespace groups contexts and members under a shared target application.
 
 ```typescript
 const { namespaceId } = await sdk.admin.createNamespace({
   applicationId,
-  upgradePolicy: 'Automatic', // or 'LazyOnAccess'
   name: 'production',
 });
 

--- a/docs/src/content/docs/reference/admin-api.mdx
+++ b/docs/src/content/docs/reference/admin-api.mdx
@@ -229,7 +229,7 @@ interface Namespace {
   namespaceId: string;
   appKey: string;
   targetApplicationId: string;
-  upgradePolicy: 'Automatic' | 'LazyOnAccess';
+  upgradePolicy: string;         // deprecated, always "LazyOnAccess"
   createdAt: number;
   name?: string;
   memberCount: number;
@@ -241,7 +241,7 @@ interface GroupInfo {              // = GroupInfoResponseData
   groupId: string;
   appKey: string;
   targetApplicationId: string;
-  upgradePolicy: 'Automatic' | 'LazyOnAccess';
+  upgradePolicy: string;         // deprecated, always "LazyOnAccess"
   memberCount: number;
   contextCount: number;
   defaultCapabilities: number;    // capability bitmask

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -652,21 +652,19 @@ describe('AdminApiClient', () => {
 
     it('createNamespace sends correct fields', async () => {
       mock.setMockResponse('POST', '/admin-api/namespaces', { data: { namespaceId: 'ns-1' } });
-      const result = await client.createNamespace({ applicationId: 'app-1', upgradePolicy: 'manual', name: 'My NS' });
+      const result = await client.createNamespace({ applicationId: 'app-1', name: 'My NS' });
       expect(result).toEqual({ namespaceId: 'ns-1' });
       expect(mock.getRequestBody('POST', '/admin-api/namespaces')).toEqual({
         applicationId: 'app-1',
-        upgradePolicy: 'manual',
         name: 'My NS',
       });
     });
 
     it('createNamespace forwards the appKey version pin', async () => {
       mock.setMockResponse('POST', '/admin-api/namespaces', { data: { namespaceId: 'ns-1' } });
-      await client.createNamespace({ applicationId: 'app-1', upgradePolicy: 'manual', appKey: 'deadbeef' });
+      await client.createNamespace({ applicationId: 'app-1', appKey: 'deadbeef' });
       expect(mock.getRequestBody('POST', '/admin-api/namespaces')).toEqual({
         applicationId: 'app-1',
-        upgradePolicy: 'manual',
         appKey: 'deadbeef',
       });
     });

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -392,6 +392,8 @@ export interface Namespace {
   namespaceId: string;
   appKey: string;
   targetApplicationId: string;
+  /** @deprecated Always `"LazyOnAccess"`. Core keeps the key only for the
+   * released Python client and drops it once that floor moves. */
   upgradePolicy: string;
   createdAt: number;
   name?: string;
@@ -413,12 +415,8 @@ export interface NamespaceIdentity {
   publicKey: string;
 }
 
-/** Core's `UpgradePolicy` enum — how a namespace/group adopts new app versions. */
-export type UpgradePolicy = 'Automatic' | 'LazyOnAccess';
-
 export interface CreateNamespaceRequest {
   applicationId: string;
-  upgradePolicy: UpgradePolicy;
   name?: string;
   /** Hex 32-byte blob id; pins the namespace to a specific installed version. */
   appKey?: string;
@@ -480,7 +478,6 @@ export interface SubgroupEntry {
 
 export interface CreateGroupRequest {
   applicationId: string;
-  upgradePolicy: string;
   groupId?: string;
   appKey?: string;
   name?: string;
@@ -570,6 +567,8 @@ export interface GroupInfo {
   groupId: string;
   appKey: string;
   targetApplicationId: string;
+  /** @deprecated Always `"LazyOnAccess"`. Core keeps the key only for the
+   * released Python client and drops it once that floor moves. */
   upgradePolicy: string;
   memberCount: number;
   contextCount: number;

--- a/tests/e2e/admin-api.test.ts
+++ b/tests/e2e/admin-api.test.ts
@@ -105,7 +105,6 @@ describe('Admin API E2E — Namespace Model', () => {
     it('should create a namespace', async () => {
       const response = await mero.admin.createNamespace({
         applicationId,
-        upgradePolicy: 'Automatic',
         alias: `e2e-test-ns-${RUN}`,
       });
       expect(response.namespaceId).toBeTruthy();
@@ -123,7 +122,6 @@ describe('Admin API E2E — Namespace Model', () => {
       const ns = await mero.admin.getNamespace(namespaceId);
       expect(ns.namespaceId).toBe(namespaceId);
       expect(ns.targetApplicationId).toBe(applicationId);
-      expect(ns.upgradePolicy).toBe('Automatic');
     });
 
     it('should get namespace identity', async () => {

--- a/tests/e2e/coverage-extra.test.ts
+++ b/tests/e2e/coverage-extra.test.ts
@@ -23,7 +23,6 @@ describe('Admin API E2E — Coverage filler', () => {
     applicationId = await ensureApplication(mero);
     const ns = await mero.admin.createNamespace({
       applicationId,
-      upgradePolicy: 'Automatic',
       alias: `cov-ns-${RUN}`,
     });
     namespaceId = ns.namespaceId;

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -42,7 +42,6 @@ describe('Admin API E2E — Route coverage sweep', () => {
     applicationId = await ensureApplication(mero);
     const ns = await mero.admin.createNamespace({
       applicationId,
-      upgradePolicy: 'Automatic',
       alias: `sweep-${RUN}`,
     });
     namespaceId = ns.namespaceId;

--- a/tests/e2e/full-api.test.ts
+++ b/tests/e2e/full-api.test.ts
@@ -108,7 +108,6 @@ describe('MeroJs E2E — Full Flow', () => {
     it('should create a namespace for the application', async () => {
       const response = await mero.admin.createNamespace({
         applicationId,
-        upgradePolicy: 'Automatic',
         alias: `e2e-full-${runId()}`,
       });
       expect(response.namespaceId).toBeTruthy();

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -34,7 +34,6 @@ suite('Multi-node E2E — namespace invite/join', () => {
 
     const ns = await n1.admin.createNamespace({
       applicationId,
-      upgradePolicy: 'Automatic',
       alias: `mn-${RUN}`,
     });
     namespaceId = ns.namespaceId;

--- a/tests/e2e/round-trip.test.ts
+++ b/tests/e2e/round-trip.test.ts
@@ -25,7 +25,6 @@ beforeAll(async () => {
   applicationId = await ensureApplication(mero);
   const ns = await mero.admin.createNamespace({
     applicationId,
-    upgradePolicy: 'Automatic',
     alias: `rt-${RUN}`,
   });
   namespaceId = ns.namespaceId;
@@ -152,11 +151,10 @@ describe('Round-trip E2E — Groups', () => {
     expect(got.acceptMock).toBe(true);
   });
 
-  // POST /admin-api/groups requires applicationId + upgradePolicy (not just a name).
+  // POST /admin-api/groups requires applicationId (not just a name).
   it('createGroup then getGroupInfo returns it', async () => {
     const created = await mero.admin.createGroup({
       applicationId,
-      upgradePolicy: 'Automatic',
       name: `rt-grp-${RUN}`,
     });
     expect(created.groupId).toBeTruthy();

--- a/tests/e2e/wire.contract.test.ts
+++ b/tests/e2e/wire.contract.test.ts
@@ -159,7 +159,6 @@ describe('live wire contract (merod responses ↔ SDK types)', () => {
     namespaceId = (
       await mero.admin.createNamespace({
         applicationId,
-        upgradePolicy: 'Automatic',
         name: `wire-contract-${RUN}`,
       })
     ).namespaceId;


### PR DESCRIPTION
## Summary

Core deleted the upgrade-policy concept, so the SDK stops sending `upgradePolicy` on the create requests.

Removed, because the server no longer accepts them: `CreateNamespaceRequest.upgradePolicy`, `CreateGroupRequest.upgradePolicy`, the `UpgradePolicy` type, and the argument at every e2e create call site.

Kept and marked `@deprecated`, because the node still sends them: `Namespace.upgradePolicy`, `GroupInfo.upgradePolicy`, and the `ns('upgradePolicy')` wire-contract entry.
Core holds a constant value on those response fields as a compatibility shim for the released Python client that merobox bundles.
`tests/e2e/wire.contract.test.ts` asserts the SDK declares every key the node sends, so removing them here would fail that gate.
They go when the shim goes, once merobox ships a client built from the new master.

Deleted the assertion at `tests/e2e/admin-api.test.ts:126`, which expected `'Automatic'` and now receives the shim's constant.
It is deleted rather than re-pointed: re-asserting the shim's value would bake it into the SDK and need undoing again when the shim is removed.

This unblocks core's `SDK E2E (paired)` job on master.
That job resolves a same-named branch on this repo, so it passed on the core PR by pairing with this branch, and started failing on master where it pairs with `master`.

## Test plan

- `build`, `typecheck`, `typecheck:contract`, and `typecheck:consumer` all pass. The contract typecheck is the compile-time half of the wire gate.
- `lint` clean: 0 errors, 2 pre-existing docs warnings.
- `test:unit`: 281 passed, 1 skipped.
- Verified against core master in the paired run: 112 passed, 3 skipped, previously 111 passed with 1 failure.
