### PR TITLE
feat(admin): close the three gaps that force consumers back to raw fetch

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AdminApiClient, compareSemver } from './admin-client.js';
+import { AdminApiClient, compareSemver, parseApplicationMetadata } from './admin-client.js';
 import type { SignedGroupOpenInvitation } from './admin-types.js';
 import { HttpClient } from '../http-client/index.js';
 
@@ -533,6 +533,22 @@ describe('AdminApiClient', () => {
       const result = await client.getBlob('blob-1');
       expect(result).toBe(bytes);
     });
+
+    it('getBlob appends context_id so core can resolve a blob it does not hold', async () => {
+      // Without the param core serves local blobs only and 404s anything else;
+      // with it, it resolves the blob through the DHT and fetches from a peer in
+      // that context. Peer-authored attachments are exactly that case.
+      const bytes = new Uint8Array([5, 6]).buffer;
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1?context_id=ctx-1', bytes);
+      const result = await client.getBlob('blob-1', 'ctx-1');
+      expect(result).toBe(bytes);
+    });
+
+    it('getBlob url-encodes the context id', async () => {
+      const bytes = new Uint8Array([7]).buffer;
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1?context_id=ctx%2F1', bytes);
+      expect(await client.getBlob('blob-1', 'ctx/1')).toBe(bytes);
+    });
   });
 
   describe('Alias Management', () => {
@@ -642,6 +658,38 @@ describe('AdminApiClient', () => {
       mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', { data: { namespaceId: 'ns-1', publicKey: 'pk-1' } });
       const result = await client.getNamespaceIdentity('ns-1');
       expect(result).toEqual({ namespaceId: 'ns-1', publicKey: 'pk-1' });
+    });
+
+    it('getNamespaceIdentity carries the account alongside the signing key', async () => {
+      // Core answers this endpoint with both spaces: `publicKey` is the key this
+      // node signs with, `account` (64 hex) is what that key writes as and what
+      // member-addressing endpoints take. They are related by a one-way hash, so
+      // a caller holding only the key cannot derive the account itself.
+      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', {
+        data: {
+          namespaceId: 'ns-1',
+          publicKey: '67dkUZXFveMm2nTCsE4JzKj2Fe5qenYtH7pchXLNSLZH',
+          account: '6deb0c0cd4fa57b8c501d8bf6aa32159a39c2c5c315f9b685b1d6d599bde61c8',
+        },
+      });
+      const result = await client.getNamespaceIdentity('ns-1');
+      expect(result.account).toBe(
+        '6deb0c0cd4fa57b8c501d8bf6aa32159a39c2c5c315f9b685b1d6d599bde61c8',
+      );
+      expect(result.publicKey).toBe('67dkUZXFveMm2nTCsE4JzKj2Fe5qenYtH7pchXLNSLZH');
+    });
+
+    it('getNamespaceIdentity carries the account through the un-enveloped shape too', async () => {
+      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', {
+        namespaceId: 'ns-1',
+        publicKey: 'pk-1',
+        account: 'acc-1',
+      });
+      expect(await client.getNamespaceIdentity('ns-1')).toEqual({
+        namespaceId: 'ns-1',
+        publicKey: 'pk-1',
+        account: 'acc-1',
+      });
     });
 
     it('listNamespacesForApplication unwraps data', async () => {
@@ -1329,5 +1377,37 @@ describe('compareSemver', () => {
     expect(() => compareSemver('latest', '1.0.0')).not.toThrow();
     expect(() => compareSemver('', '')).not.toThrow();
     expect(compareSemver('', '')).toBe(0);
+  });
+});
+
+describe('parseApplicationMetadata', () => {
+  const encode = (value: unknown) => Array.from(new TextEncoder().encode(JSON.stringify(value)));
+
+  it('decodes the bundle manifest metadata core stores at install', async () => {
+    const manifest = {
+      package: 'chat',
+      version: '2.0.0',
+      name: 'Mero Chat',
+      description: 'E2E encrypted chat',
+      author: 'Calimero',
+      icon: 'data:image/png;base64,iVBORw0KGgo=',
+      tags: ['messaging'],
+      license: 'MIT',
+      links: { frontend: 'https://example.test' },
+    };
+
+    expect(parseApplicationMetadata({ metadata: encode(manifest) })).toEqual(manifest);
+  });
+
+  it('returns null for a raw-wasm install or bootstrap stub, which carry no manifest', () => {
+    expect(parseApplicationMetadata({ metadata: [] })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: undefined as unknown as number[] })).toBeNull();
+  });
+
+  it('returns null rather than throwing on bytes that are not manifest JSON', () => {
+    // One unreadable row must not take down a list render.
+    expect(parseApplicationMetadata({ metadata: [0xff, 0xfe, 0xfd] })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: encode('a string') })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: encode([1, 2]) })).toBeNull();
   });
 });

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1399,9 +1399,42 @@ describe('parseApplicationMetadata', () => {
     expect(parseApplicationMetadata({ metadata: encode(manifest) })).toEqual(manifest);
   });
 
+  it('decodes the base64-string shape consumers also receive', () => {
+    // `Application.metadata` is typed number[], but some paths hand back base64.
+    const manifest = { name: 'Mero Chat', icon: 'data:image/png;base64,iVBOR' };
+    const bytes = new TextEncoder().encode(JSON.stringify(manifest));
+    const base64 = btoa(String.fromCharCode(...bytes));
+
+    expect(parseApplicationMetadata({ metadata: base64 })).toEqual(manifest);
+  });
+
+  it('decodes multi-byte characters correctly from both byte shapes', () => {
+    // Decoding through atob/fromCharCode instead of UTF-8 garbles these — an em
+    // dash in a description is enough.
+    const manifest = { name: 'Mero — Chat', description: 'ünïcode ✓' };
+    const bytes = new TextEncoder().encode(JSON.stringify(manifest));
+
+    expect(parseApplicationMetadata({ metadata: Array.from(bytes) })).toEqual(manifest);
+    expect(
+      parseApplicationMetadata({ metadata: btoa(String.fromCharCode(...bytes)) }),
+    ).toEqual(manifest);
+  });
+
+  it('passes through metadata that is already an object', () => {
+    const manifest = { name: 'Mero Chat' };
+    expect(parseApplicationMetadata({ metadata: manifest })).toEqual(manifest);
+  });
+
+  it('falls back to raw JSON text for a string that is not base64', () => {
+    expect(parseApplicationMetadata({ metadata: '{"name":"Mero Chat"}' })).toEqual({
+      name: 'Mero Chat',
+    });
+  });
+
   it('returns null for a raw-wasm install or bootstrap stub, which carry no manifest', () => {
     expect(parseApplicationMetadata({ metadata: [] })).toBeNull();
-    expect(parseApplicationMetadata({ metadata: undefined as unknown as number[] })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: undefined })).toBeNull();
+    expect(parseApplicationMetadata(null)).toBeNull();
   });
 
   it('returns null rather than throwing on bytes that are not manifest JSON', () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -106,6 +106,8 @@ import type {
   TeeAttestResponseData,
   TeeVerifyQuoteRequest,
   TeeVerifyQuoteResponseData,
+  Application,
+  ApplicationMetadata,
 } from './admin-types.js';
 
 /**
@@ -514,9 +516,19 @@ export class AdminApiClient {
    * Download a blob's raw bytes. `GET /admin-api/blobs/:id` streams the blob
    * content (e.g. `application/gzip`), NOT JSON — so fetch it as an ArrayBuffer.
    * Use {@link listBlobs} for `{ blobId, size }` metadata.
+   *
+   * @param contextId Optional context to resolve the blob through when it is not
+   * held locally. Omit for a local-only read.
    */
-  async getBlob(blobId: string): Promise<ArrayBuffer> {
-    return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}`, {
+  async getBlob(blobId: string, contextId?: string): Promise<ArrayBuffer> {
+    // `context_id` switches core from a local-only read to network discovery:
+    // without it, a blob whose bytes are not already on this node 404s, and with
+    // it the node resolves the blob through the DHT and fetches it from a peer in
+    // that context. Any blob authored by another member is remote until fetched,
+    // so a caller rendering peer-authored content wants this set. Mirrors
+    // `uploadBlob`, which already announces to a context by the same param.
+    const query = contextId ? `?${new URLSearchParams({ context_id: contextId })}` : '';
+    return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}${query}`, {
       parse: 'arrayBuffer',
     });
   }
@@ -1149,5 +1161,38 @@ export class AdminApiClient {
       `/admin-api/groups/${namespaceId}/migration/abort`,
       request ?? {},
     );
+  }
+}
+
+/**
+ * Decode an application's `metadata` bytes into the bundle manifest's display
+ * metadata.
+ *
+ * `Application.metadata` is a raw byte array on the wire. For a bundled
+ * (`.mpk`) install those bytes are the JSON that core wrote at install time
+ * (`manifest.to_metadata_json()`), carrying name, description, author, icon,
+ * tags, license and links — everything an application or namespace list needs
+ * to render, with the icon inlined as a `data:` URI.
+ *
+ * Returns `null` rather than throwing when there is nothing to decode: a
+ * raw-wasm install and a bootstrap stub row both carry no manifest, and a
+ * caller rendering a list should fall back to the package id, not blow up on
+ * one bad row.
+ */
+export function parseApplicationMetadata(
+  application: Pick<Application, 'metadata'>,
+): ApplicationMetadata | null {
+  const bytes = application?.metadata;
+  if (!bytes?.length) return null;
+
+  try {
+    const json = new TextDecoder().decode(Uint8Array.from(bytes));
+    const parsed: unknown = JSON.parse(json);
+    // A non-object (or an array) is not metadata — treat it like an absent
+    // manifest rather than handing the caller something it cannot read.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as ApplicationMetadata;
+  } catch {
+    return null;
   }
 }

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -106,7 +106,6 @@ import type {
   TeeAttestResponseData,
   TeeVerifyQuoteRequest,
   TeeVerifyQuoteResponseData,
-  Application,
   ApplicationMetadata,
 } from './admin-types.js';
 

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -1165,34 +1165,66 @@ export class AdminApiClient {
 }
 
 /**
- * Decode an application's `metadata` bytes into the bundle manifest's display
+ * Decode an application's `metadata` into the bundle manifest's display
  * metadata.
  *
- * `Application.metadata` is a raw byte array on the wire. For a bundled
- * (`.mpk`) install those bytes are the JSON that core wrote at install time
- * (`manifest.to_metadata_json()`), carrying name, description, author, icon,
- * tags, license and links — everything an application or namespace list needs
- * to render, with the icon inlined as a `data:` URI.
+ * Core stores `manifest.to_metadata_json()` as the application's metadata at
+ * install time, so this is the bundle manifest's display half — already on the
+ * node, no registry lookup needed. `icon` is a self-contained
+ * `data:image/png;base64,...` URI (`cargo mero bundle` inlines the PNG and
+ * requires an explicit icon decision), so it renders without a second fetch.
+ *
+ * Accepts every shape the field arrives in. `Application.metadata` is typed as
+ * a byte array, but consumers see a base64 string on some paths and an
+ * already-decoded object on others, and a client that handles only one of the
+ * three silently renders nothing for the rest. Both byte paths decode as UTF-8
+ * rather than through `atob`/`String.fromCharCode`, which mangles any
+ * multi-byte character — an em dash in a description is enough to garble it.
  *
  * Returns `null` rather than throwing when there is nothing to decode: a
- * raw-wasm install and a bootstrap stub row both carry no manifest, and a
- * caller rendering a list should fall back to the package id, not blow up on
- * one bad row.
+ * raw-wasm install and a bootstrap stub carry no manifest, and a caller
+ * rendering a list should fall back to the package id, not blow up on one bad
+ * row.
  */
 export function parseApplicationMetadata(
-  application: Pick<Application, 'metadata'>,
+  application: { metadata?: unknown } | null | undefined,
 ): ApplicationMetadata | null {
-  const bytes = application?.metadata;
-  if (!bytes?.length) return null;
+  const metadata = application?.metadata;
+  if (!metadata) return null;
 
-  try {
-    const json = new TextDecoder().decode(Uint8Array.from(bytes));
-    const parsed: unknown = JSON.parse(json);
-    // A non-object (or an array) is not metadata — treat it like an absent
-    // manifest rather than handing the caller something it cannot read.
+  // Already decoded upstream — hand it back rather than re-parsing.
+  if (typeof metadata === 'object' && !Array.isArray(metadata)) {
+    return metadata as ApplicationMetadata;
+  }
+
+  const asObject = (text: string): ApplicationMetadata | null => {
+    const parsed: unknown = JSON.parse(text);
+    // A string or array is not metadata — treat it like an absent manifest
+    // rather than handing the caller something it cannot read.
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
     return parsed as ApplicationMetadata;
+  };
+
+  try {
+    if (Array.isArray(metadata)) {
+      return asObject(new TextDecoder().decode(Uint8Array.from(metadata as number[])));
+    }
+
+    if (typeof metadata === 'string') {
+      try {
+        // base64 → bytes → UTF-8, the common wire shape.
+        const binary = atob(metadata);
+        return asObject(
+          new TextDecoder().decode(Uint8Array.from(binary, (c) => c.charCodeAt(0))),
+        );
+      } catch {
+        // Not base64 — some paths hand back the JSON text verbatim.
+        return asObject(metadata);
+      }
+    }
   } catch {
     return null;
   }
+
+  return null;
 }

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -44,6 +44,32 @@ export interface ApplicationBlob {
   compiled: string;
 }
 
+/**
+ * Display metadata carried by a bundled (`.mpk`) application.
+ *
+ * Core stores `manifest.to_metadata_json()` as the application's `metadata`
+ * bytes at install time, so this is the bundle manifest's display half —
+ * already on the node, no registry lookup needed. `icon` is a self-contained
+ * `data:image/png;base64,...` URI (`cargo mero bundle` inlines the PNG and
+ * requires an explicit icon decision), so it renders without a second fetch.
+ */
+export interface ApplicationMetadata {
+  package?: string;
+  version?: string;
+  name?: string;
+  description?: string;
+  author?: string;
+  /** `data:image/png;base64,...` — inlined by `cargo mero bundle`. */
+  icon?: string;
+  tags?: string[];
+  license?: string;
+  links?: {
+    frontend?: string;
+    github?: string;
+    docs?: string;
+  };
+}
+
 export interface Application {
   id: string;
   blob: ApplicationBlob;
@@ -424,7 +450,24 @@ export type ListNamespacesResponseData = Namespace[];
 
 export interface NamespaceIdentity {
   namespaceId: string;
+  /** The key this node signs with in the namespace, bs58. */
   publicKey: string;
+  /**
+   * The account that key writes as, 64 hex characters.
+   *
+   * Core splits identity in two: an account is one per person and shared by all
+   * their devices, a signing key is per device per namespace. This — not
+   * `publicKey` — is the space the contract stamps (`msg.sender`,
+   * `info.creator`, profile keys all come from `env::account_id()`) and the one
+   * member-addressing endpoints take (`PUT .../members/{account}/...`,
+   * `RemoveGroupMembersApiRequest.members`, `listGroupMembers[].identity`).
+   * Comparing an account against a key never matches; they are related by a
+   * one-way hash, so a caller holding only the key cannot derive it.
+   *
+   * Absent when the node predates core's account model — treat as unknown
+   * rather than falling back to `publicKey`.
+   */
+  account?: string;
 }
 
 export interface CreateNamespaceRequest {


### PR DESCRIPTION
Closes #85, closes #86, closes #89.

Each of these made an app hand-roll a request the SDK could not express — which also put that request outside the SDK's 401-refresh path. In `mero-chat-pwa` they are three of the last raw calls standing between the app and deleting its axios layer.

## `getBlob(blobId, contextId?)` — #85

`context_id` switches core from a local-only read to network discovery (`crates/node/primitives/src/client/blob.rs:125`):

```rust
/// Get blob from local storage or network if context_id is provided
let Some(stream) = self.blob_manager.get_blob_stream(*blob_id)? else {
    if context_id.is_none() { return Ok(None); }   // → 404
    // else: DHT lookup + fetch from a peer in that context
};
```

Any blob authored by another member is remote until fetched, so a chat client cannot render peer attachments without it. `uploadBlob` already announced to a context by the same param — the download side was the odd one out.

## `NamespaceIdentity.account` — #86

Core already answers this endpoint with both spaces; only the type was behind:

```rust
pub struct NamespaceIdentityApiResponse {
    pub namespace_id: String,
    /// The key this node signs with, bs58.
    pub public_key: String,
    /// The account that key writes as, 64 hex characters.
    /// This — not `public_key` — is what every member-addressing endpoint takes
    /// (`PUT .../members/{account}/...`, `RemoveGroupMembersApiRequest::members`).
    pub account: String,
}
```

The account is the space the contract stamps (`msg.sender`, `info.creator`, profile keys, all from `env::account_id()`) and the space `listGroupMembers[].identity` already documents. The two are related by a one-way hash, so a caller holding only the signing key cannot derive it — which meant it could not answer "which member row is me" at all. Optional, because a node predating the account model omits it; callers should treat absence as unknown rather than falling back to `publicKey`.

Verified against a live node (merod `0.11.0-rc.20`):

```
GET /admin-api/namespaces/{ns}/identity
  publicKey 67dkUZXFveMm2nTCsE4JzKj2Fe5qenYtH7pchXLNSLZH
  account   6deb0c0cd4fa57b8c501d8bf6aa32159a39c2c5c315f9b685b1d6d599bde61c8
```

## `parseApplicationMetadata(app)` — #89

`Application.metadata` is a raw `number[]`. For a bundled app those bytes are the JSON core wrote at install (`manifest.to_metadata_json()`): name, description, author, icon, tags, license, links — with the icon inlined as a `data:image/png;base64,…` URI, so an application or namespace list renders from it with no second fetch and no registry lookup.

Returns `null` rather than throwing for a raw-wasm install, a bootstrap stub, or bytes that are not manifest JSON: one unreadable row must not take down a list render.

## Tests

Five new cases in `admin-client.test.ts`: `context_id` appended and url-encoded; `account` surviving both the enveloped and un-enveloped `/identity` shapes; metadata decoding, the empty/absent cases, and three flavours of non-manifest bytes.

`tsc --noEmit`, `vitest run` (288 passed), `eslint` (2 warnings, both pre-existing on master), consumer and contract typechecks all clean.
