### PR TITLE
feat(auth): let the event stream and app-owned requests share the refresh

### DIFF
--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -271,6 +271,126 @@ describe('SseClient', () => {
     });
   });
 
+  describe('token refresh', () => {
+    // The stream and its subscription calls are plain `fetch`, so they do not
+    // inherit the HTTP client's 401 hook. Without these, an expired access
+    // token takes the stream down until something else rotates the bundle —
+    // for an idle tab whose only activity is SSE, that is never.
+    const unauthorized = (authError?: string) => ({
+      ok: false,
+      status: 401,
+      headers: { get: (name: string) => (name === 'x-auth-error' ? authError ?? null : null) },
+    });
+
+    const authHeader = (call: unknown[]) =>
+      ((call[1] as RequestInit).headers as Record<string, string>).Authorization;
+
+    it('refreshes once and retries the request with the new token', async () => {
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(unauthorized())
+        .mockResolvedValueOnce({ ok: true });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(authHeader(fetchMock.mock.calls[0])).toBe('Bearer stale-token');
+      expect(authHeader(fetchMock.mock.calls[1])).toBe('Bearer fresh-token');
+      c.close();
+    });
+
+    it('retries only once when the refreshed token is also rejected', async () => {
+      // Looping here would spend a single-use refresh token per attempt for a
+      // problem that is not staleness.
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      c.close();
+    });
+
+    it('does not refresh a revoked family — it reports and stops', async () => {
+      // A replayed single-use refresh token revokes the family; refreshing
+      // again would burn another token for nothing.
+      const refreshToken = vi.fn();
+      const onAuthRevoked = vi.fn();
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'dead-token',
+        refreshToken,
+        onAuthRevoked,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized('token_reuse'));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      c.close();
+    });
+
+    it('leaves the 401 alone when no refresh hook is configured', async () => {
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+      });
+      (c as any).sessionId = 'sess-1';
+      const onError = vi.fn();
+      c.on('error', onError);
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalled();
+      c.close();
+    });
+
+    it('refreshes on the stream connect too, not just subscriptions', async () => {
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+        reconnectDelayMs: 100,
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(unauthorized())
+        .mockResolvedValueOnce({ ok: true, status: 200, body: null, headers: { get: () => null } });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.connect();
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(authHeader(fetchMock.mock.calls[1])).toBe('Bearer fresh-token');
+      c.close();
+    });
+  });
+
   describe('close', () => {
     it('clears all state', () => {
       (client as any).sessionId = 'sess';

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -27,9 +27,18 @@ interface SseListeners {
   error: SseErrorHandler[];
 }
 
+/**
+ * `x-auth-error` reasons that mean the whole token family is gone. Mirrors the
+ * HTTP client: refreshing again would burn another single-use token and
+ * retrying would 401 again, so these are terminal.
+ */
+const TERMINAL_AUTH_ERRORS = new Set(['token_reuse', 'token_revoked']);
+
 export class SseClient {
   private baseUrl: string;
   private getAuthToken: () => Promise<string>;
+  private refreshToken?: () => Promise<string>;
+  private onAuthRevoked?: () => Promise<void> | void;
   private reconnectDelayMs: number;
   private sessionId: string | null = null;
   private abortController: AbortController | null = null;
@@ -42,10 +51,29 @@ export class SseClient {
   constructor(opts: {
     baseUrl: string;
     getAuthToken: () => Promise<string>;
+    /**
+     * Refresh the access token after a 401 and return the new one. Wire this to
+     * the same single-flight refresh the HTTP client uses — refresh tokens are
+     * single-use (calimero-network/core#3083), so a second, independent
+     * refresher would replay a consumed token and get the family revoked.
+     *
+     * Without it the stream cannot recover from an expired token: it 401s on
+     * connect and stays down until something else happens to rotate the bundle,
+     * which for an idle tab whose only activity is SSE is never.
+     */
+    refreshToken?: () => Promise<string>;
+    /**
+     * Called when the server reports a dead token family (`x-auth-error:
+     * token_reuse` / `token_revoked`). Terminal — the stream does not retry or
+     * reconnect, because only a fresh login can fix it.
+     */
+    onAuthRevoked?: () => Promise<void> | void;
     reconnectDelayMs?: number;
   }) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
     this.getAuthToken = opts.getAuthToken;
+    this.refreshToken = opts.refreshToken;
+    this.onAuthRevoked = opts.onAuthRevoked;
     this.reconnectDelayMs = opts.reconnectDelayMs ?? 3000;
   }
 
@@ -108,6 +136,45 @@ export class SseClient {
     }
   }
 
+  /**
+   * Fetch with a bearer token, refreshing once on a 401 and retrying.
+   *
+   * The stream and its subscription calls are plain `fetch`, not the HTTP
+   * client, so they do not inherit its 401 hook — without this an expired
+   * access token takes the stream down permanently. A revoked family is
+   * terminal and reported to `onAuthRevoked` instead of retried.
+   */
+  private async authedFetch(url: string, init: RequestInit): Promise<Response> {
+    const withToken = async (token: string): Promise<Response> =>
+      fetch(url, {
+        ...init,
+        headers: { ...(init.headers as Record<string, string>), Authorization: `Bearer ${token}` },
+      });
+
+    const response = await withToken(await this.getAuthToken());
+    if (response.status !== 401) return response;
+
+    const authError = response.headers.get('x-auth-error');
+    if (authError && TERMINAL_AUTH_ERRORS.has(authError)) {
+      try {
+        await this.onAuthRevoked?.();
+      } catch {
+        // A failing app callback must not mask the auth error.
+      }
+      return response;
+    }
+
+    if (!this.refreshToken) return response;
+
+    // One retry only: if the refreshed token is also rejected, the problem is
+    // not staleness and looping would spend refresh tokens for nothing.
+    try {
+      return await withToken(await this.refreshToken());
+    } catch {
+      return response;
+    }
+  }
+
   async connect(): Promise<void> {
     // Already connected — don't reconnect
     if (this.abortController && !this.closed) {
@@ -117,12 +184,8 @@ export class SseClient {
     this.abortController = new AbortController();
 
     try {
-      const token = await this.getAuthToken();
-      const response = await fetch(`${this.baseUrl}/sse`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'text/event-stream',
-        },
+      const response = await this.authedFetch(`${this.baseUrl}/sse`, {
+        headers: { 'Accept': 'text/event-stream' },
         signal: this.abortController.signal,
       });
 
@@ -285,16 +348,12 @@ export class SseClient {
     ids: { contextIds?: string[]; groupIds?: string[] },
   ): Promise<void> {
     try {
-      const token = await this.getAuthToken();
       const params: { contextIds?: string[]; groupIds?: string[] } = {};
       if (ids.contextIds && ids.contextIds.length > 0) params.contextIds = ids.contextIds;
       if (ids.groupIds && ids.groupIds.length > 0) params.groupIds = ids.groupIds;
-      const response = await fetch(`${this.baseUrl}/sse/subscription`, {
+      const response = await this.authedFetch(`${this.baseUrl}/sse/subscription`, {
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           id: this.sessionId,
           method,

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -173,6 +173,41 @@ export class MeroJs {
   }
 
   /**
+   * The configured HTTP client — same transport `admin` and `rpc` use.
+   *
+   * Escape hatch for a request this SDK does not model yet: an endpoint without
+   * a method, or one whose method cannot express a needed parameter. Going
+   * through here rather than a hand-rolled `fetch`/axios keeps the request
+   * inside the auth lifecycle — bearer token, single-flight refresh on 401 with
+   * one retry, and the terminal `onAuthRevoked` path.
+   *
+   * Prefer a typed method where one exists; reach for this instead of building
+   * a second HTTP layer with its own copy of the token, which is how apps end
+   * up never refreshing.
+   */
+  get http(): HttpClient {
+    return this.httpClient;
+  }
+
+  /**
+   * Force a token refresh and return the new bundle.
+   *
+   * Rarely needed — the HTTP client and the event stream refresh themselves
+   * reactively on a 401. Use it when app-owned work must hold a token the SDK
+   * never sees.
+   *
+   * Safe to call concurrently: this is the single-flight path, guarded by an
+   * in-process promise and a cross-tab Web Lock, and it re-reads the token
+   * store inside the lock so a bundle another instance already rotated is
+   * adopted rather than replayed. Do NOT call `auth.refreshToken()` directly
+   * for this — it bypasses both guards, and a replayed single-use refresh token
+   * revokes the whole family (calimero-network/core#3083).
+   */
+  async refresh(): Promise<TokenData> {
+    return this.performTokenRefresh();
+  }
+
+  /**
    * Get the RPC client (lazy initialized)
    */
   get rpc(): RpcClient {
@@ -192,6 +227,22 @@ export class MeroJs {
         getAuthToken: async () => {
           const token = await this.getValidToken();
           return token?.access_token || '';
+        },
+        // The stream is plain `fetch`, so it does not inherit the HTTP client's
+        // 401 hook. Hand it the SAME single-flight refresh: refresh tokens are
+        // single-use (calimero-network/core#3083), so an independent refresher
+        // here would replay a consumed token and revoke the family.
+        refreshToken: async () => {
+          const refreshed = await this.performTokenRefresh();
+          return refreshed.access_token;
+        },
+        onAuthRevoked: async () => {
+          this.clearToken();
+          try {
+            await this.config.onAuthRevoked?.();
+          } catch {
+            // A failing app callback must not mask the auth error.
+          }
         },
       });
     }


### PR DESCRIPTION
Closes #87, closes #88. Stacked on #90 — review that first; the base flips to `master` when it merges.

The HTTP client refreshes reactively on a 401 behind a single-flight promise and a cross-tab Web Lock. Nothing else could reach that path, so everything else silently could not recover from an expired token.

## SSE — #87

`MeroJs` handed `SseClient` only `getAuthToken`:

```ts
this.sseClient = new SseClient({
  baseUrl: this.config.baseUrl,
  getAuthToken: async () => (await this.getValidToken())?.access_token || '',
});
```

and the stream is plain `fetch`, so it never saw the HTTP client's 401 hook. `getValidToken` deliberately never refreshes proactively — the server rejects a refresh while the access token is still valid — so once it expired the stream 401'd on connect and stayed down until some *other* call happened to rotate the bundle. For an idle tab whose only activity is the event stream, that is never: the app looks live and has silently stopped receiving events.

Both the connect and the subscription calls now go through one `authedFetch` that refreshes **once** and retries. It delegates to the same single-flight refresh the HTTP client uses — refresh tokens are single-use (calimero-network/core#3083), so an independent refresher here would replay a consumed token and revoke the family. A dead family (`x-auth-error: token_reuse` / `token_revoked`) is terminal: reported via `onAuthRevoked`, never retried.

**`WsClient` is deliberately unchanged**, contrary to what #87 suggested. It carries the token as a query param on the WebSocket URL, and a browser WebSocket handshake failure is not distinguishable as a 401 — refreshing on any failed handshake would spend a single-use refresh token on every network blip. It is also flagged experimental. Worth revisiting if it is ever promoted; say the word if you'd rather have it now.

## `MeroJs.http` and `MeroJs.refresh()` — #88

An app needing a request the SDK does not model had no supported way to stay inside the auth lifecycle. `performTokenRefresh` and `httpClient` are private; `auth.refreshToken()` is public but bypasses both the single-flight promise and the Web Lock, so calling it races the SDK's own refresh over the same stored bundle and revokes the family.

The practical result is what `mero-chat-pwa` did: a second HTTP layer (40 axios calls) holding its own copy of the token, which therefore never refreshed. `http` is the escape hatch that keeps such calls in the lifecycle — bearer token, single-flight refresh, one retry, terminal `onAuthRevoked` — and `refresh()` covers the rarer case of app-owned work holding a token the SDK never sees.

Both are documented as second choices: prefer a typed method where one exists.

## Tests

Five cases in `sse.test.ts`: refresh-once-and-retry with the new token asserted on the retry; only one retry when the refreshed token is also rejected; a revoked family reported without refreshing or retrying; an unconfigured hook left alone (the 401 still surfaces as an error event); and the same behaviour on stream connect, not just subscriptions.

Verified they actually catch the defect — stubbing out the retry turns 3 of them red, and they pass again when restored.

`tsc --noEmit`, `vitest run` (293 passed), `eslint` (2 warnings, both pre-existing on master), consumer and contract typechecks all clean.
