### PR TITLE
feat(events): model the GroupMigration event family and add onMigrationEvent

### DIFF
--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -556,9 +556,15 @@ export interface GroupUpgradeStatus {
   initiatedAt: number;
   initiatedBy: string;
   status: string;
+  /** Contexts THIS NODE enumerated for the upgrade. Node-local; fleet progress
+   * is the `getMigrationStatus` rollup. */
   localContextsTotal?: number;
   localContextsSwapped?: number;
+  /** Contexts whose swap failed on this node; a non-zero value is what
+   * `retryGroupUpgrade` picks up. */
   localContextsFailed?: number;
+  /** Unix seconds at which THIS NODE finished its own context swaps. Not fleet
+   * convergence - that is `MigrationStatus.fleetCompletedAt`. */
   completedAt?: number;
 }
 
@@ -577,6 +583,10 @@ export type MigrationFailureReason =
   | 'no_migration_path';
 
 export interface MemberMigrationReport {
+  /** ABI state version the member has loaded, from `#[app::state(version = N)]` -
+   * the engine's migration gate, not the bundle semver and not a CRDT concept.
+   * The wrong reading here is how the core rollup defect (comparing bundle-semver
+   * majors instead of state versions) went unnoticed. */
   schemaVersion: number;
   residueAuto: number;
   syncedUpToHlc: number;
@@ -612,7 +622,14 @@ export interface MigrationStatusRollup {
 export interface MigrationStatus {
   targetVersion: number;
   expectedMembers: number;
+  /** Governance HLC the cohort was pinned at, as an opaque display string.
+   * Absent when there is no migration record. */
   cohortPinnedAtHlc?: string;
+  /** Unix seconds at which this node watched the FLEET converge, absent while it
+   * has not. Distinct from `GroupUpgradeStatus.completedAt`, which is this node's
+   * own local swap completion. Durable, unlike `rollup.allMigrated`, which is
+   * recomputed from in-TTL heartbeats and lapses when a member goes quiet. */
+  fleetCompletedAt?: number;
   rollup: MigrationStatusRollup;
   members: MemberMigrationStatusEntry[];
 }

--- a/src/events/group.ts
+++ b/src/events/group.ts
@@ -7,3 +7,85 @@ export interface GroupMembershipEventData {
     role?: string;
   };
 }
+
+/**
+ * A migration was accepted and its target ABI state version resolved.
+ * `toStateVersion` is the `#[app::state(version = N)]` number, not the bundle
+ * semver (`toVersion`).
+ */
+export interface MigrationStartedData {
+  fromVersion: string;
+  toVersion: string;
+  toStateVersion: number;
+  /** Contexts the EMITTING NODE enumerated for the migration. Node-local, never
+   * the fleet cohort size that `MigrationProgressData.total` carries. */
+  localContextsTotal: number;
+}
+
+/**
+ * Fleet rollup counters, recomputed as peers' heartbeat facts change. Counters
+ * only: the per-member detail behind them stays in the admin-gated
+ * `getMigrationStatus` read.
+ */
+export interface MigrationProgressData {
+  migrated: number;
+  inProgress: number;
+  unknown: number;
+  failed: number;
+  /** The pinned FLEET COHORT size, never a node-local context count like
+   * `MigrationStartedData.localContextsTotal`. */
+  total: number;
+}
+
+/**
+ * One subgroup's local context swaps advanced on the emitting node.
+ *
+ * Admin-only: it names a descendant subgroup, which a plain namespace member
+ * may not enumerate, so core withholds it from non-admin subscribers. A
+ * non-admin never receiving this variant is correct behaviour, not a gap.
+ */
+export interface CascadeProgressData {
+  /** Hex-encoded descendant subgroup id, never the namespace root the event is
+   * keyed on. */
+  subgroupId: string;
+  localContextsSwapped: number;
+  /** Contexts the emitting node holds for THIS SUBGROUP. Node-local and
+   * per-subgroup; unrelated to both sibling totals. */
+  localContextsTotal: number;
+}
+
+/** Every pinned-cohort member reported the target version. */
+export interface MigrationCompletedData {
+  toVersion: string;
+  /** FLEET convergence, in seconds since the epoch: the same stamp
+   * `MigrationStatus.fleetCompletedAt` returns. Not `GroupUpgradeStatus.completedAt`,
+   * which is this node's own local swap completion. */
+  completedAt: number;
+}
+
+/**
+ * Parsed group-migration event (core's `GroupMigration` `NodeEvent` variant),
+ * keyed on the namespace root a client subscribes with.
+ *
+ * `MigrationStarted`, `MigrationProgress` and `MigrationCompleted` reach every
+ * subscribed member; `CascadeProgress` reaches namespace admins only.
+ */
+export type GroupMigrationEventData =
+  | { groupId: string; type: 'MigrationStarted'; data: MigrationStartedData }
+  | { groupId: string; type: 'MigrationProgress'; data: MigrationProgressData }
+  | { groupId: string; type: 'CascadeProgress'; data: CascadeProgressData }
+  | { groupId: string; type: 'MigrationCompleted'; data: MigrationCompletedData };
+
+const MIGRATION_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'MigrationStarted',
+  'MigrationProgress',
+  'CascadeProgress',
+  'MigrationCompleted',
+]);
+
+/** Narrows a raw `'event'` payload to the group-migration family by its tag. */
+export function isGroupMigrationEvent(
+  event: { type?: string },
+): event is GroupMigrationEventData {
+  return event.type !== undefined && MIGRATION_EVENT_TYPES.has(event.type);
+}

--- a/src/events/index.ts
+++ b/src/events/index.ts
@@ -2,4 +2,11 @@ export { SseClient } from './sse.js';
 export type { SseEventData, AppVersionChangedEvent } from './sse.js';
 export { WsClient } from './ws.js';
 export type { WsEventData } from './ws.js';
-export type { GroupMembershipEventData } from './group.js';
+export type {
+  GroupMembershipEventData,
+  GroupMigrationEventData,
+  MigrationStartedData,
+  MigrationProgressData,
+  CascadeProgressData,
+  MigrationCompletedData,
+} from './group.js';

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SseClient } from './sse.js';
+import type { GroupMigrationEventData } from './group.js';
 
 describe('SseClient', () => {
   let client: SseClient;
@@ -79,6 +80,120 @@ describe('SseClient', () => {
       off();
 
       (client as any).handleMessage(appVersionMsg('ctx1', { toVersion: '2.0.0' }));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onMigrationEvent', () => {
+    // Group-migration events are keyed on `groupId` with `type` a sibling of
+    // `data`, same flattening as the membership family. Drive through
+    // handleMessage so the full parse path is exercised.
+    const migrationMsg = (type: string, data: Record<string, unknown>) =>
+      JSON.stringify({ result: { groupId: 'ns-1', type, data } });
+
+    it('delivers MigrationStarted with the node-local context total', () => {
+      const seen: GroupMigrationEventData[] = [];
+      client.onMigrationEvent((e) => seen.push(e));
+
+      (client as any).handleMessage(
+        migrationMsg('MigrationStarted', {
+          fromVersion: '10.1.3',
+          toVersion: '10.2.0',
+          toStateVersion: 2,
+          localContextsTotal: 7,
+        }),
+      );
+
+      expect(seen).toEqual([
+        {
+          groupId: 'ns-1',
+          type: 'MigrationStarted',
+          data: {
+            fromVersion: '10.1.3',
+            toVersion: '10.2.0',
+            toStateVersion: 2,
+            localContextsTotal: 7,
+          },
+        },
+      ]);
+    });
+
+    // The three totals are different numbers: MigrationProgress.total is the
+    // fleet cohort size, the other two are node-local. A helper that flattened
+    // them into one field would re-create the defect this surface exists to show.
+    it('keeps the cohort total and the node-local totals on separate fields', () => {
+      const seen: GroupMigrationEventData[] = [];
+      client.onMigrationEvent((e) => seen.push(e));
+
+      (client as any).handleMessage(
+        migrationMsg('MigrationProgress', {
+          migrated: 2,
+          inProgress: 1,
+          unknown: 0,
+          failed: 1,
+          total: 4,
+        }),
+      );
+      (client as any).handleMessage(
+        migrationMsg('CascadeProgress', {
+          subgroupId: 'sub-1',
+          localContextsSwapped: 3,
+          localContextsTotal: 5,
+        }),
+      );
+
+      const progress = seen[0];
+      const cascade = seen[1];
+      expect(progress.type).toBe('MigrationProgress');
+      expect(cascade.type).toBe('CascadeProgress');
+      if (progress.type !== 'MigrationProgress' || cascade.type !== 'CascadeProgress') return;
+      expect(progress.data.total).toBe(4);
+      expect(cascade.data.localContextsTotal).toBe(5);
+      expect((cascade.data as Record<string, unknown>).total).toBeUndefined();
+    });
+
+    it('delivers MigrationCompleted with the fleet-convergence stamp', () => {
+      const seen: GroupMigrationEventData[] = [];
+      client.onMigrationEvent((e) => seen.push(e));
+
+      (client as any).handleMessage(
+        migrationMsg('MigrationCompleted', { toVersion: '10.2.0', completedAt: 1_700_000_000 }),
+      );
+
+      expect(seen).toEqual([
+        {
+          groupId: 'ns-1',
+          type: 'MigrationCompleted',
+          data: { toVersion: '10.2.0', completedAt: 1_700_000_000 },
+        },
+      ]);
+    });
+
+    it('ignores membership and context events', () => {
+      const handler = vi.fn();
+      client.onMigrationEvent(handler);
+
+      (client as any).handleMessage(
+        JSON.stringify({
+          result: { groupId: 'ns-1', type: 'MemberJoined', data: { member: 'mem-1' } },
+        }),
+      );
+      (client as any).handleMessage(
+        JSON.stringify({ result: { contextId: 'ctx-1', type: 'AppVersionChanged', data: {} } }),
+      );
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('returns an unsubscribe handle that stops delivery', () => {
+      const handler = vi.fn();
+      const off = client.onMigrationEvent(handler);
+      off();
+
+      (client as any).handleMessage(
+        migrationMsg('MigrationCompleted', { toVersion: '10.2.0', completedAt: 1 }),
+      );
 
       expect(handler).not.toHaveBeenCalled();
     });

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,6 +1,7 @@
-import type { GroupMembershipEventData } from './group.js';
+import type { GroupMembershipEventData, GroupMigrationEventData } from './group.js';
+import { isGroupMigrationEvent } from './group.js';
 
-export type { GroupMembershipEventData };
+export type { GroupMembershipEventData, GroupMigrationEventData };
 
 export interface SseEventData {
   contextId: string;
@@ -17,7 +18,10 @@ export interface AppVersionChangedEvent {
   toVersion?: string;
 }
 
-type SseEventHandler = (event: SseEventData | GroupMembershipEventData) => void;
+/** Anything the `'event'` stream can deliver: context events plus the
+ * group-keyed membership and migration families. */
+type SseEvent = SseEventData | GroupMembershipEventData | GroupMigrationEventData;
+type SseEventHandler = (event: SseEvent) => void;
 type SseConnectHandler = (sessionId: string) => void;
 type SseErrorHandler = (error: Error) => void;
 
@@ -91,10 +95,27 @@ export class SseClient {
     return () => this.off('event', listener);
   }
 
+  /**
+   * Typed convenience over the generic `'event'` stream: invokes `handler` only
+   * for group-migration events, narrowed on `type` so `data` is the matching
+   * payload. Returns an unsubscribe closure.
+   *
+   * A non-admin subscriber sees `MigrationStarted`, `MigrationProgress` and
+   * `MigrationCompleted` but never `CascadeProgress`, which core delivers to
+   * namespace admins only.
+   */
+  onMigrationEvent(handler: (e: GroupMigrationEventData) => void): () => void {
+    const listener: SseEventHandler = (ev) => {
+      if (isGroupMigrationEvent(ev)) handler(ev);
+    };
+    this.on('event', listener);
+    return () => this.off('event', listener);
+  }
+
   private emit(event: 'connect', sessionId: string): void;
-  private emit(event: 'event', data: SseEventData | GroupMembershipEventData): void;
+  private emit(event: 'event', data: SseEvent): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: string | SseEventData | GroupMembershipEventData | Error): void {
+  private emit(event: string, arg?: string | SseEvent | Error): void {
     const key = event as keyof SseListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -237,7 +258,8 @@ export class SseClient {
         return;
       }
 
-      // Group-membership event message (untagged NodeEvent's group variant)
+      // Group-keyed event message (untagged NodeEvent's membership and
+      // migration variants; the `type` tag tells them apart).
       if (msg.result.groupId) {
         this.emit('event', {
           groupId: msg.result.groupId,

--- a/src/events/ws.ts
+++ b/src/events/ws.ts
@@ -1,6 +1,6 @@
-import type { GroupMembershipEventData } from './group.js';
+import type { GroupMembershipEventData, GroupMigrationEventData } from './group.js';
 
-export type { GroupMembershipEventData };
+export type { GroupMembershipEventData, GroupMigrationEventData };
 
 export interface WsEventData {
   contextId: string;
@@ -10,7 +10,10 @@ export interface WsEventData {
   data: unknown;
 }
 
-type WsEventHandler = (event: WsEventData | GroupMembershipEventData) => void;
+/** Anything the `'event'` stream can deliver: context events plus the
+ * group-keyed membership and migration families. */
+type WsEvent = WsEventData | GroupMembershipEventData | GroupMigrationEventData;
+type WsEventHandler = (event: WsEvent) => void;
 type WsConnectHandler = () => void;
 type WsErrorHandler = (error: Error) => void;
 
@@ -71,9 +74,9 @@ export class WsClient {
   }
 
   private emit(event: 'connect'): void;
-  private emit(event: 'event', data: WsEventData | GroupMembershipEventData): void;
+  private emit(event: 'event', data: WsEvent): void;
   private emit(event: 'error', error: Error): void;
-  private emit(event: string, arg?: WsEventData | GroupMembershipEventData | Error): void {
+  private emit(event: string, arg?: WsEvent | Error): void {
     const key = event as keyof WsListeners;
     if (key in this.listeners) {
       for (const handler of this.listeners[key]) {
@@ -159,7 +162,8 @@ export class WsClient {
         return;
       }
 
-      // Group-membership event message (untagged NodeEvent's group variant)
+      // Group-keyed event message (untagged NodeEvent's membership and
+      // migration variants; the `type` tag tells them apart).
       if (msg.result.groupId) {
         this.emit('event', {
           groupId: msg.result.groupId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,17 @@ export type { ExecuteParams } from './rpc/index.js';
 
 // Events (SSE / WebSocket)
 export { SseClient, WsClient } from './events/index.js';
-export type { SseEventData, WsEventData, AppVersionChangedEvent, GroupMembershipEventData } from './events/index.js';
+export type {
+  SseEventData,
+  WsEventData,
+  AppVersionChangedEvent,
+  GroupMembershipEventData,
+  GroupMigrationEventData,
+  MigrationStartedData,
+  MigrationProgressData,
+  CascadeProgressData,
+  MigrationCompletedData,
+} from './events/index.js';
 
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud/index.js';

--- a/tests/consumer/nodenext.ts
+++ b/tests/consumer/nodenext.ts
@@ -1,7 +1,7 @@
 // Compiled by tsconfig.consumer.json as an external NodeNext consumer of the built
 // dist/. The @ts-expect-error lines fail if unresolvable specifiers widen the API to any.
 import { MeroJs, RpcError } from '@calimero-network/mero-js';
-import type { MeroJsConfig } from '@calimero-network/mero-js';
+import type { GroupMigrationEventData, MeroJsConfig } from '@calimero-network/mero-js';
 
 const config: MeroJsConfig = {
   baseUrl: 'http://localhost:2428',
@@ -16,3 +16,15 @@ new RpcError('not-a-number', 'boom');
 
 // @ts-expect-error baseUrl is required
 new MeroJs({ totallyNotAnOption: true });
+
+// The migration union must narrow on `type` through dist/, not collapse to any.
+export function cohortTotal(e: GroupMigrationEventData): number | null {
+  return e.type === 'MigrationProgress' ? e.data.total : null;
+}
+
+export function cascadeTotal(
+  e: Extract<GroupMigrationEventData, { type: 'CascadeProgress' }>,
+): number {
+  // @ts-expect-error the per-subgroup count is localContextsTotal; a bare `total` is the cohort's
+  return e.data.total;
+}


### PR DESCRIPTION
## Summary

Core delivers a `GroupMigration` event family over both SSE and WebSocket. The SDK modelled none of it, so the surface the whole migration programme exists for - an admin watching fleet progress, a peer watching its own - was unreachable from TypeScript.

- **Four payload types** derived from `crates/primitives/src/events.rs` (serde attributes, not guesswork): `MigrationStartedData`, `MigrationProgressData`, `CascadeProgressData`, `MigrationCompletedData`, joined into a `GroupMigrationEventData` discriminated union keyed on the namespace root. Both transports' `'event'` unions are widened to carry it.
- **`SseClient.onMigrationEvent()`**, following `onAppVersionChanged` exactly: subscribes to the generic stream, filters by tag, returns an unsubscribe closure. Narrowing on `type` gives the caller the matching `data`.
- **`MigrationStatus.fleetCompletedAt`** declared. Core returns it on the migration-status route and the SDK type omitted it. `cohortPinnedAtHlc` was already present and is now documented.
- **`MemberMigrationReport.schemaVersion`** documented as the ABI state version from `#[app::state(version = N)]`, not a CRDT concept. That exact wrong wording is how the core rollup defect (comparing bundle-semver majors instead of state versions) went unnoticed, so the correction is not just tidiness.

Three semantics are kept apart in the types rather than unified, because flattening any of them re-creates a bug that cost real effort to find:

| Field | Meaning |
| --- | --- |
| `MigrationStarted.localContextsTotal` | this node's context count |
| `MigrationProgress.total` | fleet cohort size |
| `CascadeProgress.localContextsTotal` | node-local, for one subgroup |
| `MigrationStatus.fleetCompletedAt` | fleet convergence |
| `GroupUpgradeStatus.completedAt` | this node's own swap completion |

`CascadeProgress` is documented as admin-only on both the type and the helper: it names a descendant subgroup, which core withholds from non-admin subscribers, so a plain member never receiving it is correct behaviour and not a gap.

`onMigrationEvent` lands on `SseClient` only, matching where `onAppVersionChanged` lives; `WsClient` is `@experimental` and has neither. Its event union is widened all the same, since the WS transport does deliver these events.

**Not breaking.** The change is additive but type-affecting: existing `'event'` handlers now receive a wider union, so a handler that destructured `contextId` without narrowing may need a guard. No field is renamed or removed and no runtime behaviour changes. Batches with #93, which this targets so the stack stays coherent.

## Test plan

- `pnpm build` - clean
- `pnpm typecheck`, `pnpm typecheck:contract`, `pnpm typecheck:consumer` - clean
- `pnpm lint` - 0 errors (2 pre-existing warnings in `docs/src/scripts/diagrams.client.ts`, untouched here)
- `pnpm test:unit` - 286 passed, 1 skipped
- `CALIMERO_CORE_DIR=<core> pnpm test:contract` - 5 passed against a real core checkout (not skipped)

New coverage in `src/events/sse.test.ts` drives `handleMessage` with core's real wire shape (`result: { groupId, type, data }`) rather than hand-built events, so the full parse path runs: each variant's payload arrives intact, membership and context events are ignored, and the unsubscribe handle stops delivery. One test asserts the cohort total and the node-local totals stay on separate fields, including that `CascadeProgress` carries no bare `total`.

The tests were confirmed to be real gates: deleting `'CascadeProgress'` from the tag set fails the totals test, and `tests/consumer/nodenext.ts` carries a `@ts-expect-error` that fails if `CascadeProgressData` ever grows a `total`. The consumer file compiles against built `dist/`, so it also proves the new types survive the package-root export.