### PR TITLE
fix(admin-api): rename GroupUpgradeStatus/UpgradeGroupResponseData counters to localContexts*

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1000,7 +1000,7 @@ describe('AdminApiClient', () => {
   describe('Group Upgrade', () => {
     it('upgradeGroup sends request and unwraps data', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
-        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+        data: { groupId: 'g-1', status: 'in_progress', localContextsTotal: 3, localContextsSwapped: 0, localContextsFailed: 0 },
       });
       const result = await client.upgradeGroup('g-1', {
         targetApplicationId: 'app-2',
@@ -1013,7 +1013,7 @@ describe('AdminApiClient', () => {
 
     it('upgradeGroup forwards cascade so the upgrade fans out to subgroups', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
-        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+        data: { groupId: 'g-1', status: 'in_progress', localContextsTotal: 3, localContextsSwapped: 0, localContextsFailed: 0 },
       });
       await client.upgradeGroup('g-1', {
         targetApplicationId: 'app-2',
@@ -1027,7 +1027,7 @@ describe('AdminApiClient', () => {
 
     it('upgradeGroup forwards forceCodeOnly for an ABI-less code-only upgrade', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade', {
-        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 0, failed: 0 },
+        data: { groupId: 'g-1', status: 'in_progress', localContextsTotal: 3, localContextsSwapped: 0, localContextsFailed: 0 },
       });
       await client.upgradeGroup('g-1', {
         targetApplicationId: 'app-2',
@@ -1042,7 +1042,7 @@ describe('AdminApiClient', () => {
 
     it('getGroupUpgradeStatus returns status', async () => {
       mock.setMockResponse('GET', '/admin-api/groups/g-1/upgrade/status', {
-        data: { fromVersion: '1.0', toVersion: '2.0', initiatedAt: 123, initiatedBy: 'pk-1', status: 'completed', total: 3, completed: 3, failed: 0, completedAt: 456 },
+        data: { fromVersion: '1.0', toVersion: '2.0', initiatedAt: 123, initiatedBy: 'pk-1', status: 'completed', localContextsTotal: 3, localContextsSwapped: 3, localContextsFailed: 0, completedAt: 456 },
       });
       const result = await client.getGroupUpgradeStatus('g-1');
       expect(result?.status).toBe('completed');
@@ -1057,7 +1057,7 @@ describe('AdminApiClient', () => {
 
     it('retryGroupUpgrade unwraps data', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/g-1/upgrade/retry', {
-        data: { groupId: 'g-1', status: 'in_progress', total: 3, completed: 1, failed: 0 },
+        data: { groupId: 'g-1', status: 'in_progress', localContextsTotal: 3, localContextsSwapped: 1, localContextsFailed: 0 },
       });
       const result = await client.retryGroupUpgrade('g-1');
       expect(result.status).toBe('in_progress');

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -556,9 +556,9 @@ export interface GroupUpgradeStatus {
   initiatedAt: number;
   initiatedBy: string;
   status: string;
-  total?: number;
-  completed?: number;
-  failed?: number;
+  localContextsTotal?: number;
+  localContextsSwapped?: number;
+  localContextsFailed?: number;
   completedAt?: number;
 }
 
@@ -864,9 +864,9 @@ export interface UpgradeGroupRequest {
 export interface UpgradeGroupResponseData {
   groupId: string;
   status: string;
-  total?: number;
-  completed?: number;
-  failed?: number;
+  localContextsTotal?: number;
+  localContextsSwapped?: number;
+  localContextsFailed?: number;
 }
 
 export type GroupUpgradeStatusResponseData = GroupUpgradeStatus | null;


### PR DESCRIPTION
## Summary

Core renamed three counters on two admin DTOs.
`GroupUpgradeStatus` and `UpgradeGroupResponseData` each carried `total?`, `completed?`, `failed?` counting contexts swapped on the node that ran the upgrade.
Sitting next to a new fleet-wide migration rollup that streams its own `total`, the bare names read as fleet progress rather than per-node counts.
Core renamed them to `localContextsTotal`, `localContextsSwapped`, `localContextsFailed` on `GroupUpgradeStatusApiData` and `UpgradeGroupApiResponseData`.

This PR mirrors that rename in both matching SDK interfaces and updates the mock fixtures in `admin-client.test.ts` that construct those DTOs.
`MigrationStatusRollup` (`migrated`/`inProgress`/`unknown`/`failed`/`total`) is untouched, core did not rename that type.

## Test plan

- `pnpm build` - pass
- `pnpm typecheck` - pass
- `pnpm typecheck:contract` - pass
- `pnpm typecheck:consumer` - pass
- `pnpm lint` - pass (2 pre-existing unrelated warnings, 0 errors)
- `pnpm test:unit` - pass (281 passed, 1 skipped)
