### PR TITLE
fix(auth): stop claiming admin on every authenticate() call

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AdminApiClient, compareSemver } from './admin-client.js';
+import { AdminApiClient, compareSemver, parseApplicationMetadata } from './admin-client.js';
 import type { SignedGroupOpenInvitation } from './admin-types.js';
 import { HttpClient } from '../http-client/index.js';
 
@@ -533,6 +533,22 @@ describe('AdminApiClient', () => {
       const result = await client.getBlob('blob-1');
       expect(result).toBe(bytes);
     });
+
+    it('getBlob appends context_id so core can resolve a blob it does not hold', async () => {
+      // Without the param core serves local blobs only and 404s anything else;
+      // with it, it resolves the blob through the DHT and fetches from a peer in
+      // that context. Peer-authored attachments are exactly that case.
+      const bytes = new Uint8Array([5, 6]).buffer;
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1?context_id=ctx-1', bytes);
+      const result = await client.getBlob('blob-1', 'ctx-1');
+      expect(result).toBe(bytes);
+    });
+
+    it('getBlob url-encodes the context id', async () => {
+      const bytes = new Uint8Array([7]).buffer;
+      mock.setMockResponse('GET', '/admin-api/blobs/blob-1?context_id=ctx%2F1', bytes);
+      expect(await client.getBlob('blob-1', 'ctx/1')).toBe(bytes);
+    });
   });
 
   describe('Alias Management', () => {
@@ -642,6 +658,38 @@ describe('AdminApiClient', () => {
       mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', { data: { namespaceId: 'ns-1', publicKey: 'pk-1' } });
       const result = await client.getNamespaceIdentity('ns-1');
       expect(result).toEqual({ namespaceId: 'ns-1', publicKey: 'pk-1' });
+    });
+
+    it('getNamespaceIdentity carries the account alongside the signing key', async () => {
+      // Core answers this endpoint with both spaces: `publicKey` is the key this
+      // node signs with, `account` (64 hex) is what that key writes as and what
+      // member-addressing endpoints take. They are related by a one-way hash, so
+      // a caller holding only the key cannot derive the account itself.
+      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', {
+        data: {
+          namespaceId: 'ns-1',
+          publicKey: '67dkUZXFveMm2nTCsE4JzKj2Fe5qenYtH7pchXLNSLZH',
+          account: '6deb0c0cd4fa57b8c501d8bf6aa32159a39c2c5c315f9b685b1d6d599bde61c8',
+        },
+      });
+      const result = await client.getNamespaceIdentity('ns-1');
+      expect(result.account).toBe(
+        '6deb0c0cd4fa57b8c501d8bf6aa32159a39c2c5c315f9b685b1d6d599bde61c8',
+      );
+      expect(result.publicKey).toBe('67dkUZXFveMm2nTCsE4JzKj2Fe5qenYtH7pchXLNSLZH');
+    });
+
+    it('getNamespaceIdentity carries the account through the un-enveloped shape too', async () => {
+      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', {
+        namespaceId: 'ns-1',
+        publicKey: 'pk-1',
+        account: 'acc-1',
+      });
+      expect(await client.getNamespaceIdentity('ns-1')).toEqual({
+        namespaceId: 'ns-1',
+        publicKey: 'pk-1',
+        account: 'acc-1',
+      });
     });
 
     it('listNamespacesForApplication unwraps data', async () => {
@@ -1329,5 +1377,37 @@ describe('compareSemver', () => {
     expect(() => compareSemver('latest', '1.0.0')).not.toThrow();
     expect(() => compareSemver('', '')).not.toThrow();
     expect(compareSemver('', '')).toBe(0);
+  });
+});
+
+describe('parseApplicationMetadata', () => {
+  const encode = (value: unknown) => Array.from(new TextEncoder().encode(JSON.stringify(value)));
+
+  it('decodes the bundle manifest metadata core stores at install', async () => {
+    const manifest = {
+      package: 'chat',
+      version: '2.0.0',
+      name: 'Mero Chat',
+      description: 'E2E encrypted chat',
+      author: 'Calimero',
+      icon: 'data:image/png;base64,iVBORw0KGgo=',
+      tags: ['messaging'],
+      license: 'MIT',
+      links: { frontend: 'https://example.test' },
+    };
+
+    expect(parseApplicationMetadata({ metadata: encode(manifest) })).toEqual(manifest);
+  });
+
+  it('returns null for a raw-wasm install or bootstrap stub, which carry no manifest', () => {
+    expect(parseApplicationMetadata({ metadata: [] })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: undefined as unknown as number[] })).toBeNull();
+  });
+
+  it('returns null rather than throwing on bytes that are not manifest JSON', () => {
+    // One unreadable row must not take down a list render.
+    expect(parseApplicationMetadata({ metadata: [0xff, 0xfe, 0xfd] })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: encode('a string') })).toBeNull();
+    expect(parseApplicationMetadata({ metadata: encode([1, 2]) })).toBeNull();
   });
 });

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -106,6 +106,8 @@ import type {
   TeeAttestResponseData,
   TeeVerifyQuoteRequest,
   TeeVerifyQuoteResponseData,
+  Application,
+  ApplicationMetadata,
 } from './admin-types.js';
 
 /**
@@ -514,9 +516,19 @@ export class AdminApiClient {
    * Download a blob's raw bytes. `GET /admin-api/blobs/:id` streams the blob
    * content (e.g. `application/gzip`), NOT JSON — so fetch it as an ArrayBuffer.
    * Use {@link listBlobs} for `{ blobId, size }` metadata.
+   *
+   * @param contextId Optional context to resolve the blob through when it is not
+   * held locally. Omit for a local-only read.
    */
-  async getBlob(blobId: string): Promise<ArrayBuffer> {
-    return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}`, {
+  async getBlob(blobId: string, contextId?: string): Promise<ArrayBuffer> {
+    // `context_id` switches core from a local-only read to network discovery:
+    // without it, a blob whose bytes are not already on this node 404s, and with
+    // it the node resolves the blob through the DHT and fetches it from a peer in
+    // that context. Any blob authored by another member is remote until fetched,
+    // so a caller rendering peer-authored content wants this set. Mirrors
+    // `uploadBlob`, which already announces to a context by the same param.
+    const query = contextId ? `?${new URLSearchParams({ context_id: contextId })}` : '';
+    return this.httpClient.get<ArrayBuffer>(`/admin-api/blobs/${blobId}${query}`, {
       parse: 'arrayBuffer',
     });
   }
@@ -1149,5 +1161,38 @@ export class AdminApiClient {
       `/admin-api/groups/${namespaceId}/migration/abort`,
       request ?? {},
     );
+  }
+}
+
+/**
+ * Decode an application's `metadata` bytes into the bundle manifest's display
+ * metadata.
+ *
+ * `Application.metadata` is a raw byte array on the wire. For a bundled
+ * (`.mpk`) install those bytes are the JSON that core wrote at install time
+ * (`manifest.to_metadata_json()`), carrying name, description, author, icon,
+ * tags, license and links — everything an application or namespace list needs
+ * to render, with the icon inlined as a `data:` URI.
+ *
+ * Returns `null` rather than throwing when there is nothing to decode: a
+ * raw-wasm install and a bootstrap stub row both carry no manifest, and a
+ * caller rendering a list should fall back to the package id, not blow up on
+ * one bad row.
+ */
+export function parseApplicationMetadata(
+  application: Pick<Application, 'metadata'>,
+): ApplicationMetadata | null {
+  const bytes = application?.metadata;
+  if (!bytes?.length) return null;
+
+  try {
+    const json = new TextDecoder().decode(Uint8Array.from(bytes));
+    const parsed: unknown = JSON.parse(json);
+    // A non-object (or an array) is not metadata — treat it like an absent
+    // manifest rather than handing the caller something it cannot read.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as ApplicationMetadata;
+  } catch {
+    return null;
   }
 }

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -44,6 +44,32 @@ export interface ApplicationBlob {
   compiled: string;
 }
 
+/**
+ * Display metadata carried by a bundled (`.mpk`) application.
+ *
+ * Core stores `manifest.to_metadata_json()` as the application's `metadata`
+ * bytes at install time, so this is the bundle manifest's display half —
+ * already on the node, no registry lookup needed. `icon` is a self-contained
+ * `data:image/png;base64,...` URI (`cargo mero bundle` inlines the PNG and
+ * requires an explicit icon decision), so it renders without a second fetch.
+ */
+export interface ApplicationMetadata {
+  package?: string;
+  version?: string;
+  name?: string;
+  description?: string;
+  author?: string;
+  /** `data:image/png;base64,...` — inlined by `cargo mero bundle`. */
+  icon?: string;
+  tags?: string[];
+  license?: string;
+  links?: {
+    frontend?: string;
+    github?: string;
+    docs?: string;
+  };
+}
+
 export interface Application {
   id: string;
   blob: ApplicationBlob;
@@ -424,7 +450,24 @@ export type ListNamespacesResponseData = Namespace[];
 
 export interface NamespaceIdentity {
   namespaceId: string;
+  /** The key this node signs with in the namespace, bs58. */
   publicKey: string;
+  /**
+   * The account that key writes as, 64 hex characters.
+   *
+   * Core splits identity in two: an account is one per person and shared by all
+   * their devices, a signing key is per device per namespace. This — not
+   * `publicKey` — is the space the contract stamps (`msg.sender`,
+   * `info.creator`, profile keys all come from `env::account_id()`) and the one
+   * member-addressing endpoints take (`PUT .../members/{account}/...`,
+   * `RemoveGroupMembersApiRequest.members`, `listGroupMembers[].identity`).
+   * Comparing an account against a key never matches; they are related by a
+   * one-way hash, so a caller holding only the key cannot derive it.
+   *
+   * Absent when the node predates core's account model — treat as unknown
+   * rather than falling back to `publicKey`.
+   */
+  account?: string;
 }
 
 export interface CreateNamespaceRequest {

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -271,6 +271,126 @@ describe('SseClient', () => {
     });
   });
 
+  describe('token refresh', () => {
+    // The stream and its subscription calls are plain `fetch`, so they do not
+    // inherit the HTTP client's 401 hook. Without these, an expired access
+    // token takes the stream down until something else rotates the bundle —
+    // for an idle tab whose only activity is SSE, that is never.
+    const unauthorized = (authError?: string) => ({
+      ok: false,
+      status: 401,
+      headers: { get: (name: string) => (name === 'x-auth-error' ? authError ?? null : null) },
+    });
+
+    const authHeader = (call: unknown[]) =>
+      ((call[1] as RequestInit).headers as Record<string, string>).Authorization;
+
+    it('refreshes once and retries the request with the new token', async () => {
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(unauthorized())
+        .mockResolvedValueOnce({ ok: true });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(authHeader(fetchMock.mock.calls[0])).toBe('Bearer stale-token');
+      expect(authHeader(fetchMock.mock.calls[1])).toBe('Bearer fresh-token');
+      c.close();
+    });
+
+    it('retries only once when the refreshed token is also rejected', async () => {
+      // Looping here would spend a single-use refresh token per attempt for a
+      // problem that is not staleness.
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      c.close();
+    });
+
+    it('does not refresh a revoked family — it reports and stops', async () => {
+      // A replayed single-use refresh token revokes the family; refreshing
+      // again would burn another token for nothing.
+      const refreshToken = vi.fn();
+      const onAuthRevoked = vi.fn();
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'dead-token',
+        refreshToken,
+        onAuthRevoked,
+      });
+      (c as any).sessionId = 'sess-1';
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized('token_reuse'));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(onAuthRevoked).toHaveBeenCalledTimes(1);
+      expect(refreshToken).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      c.close();
+    });
+
+    it('leaves the 401 alone when no refresh hook is configured', async () => {
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+      });
+      (c as any).sessionId = 'sess-1';
+      const onError = vi.fn();
+      c.on('error', onError);
+      const fetchMock = vi.fn().mockResolvedValue(unauthorized());
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.subscribe({ contextIds: ['ctx-1'] });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalled();
+      c.close();
+    });
+
+    it('refreshes on the stream connect too, not just subscriptions', async () => {
+      const refreshToken = vi.fn().mockResolvedValue('fresh-token');
+      const c = new SseClient({
+        baseUrl: 'http://localhost:4001',
+        getAuthToken: async () => 'stale-token',
+        refreshToken,
+        reconnectDelayMs: 100,
+      });
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(unauthorized())
+        .mockResolvedValueOnce({ ok: true, status: 200, body: null, headers: { get: () => null } });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await c.connect();
+
+      expect(refreshToken).toHaveBeenCalledTimes(1);
+      expect(authHeader(fetchMock.mock.calls[1])).toBe('Bearer fresh-token');
+      c.close();
+    });
+  });
+
   describe('close', () => {
     it('clears all state', () => {
       (client as any).sessionId = 'sess';

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -27,9 +27,18 @@ interface SseListeners {
   error: SseErrorHandler[];
 }
 
+/**
+ * `x-auth-error` reasons that mean the whole token family is gone. Mirrors the
+ * HTTP client: refreshing again would burn another single-use token and
+ * retrying would 401 again, so these are terminal.
+ */
+const TERMINAL_AUTH_ERRORS = new Set(['token_reuse', 'token_revoked']);
+
 export class SseClient {
   private baseUrl: string;
   private getAuthToken: () => Promise<string>;
+  private refreshToken?: () => Promise<string>;
+  private onAuthRevoked?: () => Promise<void> | void;
   private reconnectDelayMs: number;
   private sessionId: string | null = null;
   private abortController: AbortController | null = null;
@@ -42,10 +51,29 @@ export class SseClient {
   constructor(opts: {
     baseUrl: string;
     getAuthToken: () => Promise<string>;
+    /**
+     * Refresh the access token after a 401 and return the new one. Wire this to
+     * the same single-flight refresh the HTTP client uses — refresh tokens are
+     * single-use (calimero-network/core#3083), so a second, independent
+     * refresher would replay a consumed token and get the family revoked.
+     *
+     * Without it the stream cannot recover from an expired token: it 401s on
+     * connect and stays down until something else happens to rotate the bundle,
+     * which for an idle tab whose only activity is SSE is never.
+     */
+    refreshToken?: () => Promise<string>;
+    /**
+     * Called when the server reports a dead token family (`x-auth-error:
+     * token_reuse` / `token_revoked`). Terminal — the stream does not retry or
+     * reconnect, because only a fresh login can fix it.
+     */
+    onAuthRevoked?: () => Promise<void> | void;
     reconnectDelayMs?: number;
   }) {
     this.baseUrl = opts.baseUrl.replace(/\/+$/, '');
     this.getAuthToken = opts.getAuthToken;
+    this.refreshToken = opts.refreshToken;
+    this.onAuthRevoked = opts.onAuthRevoked;
     this.reconnectDelayMs = opts.reconnectDelayMs ?? 3000;
   }
 
@@ -108,6 +136,45 @@ export class SseClient {
     }
   }
 
+  /**
+   * Fetch with a bearer token, refreshing once on a 401 and retrying.
+   *
+   * The stream and its subscription calls are plain `fetch`, not the HTTP
+   * client, so they do not inherit its 401 hook — without this an expired
+   * access token takes the stream down permanently. A revoked family is
+   * terminal and reported to `onAuthRevoked` instead of retried.
+   */
+  private async authedFetch(url: string, init: RequestInit): Promise<Response> {
+    const withToken = async (token: string): Promise<Response> =>
+      fetch(url, {
+        ...init,
+        headers: { ...(init.headers as Record<string, string>), Authorization: `Bearer ${token}` },
+      });
+
+    const response = await withToken(await this.getAuthToken());
+    if (response.status !== 401) return response;
+
+    const authError = response.headers.get('x-auth-error');
+    if (authError && TERMINAL_AUTH_ERRORS.has(authError)) {
+      try {
+        await this.onAuthRevoked?.();
+      } catch {
+        // A failing app callback must not mask the auth error.
+      }
+      return response;
+    }
+
+    if (!this.refreshToken) return response;
+
+    // One retry only: if the refreshed token is also rejected, the problem is
+    // not staleness and looping would spend refresh tokens for nothing.
+    try {
+      return await withToken(await this.refreshToken());
+    } catch {
+      return response;
+    }
+  }
+
   async connect(): Promise<void> {
     // Already connected — don't reconnect
     if (this.abortController && !this.closed) {
@@ -117,12 +184,8 @@ export class SseClient {
     this.abortController = new AbortController();
 
     try {
-      const token = await this.getAuthToken();
-      const response = await fetch(`${this.baseUrl}/sse`, {
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'text/event-stream',
-        },
+      const response = await this.authedFetch(`${this.baseUrl}/sse`, {
+        headers: { 'Accept': 'text/event-stream' },
         signal: this.abortController.signal,
       });
 
@@ -285,16 +348,12 @@ export class SseClient {
     ids: { contextIds?: string[]; groupIds?: string[] },
   ): Promise<void> {
     try {
-      const token = await this.getAuthToken();
       const params: { contextIds?: string[]; groupIds?: string[] } = {};
       if (ids.contextIds && ids.contextIds.length > 0) params.contextIds = ids.contextIds;
       if (ids.groupIds && ids.groupIds.length > 0) params.groupIds = ids.groupIds;
-      const response = await fetch(`${this.baseUrl}/sse/subscription`, {
+      const response = await this.authedFetch(`${this.baseUrl}/sse/subscription`, {
         method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           id: this.sessionId,
           method,

--- a/src/mero-js.test.ts
+++ b/src/mero-js.test.ts
@@ -150,7 +150,6 @@ describe('MeroJs SDK', () => {
         auth_method: 'user_password',
         public_key: 'admin',
         client_name: 'mero-js-sdk',
-        permissions: ['admin'],
         timestamp: expect.any(Number),
         provider_data: {
           username: 'admin',
@@ -186,7 +185,6 @@ describe('MeroJs SDK', () => {
         auth_method: 'user_password',
         public_key: 'custom-user',
         client_name: 'mero-js-sdk',
-        permissions: ['admin'],
         timestamp: expect.any(Number),
         provider_data: {
           username: 'custom-user',
@@ -195,6 +193,39 @@ describe('MeroJs SDK', () => {
       });
 
       expect(tokenData.access_token).toBe('mock-access-token');
+    });
+
+    it('omits permissions entirely when the caller does not ask for any', async () => {
+      // The node ignores this field on POST /auth/token (scope comes from the
+      // root key), so sending ['admin'] claimed a privilege the request never
+      // actually requested — and would have become a real escalation the moment
+      // core started honouring it.
+      mockAuthClient.generateTokens.mockResolvedValue({
+        data: { access_token: 'a', refresh_token: 'r' },
+      });
+
+      await meroJs.authenticate();
+
+      const body = mockAuthClient.generateTokens.mock.calls[0][0];
+      expect(body).not.toHaveProperty('permissions');
+    });
+
+    it('passes through the permissions and client name the caller supplies', async () => {
+      mockAuthClient.generateTokens.mockResolvedValue({
+        data: { access_token: 'a', refresh_token: 'r' },
+      });
+
+      await meroJs.authenticate(undefined, {
+        permissions: ['context:list'],
+        clientName: 'my-tool',
+      });
+
+      expect(mockAuthClient.generateTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          client_name: 'my-tool',
+          permissions: ['context:list'],
+        }),
+      );
     });
 
     it('should throw error when authentication fails', async () => {

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -283,19 +283,19 @@ export class MeroJs {
       /**
        * Permissions to request. Sent only when supplied.
        *
-       * **The node currently ignores this on this endpoint.** `POST /auth/token`
-       * with `user_password` derives the token's scope from the authenticating
-       * ROOT KEY (`authenticate_core` returns `root_key.permissions`), so a
-       * request for a narrower set is discarded and an admin root key always
-       * yields an admin token. Verified against merod 0.11.0-rc.20: requesting
-       * `['context:list']` returned a token carrying `['admin']`.
+       * **The node ignores this on this endpoint, by design.** This is the
+       * ROOT-KEY login: `POST /auth/token` returns the authenticating key's own
+       * permissions (`authenticate_core` returns `root_key.permissions`), so an
+       * admin account always yields an admin token. Verified against merod
+       * 0.11.0-rc.20 — requesting `['context:list']` returned `['admin']`.
        *
-       * It is passed through anyway so a caller can state intent and so this
-       * keeps working if the node starts honouring it (see
-       * calimero-network/core#3403). Least privilege on a *browser* login is
-       * expressible today — `buildAuthLoginUrl({ permissions })` drives the
-       * consent screen and mints a scoped client key, each entry checked
-       * against the root key.
+       * For a least-privilege token, do what the auth frontend does: use this
+       * token once to mint a scoped client key with
+       * {@link AuthApiClient.generateClientKey}, which takes `permissions` and
+       * validates each against the root key. Work with that token, not this one.
+       *
+       * Passed through when supplied so intent is on the wire and so callers
+       * keep working if the endpoint ever honours it.
        */
       permissions?: string[];
       /** Identifies this client in the node's key list. Defaults to `mero-js-sdk`. */
@@ -308,10 +308,9 @@ export class MeroJs {
     }
 
     try {
-      // No hardcoded `['admin']`: it was inert (the node ignores it here) while
-      // reading as though every SDK login demanded full node administration,
-      // and it would have become a real privilege escalation the moment core
-      // started honouring the field. Omitted unless the caller asks.
+      // No hardcoded `['admin']`: inert (this endpoint scopes from the root key)
+      // while reading as though every SDK login demanded full node
+      // administration. Omitted unless the caller asks.
       const requestBody = {
         auth_method: 'user_password',
         public_key: creds.username,

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -274,21 +274,49 @@ export class MeroJs {
    * Authenticate with the provided credentials
    * This will create the root key on first use
    */
-  async authenticate(credentials?: {
-    username: string;
-    password: string;
-  }): Promise<TokenData> {
+  async authenticate(
+    credentials?: {
+      username: string;
+      password: string;
+    },
+    options?: {
+      /**
+       * Permissions to request. Sent only when supplied.
+       *
+       * **The node currently ignores this on this endpoint.** `POST /auth/token`
+       * with `user_password` derives the token's scope from the authenticating
+       * ROOT KEY (`authenticate_core` returns `root_key.permissions`), so a
+       * request for a narrower set is discarded and an admin root key always
+       * yields an admin token. Verified against merod 0.11.0-rc.20: requesting
+       * `['context:list']` returned a token carrying `['admin']`.
+       *
+       * It is passed through anyway so a caller can state intent and so this
+       * keeps working if the node starts honouring it (see
+       * calimero-network/core#3403). Least privilege on a *browser* login is
+       * expressible today — `buildAuthLoginUrl({ permissions })` drives the
+       * consent screen and mints a scoped client key, each entry checked
+       * against the root key.
+       */
+      permissions?: string[];
+      /** Identifies this client in the node's key list. Defaults to `mero-js-sdk`. */
+      clientName?: string;
+    },
+  ): Promise<TokenData> {
     const creds = credentials || this.config.credentials;
     if (!creds) {
       throw new Error('No credentials provided for authentication');
     }
 
     try {
+      // No hardcoded `['admin']`: it was inert (the node ignores it here) while
+      // reading as though every SDK login demanded full node administration,
+      // and it would have become a real privilege escalation the moment core
+      // started honouring the field. Omitted unless the caller asks.
       const requestBody = {
         auth_method: 'user_password',
         public_key: creds.username,
-        client_name: 'mero-js-sdk',
-        permissions: ['admin'],
+        client_name: options?.clientName ?? 'mero-js-sdk',
+        ...(options?.permissions ? { permissions: options.permissions } : {}),
         timestamp: Math.floor(Date.now() / 1000),
         provider_data: {
           username: creds.username,

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -173,6 +173,41 @@ export class MeroJs {
   }
 
   /**
+   * The configured HTTP client — same transport `admin` and `rpc` use.
+   *
+   * Escape hatch for a request this SDK does not model yet: an endpoint without
+   * a method, or one whose method cannot express a needed parameter. Going
+   * through here rather than a hand-rolled `fetch`/axios keeps the request
+   * inside the auth lifecycle — bearer token, single-flight refresh on 401 with
+   * one retry, and the terminal `onAuthRevoked` path.
+   *
+   * Prefer a typed method where one exists; reach for this instead of building
+   * a second HTTP layer with its own copy of the token, which is how apps end
+   * up never refreshing.
+   */
+  get http(): HttpClient {
+    return this.httpClient;
+  }
+
+  /**
+   * Force a token refresh and return the new bundle.
+   *
+   * Rarely needed — the HTTP client and the event stream refresh themselves
+   * reactively on a 401. Use it when app-owned work must hold a token the SDK
+   * never sees.
+   *
+   * Safe to call concurrently: this is the single-flight path, guarded by an
+   * in-process promise and a cross-tab Web Lock, and it re-reads the token
+   * store inside the lock so a bundle another instance already rotated is
+   * adopted rather than replayed. Do NOT call `auth.refreshToken()` directly
+   * for this — it bypasses both guards, and a replayed single-use refresh token
+   * revokes the whole family (calimero-network/core#3083).
+   */
+  async refresh(): Promise<TokenData> {
+    return this.performTokenRefresh();
+  }
+
+  /**
    * Get the RPC client (lazy initialized)
    */
   get rpc(): RpcClient {
@@ -192,6 +227,22 @@ export class MeroJs {
         getAuthToken: async () => {
           const token = await this.getValidToken();
           return token?.access_token || '';
+        },
+        // The stream is plain `fetch`, so it does not inherit the HTTP client's
+        // 401 hook. Hand it the SAME single-flight refresh: refresh tokens are
+        // single-use (calimero-network/core#3083), so an independent refresher
+        // here would replay a consumed token and revoke the family.
+        refreshToken: async () => {
+          const refreshed = await this.performTokenRefresh();
+          return refreshed.access_token;
+        },
+        onAuthRevoked: async () => {
+          this.clearToken();
+          try {
+            await this.config.onAuthRevoked?.();
+          } catch {
+            // A failing app callback must not mask the auth error.
+          }
         },
       });
     }


### PR DESCRIPTION
Closes #84 — though not for the reason the issue gives.

## The premise in #84 is wrong: the field is inert

`POST /auth/token` with `user_password` never reads the request's `permissions`. It is the **root-key login**, and it returns the authenticating key's own permissions:

```rust
// crates/auth/src/providers/impls/user_password.rs:306
if let Some((key_id, root_key)) = self.verify_credentials(username, password).await? {
    let permissions = root_key.permissions.clone();
    return Ok((key_id, permissions));
}
```

Confirmed against a live node (merod `0.11.0-rc.20`, embedded auth):

```
POST /auth/token  { "permissions": ["context:list"], … admin credentials }
→ token claims: { "permissions": ["admin"] }
```

That behaviour is correct: this is the credential you use to mint scoped keys, so it necessarily carries the account's own scope. Least privilege comes from the second tier — `POST /admin/client-key` (`auth.generateClientKey()`), which takes `permissions`, validates each against the root key, and 400s by name on a miss. That is the flow the auth frontend guides a user through, and it is equally available to a script.

It was also never causing a "Full Node Administration — HIGH RISK" consent prompt: that copy lives in the auth frontend's `PermissionsView`, which renders the permissions from the **browser** login URL. `mero-react` passes a scoped set there (`getPermissionsForMode`), so app users never saw it. `authenticate()` shows no UI at all.

## Why change it anyway

- Every SDK login read on the wire, and in the node's key list, as a demand for full node administration.
- No caller could state a narrower intent, or name itself.
- If the endpoint ever does honour the field, a hardcoded `['admin']` becomes a real escalation rather than a cosmetic one.

## The change

```ts
authenticate(credentials?, options?: { permissions?: string[]; clientName?: string })
```

`permissions` is sent only when supplied — nothing is claimed that was not asked for. `clientName` lets a tool identify itself in the node's key list instead of every consumer appearing as `mero-js-sdk`.

The doc comment states that this endpoint scopes from the root key by design, and points callers who want a least-privilege token at `generateClientKey` — use this token once to mint a scoped one, then work with that.

## Tests

The two existing `authenticate` assertions dropped `permissions: ['admin']`, plus two new cases: the field is absent from the request body when the caller asks for nothing, and both `permissions` and `clientName` pass through when supplied.

`tsc --noEmit`, `vitest run` (295 passed), `eslint` (2 warnings, both pre-existing on master) all clean.
