### PR TITLE
test(contract): wire the group upgrade fixtures into the wire contract

### DIFF
--- a/src/__contract__/wire.contract.test.ts
+++ b/src/__contract__/wire.contract.test.ts
@@ -11,6 +11,9 @@
  * The `key<T>()` helper makes each declared key a *compile-time* reference to the
  * SDK type, so a renamed/removed field fails `typecheck:contract`. Skips when
  * CALIMERO_CORE_DIR is unset, so it is a no-op in the plain unit run.
+ *
+ * The fixtures are a committed snapshot core regenerates with `UPDATE_FIXTURES=1`,
+ * not a live node: a core-side rename lands here only once someone regenerates it.
  */
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
@@ -19,8 +22,10 @@ import { join } from 'path';
 import type {
   CreateContextRequest,
   CreateContextResponseData,
+  GroupUpgradeStatus,
   ReparentGroupRequest,
   ReparentGroupResponseData,
+  UpgradeGroupResponseData,
 } from '../admin-api/admin-types.js';
 import type { ExecuteParams } from '../rpc/index.js';
 
@@ -43,6 +48,9 @@ interface Spec {
   optional: string[];
   /** Core-optional fields the SDK intentionally does not model (no drift). */
   ignoredCoreKeys?: string[];
+  /** Envelope key to descend into first. Core wraps some admin responses in
+   * `data`; the SDK type models the inner object. */
+  envelope?: string;
 }
 
 const ctxReq = key<CreateContextRequest>();
@@ -50,7 +58,12 @@ const ctxRes = key<CreateContextResponseData>();
 const reReq = key<ReparentGroupRequest>();
 const reRes = key<ReparentGroupResponseData>();
 const exec = key<ExecuteParams>();
+const upRes = key<UpgradeGroupResponseData>();
+const upStatus = key<GroupUpgradeStatus>();
 
+// `jsonrpc/execute.res.json` is deliberately absent: its SDK counterpart is an
+// unexported inline type whose index signature makes `key<T>()` accept any
+// string, so a spec for it would compile no matter how wrong the name was.
 const SPECS: Spec[] = [
   {
     type: 'CreateContextRequest',
@@ -88,6 +101,35 @@ const SPECS: Spec[] = [
     required: [exec('contextId'), exec('method')],
     optional: [exec('argsJson'), exec('executorPublicKey')],
   },
+  {
+    type: 'UpgradeGroupResponseData',
+    file: 'groups/upgrade.res.json',
+    envelope: 'data',
+    required: [upRes('groupId'), upRes('status')],
+    optional: [
+      upRes('localContextsTotal'),
+      upRes('localContextsSwapped'),
+      upRes('localContextsFailed'),
+    ],
+  },
+  {
+    type: 'GroupUpgradeStatus',
+    file: 'groups/upgrade_status.res.json',
+    envelope: 'data',
+    required: [
+      upStatus('fromVersion'),
+      upStatus('toVersion'),
+      upStatus('initiatedAt'),
+      upStatus('initiatedBy'),
+      upStatus('status'),
+    ],
+    optional: [
+      upStatus('localContextsTotal'),
+      upStatus('localContextsSwapped'),
+      upStatus('localContextsFailed'),
+      upStatus('completedAt'),
+    ],
+  },
 ];
 
 describe('wire contract (core fixtures ↔ SDK types)', () => {
@@ -98,9 +140,11 @@ describe('wire contract (core fixtures ↔ SDK types)', () => {
 
   for (const spec of SPECS) {
     it(`${spec.type} ↔ ${spec.file}`, () => {
-      const fixture = JSON.parse(
+      const raw = JSON.parse(
         readFileSync(join(WIRE_DIR, spec.file), 'utf8'),
       ) as Record<string, unknown>;
+      const fixture = (spec.envelope ? raw[spec.envelope] : raw) as Record<string, unknown>;
+      expect(fixture, `fixture ${spec.file} has no '${spec.envelope}' envelope`).toBeTruthy();
       const fixtureKeys = Object.keys(fixture);
       const known = new Set([
         ...spec.required,


### PR DESCRIPTION
## Summary

Core commits eight wire fixtures under `crates/server/primitives/fixtures/wire/`. The SDK checked five of them. Two of the three unwired ones cover exactly the types whose `localContexts*` rename had to be caught by hand-reading downstream repos, because no test was watching.

- **`groups/upgrade.res.json` → `UpgradeGroupResponseData`**
- **`groups/upgrade_status.res.json` → `GroupUpgradeStatus`**

Both fixtures wrap their payload in a `data` envelope while the already-wired ones do not, so `Spec` gains an optional `envelope` key the loader descends through before reading key names. That is the only mechanism added.

**`jsonrpc/execute.res.json` is deliberately left unwired.** Its SDK counterpart is `JsonRpcResponse['result']`, an unexported inline type carrying `[key: string]: unknown`. An index signature makes `keyof T & string` collapse to `string`, so `key<T>()` accepts any string at all - I verified this compiles clean under `--strict`:

```ts
interface WithIndex { output?: unknown; [k: string]: unknown; }
const w = key<WithIndex>();
export const typo = w('totallyNotAField');   // compiles
```

A spec for it would pass however wrong the name was, and would also require exporting an internal type purely to satisfy a test. A gate that cannot fail is worse than an absent one, because it reads as coverage. The reason is recorded next to `SPECS` so nobody re-attempts it.

## Proof it is a gate

Both halves were broken deliberately and both went red.

**Compile-time half** - rename `localContextsSwapped` in the SDK type, leave the spec alone:

```
src/__contract__/wire.contract.test.ts(107,13): error TS2345: Argument of type '"localContextsSwapped"' is not assignable to parameter of type '"status" | "groupId" | "localContextsTotal" | "contextsSwapped" | "localContextsFailed"'.
src/__contract__/wire.contract.test.ts(124,16): error TS2345: Argument of type '"localContextsSwapped"' is not assignable to parameter of type '"status" | "localContextsTotal" | "contextsSwapped" | "localContextsFailed" | "fromVersion" | "toVersion" | "initiatedAt" | "initiatedBy" | "completedAt"'.
```

**Runtime half** - rename type *and* spec together, so the fixture is the only remaining source of truth:

```
 × wire contract (core fixtures ↔ SDK types) > UpgradeGroupResponseData ↔ groups/upgrade.res.json 6ms
   → core wire key 'localContextsSwapped' is not declared by SDK type UpgradeGroupResponseData (groups/upgrade.res.json)
 × wire contract (core fixtures ↔ SDK types) > GroupUpgradeStatus ↔ groups/upgrade_status.res.json 1ms
   → core wire key 'localContextsSwapped' is not declared by SDK type GroupUpgradeStatus (groups/upgrade_status.res.json)

 Tests  2 failed | 5 passed (7)
```

Both failures name the offending field. Both files were restored and the suite re-run green.

## What this does and does not catch

The fixtures are a committed snapshot core regenerates with `UPDATE_FIXTURES=1 cargo test -p calimero-server-primitives --test wire_fixtures`, not a live node.

**Catches:** a field the SDK type declares that core's snapshot does not carry; a field core's snapshot carries that the SDK does not declare; any rename inside the SDK, immediately, via the compile-time half.

**Does not catch:** a core-side rename until somebody regenerates the fixture in core. Until that regeneration, the snapshot still shows the old shape and this suite stays green while a live node disagrees. It also says nothing about value types, only key presence, and nothing about routes with no fixture at all.

So it closes the "SDK drifted from a known-good shape" hole, not the "core changed and nobody told us" hole. The live sibling `tests/e2e/wire.contract.test.ts` is what covers the latter, and only for the six DTOs it registers. This is strictly better than nothing and should not be read as more.

Noted in the file header so the next reader calibrates from the source rather than from a green check mark.

## Test plan

- `pnpm build` - clean
- `pnpm typecheck`, `pnpm typecheck:contract`, `pnpm typecheck:consumer` - clean
- `pnpm lint` - 0 errors (2 pre-existing warnings in `docs/src/scripts/diagrams.client.ts`, untouched)
- `pnpm test:unit` - 286 passed, 1 skipped
- `CALIMERO_CORE_DIR=<core> pnpm test:contract` - **7 passed**, up from 5, against a real core checkout

Batches with #93, #94 and #95. Not breaking: test-only, no shipped type or runtime behaviour changes.