### PR TITLE
fix(events): rename GroupMembershipEventData.member to memberAccount

### DIFF
--- a/src/events/group.ts
+++ b/src/events/group.ts
@@ -3,8 +3,14 @@ export interface GroupMembershipEventData {
   groupId: string;
   type: 'MemberJoined' | 'MemberAdded' | 'MemberRemoved';
   data: {
-    member: string;
-    role?: string;
+    /** The member's ACCOUNT, hex-encoded 32 bytes (64 chars) - the principal the
+     * governance rows name. Not a bs58 signing key: the field this replaced
+     * carried one, and both are strings, so the rename is what makes a stale
+     * consumer fail loudly instead of comparing accounts against keys forever. */
+    memberAccount: string;
+    /** Absent on `MemberRemoved`, and on a `MemberJoined` inherited from an Open
+     * subgroup. Core's set is closed. */
+    role?: 'Admin' | 'Member' | 'ReadOnly' | 'ReadOnlyTee';
   };
 }
 

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -176,7 +176,7 @@ describe('SseClient', () => {
 
       (client as any).handleMessage(
         JSON.stringify({
-          result: { groupId: 'ns-1', type: 'MemberJoined', data: { member: 'mem-1' } },
+          result: { groupId: 'ns-1', type: 'MemberJoined', data: { memberAccount: 'acct-1' } },
         }),
       );
       (client as any).handleMessage(
@@ -328,14 +328,14 @@ describe('SseClient', () => {
         result: {
           groupId: 'grp-1',
           type: 'MemberJoined',
-          data: { member: 'mem-1', role: 'Member' },
+          data: { memberAccount: 'acct-1', role: 'Member' },
         },
       }));
 
       expect(handler).toHaveBeenCalledWith({
         groupId: 'grp-1',
         type: 'MemberJoined',
-        data: { member: 'mem-1', role: 'Member' },
+        data: { memberAccount: 'acct-1', role: 'Member' },
       });
     });
 

--- a/src/events/ws.test.ts
+++ b/src/events/ws.test.ts
@@ -85,14 +85,14 @@ describe('WsClient', () => {
         result: {
           groupId: 'grp-1',
           type: 'MemberJoined',
-          data: { member: 'mem-1', role: 'Member' },
+          data: { memberAccount: 'acct-1', role: 'Member' },
         },
       }));
 
       expect(handler).toHaveBeenCalledWith({
         groupId: 'grp-1',
         type: 'MemberJoined',
-        data: { member: 'mem-1', role: 'Member' },
+        data: { memberAccount: 'acct-1', role: 'Member' },
       });
     });
   });

--- a/tests/consumer/nodenext.ts
+++ b/tests/consumer/nodenext.ts
@@ -1,7 +1,11 @@
 // Compiled by tsconfig.consumer.json as an external NodeNext consumer of the built
 // dist/. The @ts-expect-error lines fail if unresolvable specifiers widen the API to any.
 import { MeroJs, RpcError } from '@calimero-network/mero-js';
-import type { GroupMigrationEventData, MeroJsConfig } from '@calimero-network/mero-js';
+import type {
+  GroupMembershipEventData,
+  GroupMigrationEventData,
+  MeroJsConfig,
+} from '@calimero-network/mero-js';
 
 const config: MeroJsConfig = {
   baseUrl: 'http://localhost:2428',
@@ -20,6 +24,15 @@ new MeroJs({ totallyNotAnOption: true });
 // The migration union must narrow on `type` through dist/, not collapse to any.
 export function cohortTotal(e: GroupMigrationEventData): number | null {
   return e.type === 'MigrationProgress' ? e.data.total : null;
+}
+
+export const memberAccount = (e: GroupMembershipEventData): string => e.data.memberAccount;
+
+// Core dropped the `member` wire key so a stale consumer fails at a field it
+// cannot find. The SDK type must deny it too, or that loud failure goes silent.
+export function staleMemberRead(e: GroupMembershipEventData): string {
+  // @ts-expect-error the account is `memberAccount`; `member` carried a bs58 signing key
+  return e.data.member;
 }
 
 export function cascadeTotal(


### PR DESCRIPTION
## Summary

Core renamed the membership event's wire key to `memberAccount` and changed what it holds - the field carried a bs58 signing key and now carries a 64-hex account, a different principal entirely. Core's own test asserts the old `member` key is **absent**, with the reasoning stated in `crates/primitives/src/events.rs`:

> Both are strings, so a consumer still reading `member` would have parsed the new value as the old kind and compared it against keys forever - silently, and against nothing. Renaming makes a consumer that has not been updated fail at the field it no longer finds, which is the only honest way to ship this change.

The SDK still declared `member: string`, which defeated exactly that intent: a consumer read `undefined` with no type error. That is the silent failure the rename exists to prevent. This restores it.

- **`memberAccount`**, documented as hex-encoded 32 bytes and explicitly not a bs58 signing key. The SDK has no account brand or alias - every id is `string` (`peer`, `initiatedBy`, and the rest) - so the format lives in the doc comment rather than in a new type.
- **`role` tightened** to core's closed set: `'Admin' | 'Member' | 'ReadOnly' | 'ReadOnlyTee'`. It was `string`. The name and optionality had not drifted, but `string` hid `ReadOnlyTee` from anyone reading the type, and core marks the enum deliberately not `#[non_exhaustive]`. Documented as absent on `MemberRemoved` and on a `MemberJoined` inherited from an Open subgroup, matching `crates/context/src/membership_events.rs`.
- **Consumers fixed:** the stale name appeared only in test fixtures - two in `src/events/sse.test.ts`, two in `src/events/ws.test.ts` - which encoded the wrong wire shape and so would have kept asserting a shape core no longer emits.

**Breaking.** `GroupMembershipEventData.data.member` is gone; read `memberAccount`. Narrowing `role` is breaking only for code assigning an arbitrary string into the type, which consumers of a received event do not do. Batches with #93 and #94.

### On wire-contract coverage

No, the contract test does not cover `GroupMembershipEventData`, and that absence is why this drift survived. It cannot be added here: `wire.contract.test.ts` checks SDK types against fixtures committed in core under `crates/server/primitives/fixtures/wire/`, and there is no membership-event fixture - the event types live in `calimero_primitives::events`, which contributes no fixtures at all. Adding one is a core-side change, not something this PR can provide.

What is available locally is a compile-time equivalent, so the gap is not left open: `tests/consumer/nodenext.ts` compiles a `@ts-expect-error` read of the old `member` name against built `dist/`, which fails the build if the stale field is ever restored, and a plain read of `memberAccount` that fails if the new name stops surviving the package-root export.

## Test plan

- `pnpm build` - clean
- `pnpm typecheck`, `pnpm typecheck:contract`, `pnpm typecheck:consumer` - clean
- `pnpm lint` - 0 errors (2 pre-existing warnings in `docs/src/scripts/diagrams.client.ts`, untouched here)
- `pnpm test:unit` - 286 passed, 1 skipped
- `CALIMERO_CORE_DIR=<core> pnpm test:contract` - 5 passed against a real core checkout (not skipped)

Mutation-checked rather than only observed passing: re-adding `member: string` to the type makes `typecheck:consumer` fail with `TS2578: Unused '@ts-expect-error' directive`, confirming the guard is load-bearing and not decorative.

No runtime test was added. The transports forward `data` verbatim, so there is no parsing logic here to break - the type is the fix, and the existing membership pass-through tests already cover the forwarding with corrected fixtures.