### PR TITLE
feat(ephemeral): add mero.ephemeral presence client (set/get/subscribe)

### DIFF
--- a/src/ephemeral/codec.ts
+++ b/src/ephemeral/codec.ts
@@ -1,0 +1,14 @@
+import type { Codec } from './types.js';
+
+/** Default codec: JSON text as a byte array. The wire carries `state` as
+ * `number[]`, not a string, so this encodes to bytes rather than to text. */
+export function jsonCodec<T>(): Codec<T> {
+  return {
+    encode(value: T): number[] {
+      return Array.from(new TextEncoder().encode(JSON.stringify(value)));
+    },
+    decode(bytes: number[]): T {
+      return JSON.parse(new TextDecoder().decode(new Uint8Array(bytes))) as T;
+    },
+  };
+}

--- a/src/ephemeral/ephemeral.test.ts
+++ b/src/ephemeral/ephemeral.test.ts
@@ -73,3 +73,90 @@ describe('EphemeralClient.get', () => {
     expect(await client.get('ctx-1')).toEqual([]);
   });
 });
+
+describe('EphemeralClient.subscribe', () => {
+  function fakeSse() {
+    const handlers: Array<(e: unknown) => void> = [];
+    return {
+      handlers,
+      on: vi.fn((_evt: string, h: (e: unknown) => void) => { handlers.push(h); }),
+      off: vi.fn((_evt: string, h: (e: unknown) => void) => {
+        const i = handlers.indexOf(h);
+        if (i >= 0) handlers.splice(i, 1);
+      }),
+      connect: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn().mockResolvedValue(undefined),
+      emit: (e: unknown) => handlers.forEach(h => h(e)),
+    };
+  }
+
+  const encoded = (v: unknown) => Array.from(new TextEncoder().encode(JSON.stringify(v)));
+
+  it('delivers only Ephemeral events for the requested context', () => {
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    const seen: unknown[] = [];
+    client.subscribe('ctx-1', e => seen.push(e));
+
+    // Wrong type -> ignored.
+    sse.emit({ contextId: 'ctx-1', type: 'AppVersionChanged', data: {} });
+    // Wrong context -> ignored.
+    sse.emit({ contextId: 'ctx-2', type: 'Ephemeral', data: { author: 'A', state: encoded(1) } });
+    // Match.
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded({ x: 1 }) } });
+
+    expect(seen).toEqual([{ author: 'A', state: { x: 1 }, removed: false }]);
+  });
+
+  it('treats a MISSING removed as an upsert and a true removed as a removal', () => {
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    const seen: Array<{ author: string; removed?: boolean; state?: unknown }> = [];
+    client.subscribe('ctx-1', e => seen.push(e));
+
+    // Core omits `removed` entirely on an upsert (skip_serializing_if).
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded({ x: 1 }) } });
+    // On a removal, `state` is omitted and `removed` is true.
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', removed: true } });
+
+    expect(seen[0].removed).toBe(false);
+    expect(seen[0].state).toEqual({ x: 1 });
+    expect(seen[1].removed).toBe(true);
+    expect(seen[1].state).toBeUndefined();
+  });
+
+  it('does not throw when a removal arrives with no state to decode', () => {
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    client.subscribe('ctx-1', () => {});
+    expect(() =>
+      sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', removed: true } }),
+    ).not.toThrow();
+  });
+
+  it('stops delivering after the returned unsubscribe is called', () => {
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    const seen: unknown[] = [];
+    const unsubscribe = client.subscribe('ctx-1', e => seen.push(e));
+
+    unsubscribe();
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded(1) } });
+
+    expect(seen).toEqual([]);
+    expect(sse.off).toHaveBeenCalled();
+  });
+
+  it('leaves data.state as a raw byte array (mero-js auto-decode must not fire)', () => {
+    // SseClient auto-decodes a byte-array `data` (sse.ts:215-225). Presence
+    // `data` is an OBJECT so that decode does not fire, and the nested
+    // `data.state` must reach us raw for the codec to decode. If a future
+    // change recursed into nested arrays, this test fails loudly.
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    let received: { x: number } | undefined;
+    client.subscribe<{ x: number }>('ctx-1', e => { received = e.state; });
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded({ x: 42 }) } });
+    expect(received).toEqual({ x: 42 });
+  });
+});

--- a/src/ephemeral/ephemeral.test.ts
+++ b/src/ephemeral/ephemeral.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EphemeralClient, jsonCodec } from './index.js';
+import { RpcError } from '../rpc/index.js';
 import type { HttpClient } from '../http-client/index.js';
 
 function mockHttp(postResponse: unknown): HttpClient {
@@ -49,6 +50,28 @@ describe('EphemeralClient.set', () => {
     const client = new EphemeralClient({ httpClient: http, sse: noopSse });
     await expect(client.set('ctx-1', { cursor: 1 })).rejects.toThrow('nope');
   });
+
+  it('throws a typed RpcError carrying the server type and data', async () => {
+    // Core returns `{ type, data }` (no code/message) — an oversized slice must
+    // keep the size detail instead of collapsing to Error("SliceTooLarge").
+    const http = mockHttp({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { type: 'SliceTooLarge', data: { maxBytes: 16384, gotBytes: 20000 } },
+    });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+
+    await expect(client.set('ctx-1', { cursor: 1 })).rejects.toBeInstanceOf(RpcError);
+    try {
+      await client.set('ctx-1', { cursor: 1 });
+      expect.unreachable('set should reject');
+    } catch (e) {
+      expect(e).toBeInstanceOf(RpcError);
+      expect((e as RpcError).type).toBe('SliceTooLarge');
+      expect((e as RpcError).message).toBe('SliceTooLarge');
+      expect((e as RpcError).data).toEqual({ maxBytes: 16384, gotBytes: 20000 });
+    }
+  });
 });
 
 describe('EphemeralClient.get', () => {
@@ -65,6 +88,26 @@ describe('EphemeralClient.get', () => {
     const entries = await client.get<{ cursor: number }>('ctx-1');
 
     expect(entries).toEqual([{ author: 'AUTHOR_A', state: { cursor: 9 }, ageMs: 447 }]);
+  });
+
+  it('skips an undecodable entry instead of rejecting the whole snapshot', async () => {
+    const good = Array.from(new TextEncoder().encode(JSON.stringify({ cursor: 9 })));
+    const garbage = [0xff, 0xfe, 0xfd];
+    const http = mockHttp({
+      jsonrpc: '2.0',
+      id: 1,
+      result: {
+        entries: {
+          BAD: { state: garbage, ageMs: 10 },
+          GOOD: { state: good, ageMs: 20 },
+        },
+      },
+    });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+
+    // One malformed peer must not blank the roster.
+    const entries = await client.get<{ cursor: number }>('ctx-1');
+    expect(entries).toEqual([{ author: 'GOOD', state: { cursor: 9 }, ageMs: 20 }]);
   });
 
   it('returns an empty array when the snapshot is empty', async () => {

--- a/src/ephemeral/ephemeral.test.ts
+++ b/src/ephemeral/ephemeral.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EphemeralClient, jsonCodec } from './index.js';
+import type { HttpClient } from '../http-client/index.js';
+
+function mockHttp(postResponse: unknown): HttpClient {
+  return {
+    get: vi.fn(),
+    post: vi.fn().mockResolvedValue(postResponse),
+    put: vi.fn(),
+    delete: vi.fn(),
+    patch: vi.fn(),
+    head: vi.fn(),
+    request: vi.fn(),
+  } as unknown as HttpClient;
+}
+
+// A minimal SseClient stand-in; Task 1 never touches it.
+const noopSse = { on: vi.fn(), off: vi.fn(), connect: vi.fn(), subscribe: vi.fn() } as never;
+
+describe('jsonCodec', () => {
+  it('round-trips a value through a byte array', () => {
+    const c = jsonCodec<{ x: number }>();
+    const bytes = c.encode({ x: 7 });
+    expect(Array.isArray(bytes)).toBe(true);
+    expect(bytes.every(b => typeof b === 'number')).toBe(true);
+    expect(c.decode(bytes)).toEqual({ x: 7 });
+  });
+});
+
+describe('EphemeralClient.set', () => {
+  it('posts set_ephemeral with the encoded state and no author', async () => {
+    const http = mockHttp({ jsonrpc: '2.0', id: 1, result: {} });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+
+    await client.set('ctx-1', { cursor: 1 });
+
+    expect(http.post).toHaveBeenCalledTimes(1);
+    const [path, body] = (http.post as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(path).toBe('/jsonrpc');
+    expect(body.method).toBe('set_ephemeral');
+    expect(body.params.contextId).toBe('ctx-1');
+    expect(Array.isArray(body.params.state)).toBe(true);
+    // The author is resolved server-side; a client cannot set it.
+    expect(body.params).not.toHaveProperty('author');
+  });
+
+  it('throws on an RPC error rather than resolving silently', async () => {
+    const http = mockHttp({ jsonrpc: '2.0', id: 1, error: { code: -32000, message: 'nope' } });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+    await expect(client.set('ctx-1', { cursor: 1 })).rejects.toThrow('nope');
+  });
+});
+
+describe('EphemeralClient.get', () => {
+  it('decodes the author-keyed map into entries carrying ageMs', async () => {
+    // EXACT shape captured from a live node (core 11418a3c).
+    const state = Array.from(new TextEncoder().encode(JSON.stringify({ cursor: 9 })));
+    const http = mockHttp({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { entries: { 'AUTHOR_A': { state, ageMs: 447 } } },
+    });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+
+    const entries = await client.get<{ cursor: number }>('ctx-1');
+
+    expect(entries).toEqual([{ author: 'AUTHOR_A', state: { cursor: 9 }, ageMs: 447 }]);
+  });
+
+  it('returns an empty array when the snapshot is empty', async () => {
+    const http = mockHttp({ jsonrpc: '2.0', id: 1, result: { entries: {} } });
+    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
+    expect(await client.get('ctx-1')).toEqual([]);
+  });
+});

--- a/src/ephemeral/ephemeral.test.ts
+++ b/src/ephemeral/ephemeral.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { EphemeralClient, jsonCodec } from './index.js';
+import type { EphemeralEntry } from './index.js';
 import { RpcError } from '../rpc/index.js';
 import type { HttpClient } from '../http-client/index.js';
 
@@ -71,49 +72,6 @@ describe('EphemeralClient.set', () => {
       expect((e as RpcError).message).toBe('SliceTooLarge');
       expect((e as RpcError).data).toEqual({ maxBytes: 16384, gotBytes: 20000 });
     }
-  });
-});
-
-describe('EphemeralClient.get', () => {
-  it('decodes the author-keyed map into entries carrying ageMs', async () => {
-    // EXACT shape captured from a live node (core 11418a3c).
-    const state = Array.from(new TextEncoder().encode(JSON.stringify({ cursor: 9 })));
-    const http = mockHttp({
-      jsonrpc: '2.0',
-      id: 1,
-      result: { entries: { 'AUTHOR_A': { state, ageMs: 447 } } },
-    });
-    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
-
-    const entries = await client.get<{ cursor: number }>('ctx-1');
-
-    expect(entries).toEqual([{ author: 'AUTHOR_A', state: { cursor: 9 }, ageMs: 447 }]);
-  });
-
-  it('skips an undecodable entry instead of rejecting the whole snapshot', async () => {
-    const good = Array.from(new TextEncoder().encode(JSON.stringify({ cursor: 9 })));
-    const garbage = [0xff, 0xfe, 0xfd];
-    const http = mockHttp({
-      jsonrpc: '2.0',
-      id: 1,
-      result: {
-        entries: {
-          BAD: { state: garbage, ageMs: 10 },
-          GOOD: { state: good, ageMs: 20 },
-        },
-      },
-    });
-    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
-
-    // One malformed peer must not blank the roster.
-    const entries = await client.get<{ cursor: number }>('ctx-1');
-    expect(entries).toEqual([{ author: 'GOOD', state: { cursor: 9 }, ageMs: 20 }]);
-  });
-
-  it('returns an empty array when the snapshot is empty', async () => {
-    const http = mockHttp({ jsonrpc: '2.0', id: 1, result: { entries: {} } });
-    const client = new EphemeralClient({ httpClient: http, sse: noopSse });
-    expect(await client.get('ctx-1')).toEqual([]);
   });
 });
 
@@ -201,5 +159,34 @@ describe('EphemeralClient.subscribe', () => {
     client.subscribe<{ x: number }>('ctx-1', e => { received = e.state; });
     sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded({ x: 42 }) } });
     expect(received).toEqual({ x: 42 });
+  });
+
+  it('passes ageMs through on a replayed seed entry', () => {
+    // EXACT shape: a replay-on-subscribe seed entry carries ageMs.
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    const seen: Array<EphemeralEntry<{ x: number }>> = [];
+    client.subscribe<{ x: number }>('ctx-1', e => seen.push(e));
+
+    sse.emit({
+      contextId: 'ctx-1',
+      type: 'Ephemeral',
+      data: { author: 'A', state: encoded({ x: 1 }), ageMs: 447 },
+    });
+
+    expect(seen).toEqual([{ author: 'A', state: { x: 1 }, removed: false, ageMs: 447 }]);
+  });
+
+  it('leaves ageMs undefined (not 0) on a live delta', () => {
+    // EXACT shape: a live delta carries no ageMs at all (skip_serializing_if).
+    const sse = fakeSse();
+    const client = new EphemeralClient({ httpClient: mockHttp({}), sse: sse as never });
+    const seen: Array<EphemeralEntry<{ x: number }>> = [];
+    client.subscribe<{ x: number }>('ctx-1', e => seen.push(e));
+
+    sse.emit({ contextId: 'ctx-1', type: 'Ephemeral', data: { author: 'A', state: encoded({ x: 1 }) } });
+
+    expect(seen[0].ageMs).toBeUndefined();
+    expect('ageMs' in seen[0]).toBe(false);
   });
 });

--- a/src/ephemeral/index.ts
+++ b/src/ephemeral/index.ts
@@ -1,0 +1,73 @@
+import type { HttpClient } from '../http-client/index.js';
+import type { SseClient } from '../events/index.js';
+import { jsonCodec } from './codec.js';
+import type { Codec, EphemeralEntry, EphemeralSnapshotEntry } from './types.js';
+
+export { jsonCodec };
+export type { Codec, EphemeralEntry, EphemeralSnapshotEntry };
+
+interface JsonRpcResponse {
+  result?: unknown;
+  error?: { code?: number; message?: string; type?: string; data?: unknown };
+}
+
+/**
+ * Ephemeral presence: transient, encrypted, never-persisted state (cursors,
+ * typing, presence) that gossips between nodes without a WASM run or DAG
+ * growth.
+ *
+ * The write/read asymmetry is the model, not an oversight. `set` takes no
+ * author: you can only ever write your OWN slot, and the node resolves the
+ * author server-side from its owned context identity — which is also why a
+ * client cannot publish as somebody else. `get`/`subscribe` return everyone's
+ * slots, so each carries its `author`. The store is N independent
+ * single-writer registers keyed by author; there is no merge across authors.
+ */
+export class EphemeralClient {
+  private httpClient: HttpClient;
+  private sse: SseClient;
+
+  constructor(opts: { httpClient: HttpClient; sse: SseClient }) {
+    this.httpClient = opts.httpClient;
+    this.sse = opts.sse;
+  }
+
+  private async rpc<T>(method: string, params: unknown): Promise<T> {
+    const response = await this.httpClient.post<JsonRpcResponse>('/jsonrpc', {
+      jsonrpc: '2.0',
+      id: 1,
+      method,
+      params,
+    });
+    if (response.error) {
+      const err = response.error;
+      throw new Error(err.message ?? err.type ?? `${method} failed`);
+    }
+    return response.result as T;
+  }
+
+  /** Publish your own presence slice, replacing it wholesale. */
+  async set<T>(contextId: string, state: T, codec: Codec<T> = jsonCodec<T>()): Promise<void> {
+    await this.rpc<Record<string, never>>('set_ephemeral', {
+      contextId,
+      state: codec.encode(state),
+    });
+  }
+
+  /** Snapshot every live entry for a context. */
+  async get<T>(
+    contextId: string,
+    codec: Codec<T> = jsonCodec<T>(),
+  ): Promise<EphemeralSnapshotEntry<T>[]> {
+    const result = await this.rpc<{ entries?: Record<string, { state: number[]; ageMs: number }> }>(
+      'get_ephemeral',
+      { contextId },
+    );
+    const entries = result?.entries ?? {};
+    return Object.entries(entries).map(([author, value]) => ({
+      author,
+      state: codec.decode(value.state),
+      ageMs: value.ageMs,
+    }));
+  }
+}

--- a/src/ephemeral/index.ts
+++ b/src/ephemeral/index.ts
@@ -1,15 +1,11 @@
 import type { HttpClient } from '../http-client/index.js';
 import type { SseClient } from '../events/index.js';
+import { jsonRpcCall } from '../rpc/index.js';
 import { jsonCodec } from './codec.js';
 import type { Codec, EphemeralEntry, EphemeralSnapshotEntry } from './types.js';
 
 export { jsonCodec };
 export type { Codec, EphemeralEntry, EphemeralSnapshotEntry };
-
-interface JsonRpcResponse {
-  result?: unknown;
-  error?: { code?: number; message?: string; type?: string; data?: unknown };
-}
 
 /**
  * Ephemeral presence: transient, encrypted, never-persisted state (cursors,
@@ -32,43 +28,46 @@ export class EphemeralClient {
     this.sse = opts.sse;
   }
 
-  private async rpc<T>(method: string, params: unknown): Promise<T> {
-    const response = await this.httpClient.post<JsonRpcResponse>('/jsonrpc', {
-      jsonrpc: '2.0',
-      id: 1,
-      method,
-      params,
-    });
-    if (response.error) {
-      const err = response.error;
-      throw new Error(err.message ?? err.type ?? `${method} failed`);
-    }
-    return response.result as T;
-  }
-
-  /** Publish your own presence slice, replacing it wholesale. */
+  /**
+   * Publish your own presence slice, replacing it wholesale.
+   *
+   * Rejects with an `RpcError` (not a bare `Error`), so a typed failure such as
+   * an oversized slice keeps its `type` and `data` — e.g. `SliceTooLarge` with
+   * the offending size — and is `instanceof RpcError` like every other RPC in
+   * this SDK.
+   */
   async set<T>(contextId: string, state: T, codec: Codec<T> = jsonCodec<T>()): Promise<void> {
-    await this.rpc<Record<string, never>>('set_ephemeral', {
+    await jsonRpcCall<Record<string, never>>(this.httpClient, 'set_ephemeral', {
       contextId,
       state: codec.encode(state),
     });
   }
 
-  /** Snapshot every live entry for a context. */
+  /**
+   * Snapshot every live entry for a context.
+   *
+   * An entry that fails to decode is SKIPPED, not fatal: presence slices are
+   * per-author and independent, so one peer publishing a slice this codec
+   * cannot read must not blank the whole roster (which, with only a low-rate
+   * reconciliation to recover, could persist).
+   */
   async get<T>(
     contextId: string,
     codec: Codec<T> = jsonCodec<T>(),
   ): Promise<EphemeralSnapshotEntry<T>[]> {
-    const result = await this.rpc<{ entries?: Record<string, { state: number[]; ageMs: number }> }>(
-      'get_ephemeral',
-      { contextId },
-    );
+    const result = await jsonRpcCall<{
+      entries?: Record<string, { state: number[]; ageMs: number }>;
+    }>(this.httpClient, 'get_ephemeral', { contextId });
     const entries = result?.entries ?? {};
-    return Object.entries(entries).map(([author, value]) => ({
-      author,
-      state: codec.decode(value.state),
-      ageMs: value.ageMs,
-    }));
+    const decoded: EphemeralSnapshotEntry<T>[] = [];
+    for (const [author, value] of Object.entries(entries)) {
+      try {
+        decoded.push({ author, state: codec.decode(value.state), ageMs: value.ageMs });
+      } catch {
+        // Undecodable slice from one peer — drop that peer, keep the rest.
+      }
+    }
+    return decoded;
   }
 
   /**

--- a/src/ephemeral/index.ts
+++ b/src/ephemeral/index.ts
@@ -70,4 +70,44 @@ export class EphemeralClient {
       ageMs: value.ageMs,
     }));
   }
+
+  /**
+   * Observe presence changes for a context.
+   *
+   * This adds NO transport — it is a typed filter over the existing SSE event
+   * stream, which already carries `{ contextId, type, data }`. Returns an
+   * unsubscribe function.
+   */
+  subscribe<T>(
+    contextId: string,
+    handler: (entry: EphemeralEntry<T>) => void,
+    codec: Codec<T> = jsonCodec<T>(),
+  ): () => void {
+    const listener = (event: unknown): void => {
+      const e = event as { contextId?: string; type?: string; data?: unknown };
+      if (e.type !== 'Ephemeral' || e.contextId !== contextId) return;
+
+      const data = e.data as { author?: string; state?: number[]; removed?: boolean } | undefined;
+      if (!data?.author) return;
+
+      // `removed` is omitted on an upsert, so normalize to a boolean here and
+      // spare every caller the truthiness rule.
+      const removed = Boolean(data.removed);
+      handler({
+        author: data.author,
+        state: removed || data.state === undefined ? undefined : codec.decode(data.state),
+        removed,
+      });
+    };
+
+    this.sse.on('event', listener);
+    // Errors surface via the SSE client's own 'error' event; nothing more to
+    // do with them here.
+    void this.sse.connect().catch(() => undefined);
+    void this.sse.subscribe([contextId]).catch(() => undefined);
+
+    return () => {
+      this.sse.off('event', listener);
+    };
+  }
 }

--- a/src/ephemeral/index.ts
+++ b/src/ephemeral/index.ts
@@ -2,10 +2,10 @@ import type { HttpClient } from '../http-client/index.js';
 import type { SseClient } from '../events/index.js';
 import { jsonRpcCall } from '../rpc/index.js';
 import { jsonCodec } from './codec.js';
-import type { Codec, EphemeralEntry, EphemeralSnapshotEntry } from './types.js';
+import type { Codec, EphemeralEntry } from './types.js';
 
 export { jsonCodec };
-export type { Codec, EphemeralEntry, EphemeralSnapshotEntry };
+export type { Codec, EphemeralEntry };
 
 /**
  * Ephemeral presence: transient, encrypted, never-persisted state (cursors,
@@ -15,9 +15,14 @@ export type { Codec, EphemeralEntry, EphemeralSnapshotEntry };
  * The write/read asymmetry is the model, not an oversight. `set` takes no
  * author: you can only ever write your OWN slot, and the node resolves the
  * author server-side from its owned context identity — which is also why a
- * client cannot publish as somebody else. `get`/`subscribe` return everyone's
+ * client cannot publish as somebody else. `subscribe` returns everyone's
  * slots, so each carries its `author`. The store is N independent
  * single-writer registers keyed by author; there is no merge across authors.
+ *
+ * There is a single read path: `subscribe`. On subscribing to a context, the
+ * node replays that context's current presence to this connection as
+ * ordinary `Ephemeral` events (carrying `ageMs`), before any live deltas
+ * (which carry no `ageMs`). There is no separate snapshot RPC.
  */
 export class EphemeralClient {
   private httpClient: HttpClient;
@@ -44,38 +49,14 @@ export class EphemeralClient {
   }
 
   /**
-   * Snapshot every live entry for a context.
-   *
-   * An entry that fails to decode is SKIPPED, not fatal: presence slices are
-   * per-author and independent, so one peer publishing a slice this codec
-   * cannot read must not blank the whole roster (which, with only a low-rate
-   * reconciliation to recover, could persist).
-   */
-  async get<T>(
-    contextId: string,
-    codec: Codec<T> = jsonCodec<T>(),
-  ): Promise<EphemeralSnapshotEntry<T>[]> {
-    const result = await jsonRpcCall<{
-      entries?: Record<string, { state: number[]; ageMs: number }>;
-    }>(this.httpClient, 'get_ephemeral', { contextId });
-    const entries = result?.entries ?? {};
-    const decoded: EphemeralSnapshotEntry<T>[] = [];
-    for (const [author, value] of Object.entries(entries)) {
-      try {
-        decoded.push({ author, state: codec.decode(value.state), ageMs: value.ageMs });
-      } catch {
-        // Undecodable slice from one peer — drop that peer, keep the rest.
-      }
-    }
-    return decoded;
-  }
-
-  /**
    * Observe presence changes for a context.
    *
    * This adds NO transport — it is a typed filter over the existing SSE event
-   * stream, which already carries `{ contextId, type, data }`. Returns an
-   * unsubscribe function.
+   * stream, which already carries `{ contextId, type, data }`. On subscribing,
+   * the node replays that context's current presence to this connection as
+   * ordinary `Ephemeral` events before any live deltas; a replayed entry
+   * carries `ageMs`, a live delta does not (never synthesized as `0` — absent
+   * and zero mean different things). Returns an unsubscribe function.
    */
   subscribe<T>(
     contextId: string,
@@ -86,17 +67,23 @@ export class EphemeralClient {
       const e = event as { contextId?: string; type?: string; data?: unknown };
       if (e.type !== 'Ephemeral' || e.contextId !== contextId) return;
 
-      const data = e.data as { author?: string; state?: number[]; removed?: boolean } | undefined;
+      const data = e.data as
+        | { author?: string; state?: number[]; removed?: boolean; ageMs?: number }
+        | undefined;
       if (!data?.author) return;
 
       // `removed` is omitted on an upsert, so normalize to a boolean here and
       // spare every caller the truthiness rule.
       const removed = Boolean(data.removed);
-      handler({
+      const entry: EphemeralEntry<T> = {
         author: data.author,
         state: removed || data.state === undefined ? undefined : codec.decode(data.state),
         removed,
-      });
+      };
+      // `ageMs` is present only on a replayed seed entry; pass it through as-is
+      // rather than defaulting a live delta to 0.
+      if (data.ageMs !== undefined) entry.ageMs = data.ageMs;
+      handler(entry);
     };
 
     this.sse.on('event', listener);

--- a/src/ephemeral/types.ts
+++ b/src/ephemeral/types.ts
@@ -1,0 +1,25 @@
+/** Encoding for a presence slice. The node never deserializes it — the wire
+ * encoding is chosen client-side and travels client-to-client. */
+export interface Codec<T> {
+  encode(value: T): number[];
+  decode(bytes: number[]): T;
+}
+
+/** One entry from a `get` snapshot. `state` and `ageMs` are always present. */
+export interface EphemeralSnapshotEntry<T> {
+  /** Context member public key — a DEVICE key, not an account id. */
+  author: string;
+  state: T;
+  /** Milliseconds since this author was last heard from, measured on the node.
+   * Relative, so no clock agreement between machines is needed. Bounded above
+   * by the node's 7s presence TTL. */
+  ageMs: number;
+}
+
+/** One delta from `subscribe`. Carries no age — a delta is fresh at receipt.
+ * `state` is absent on a removal; `removed` is ABSENT (not false) on an upsert. */
+export interface EphemeralEntry<T> {
+  author: string;
+  state?: T;
+  removed?: boolean;
+}

--- a/src/ephemeral/types.ts
+++ b/src/ephemeral/types.ts
@@ -5,21 +5,19 @@ export interface Codec<T> {
   decode(bytes: number[]): T;
 }
 
-/** One entry from a `get` snapshot. `state` and `ageMs` are always present. */
-export interface EphemeralSnapshotEntry<T> {
-  /** Context member public key — a DEVICE key, not an account id. */
-  author: string;
-  state: T;
-  /** Milliseconds since this author was last heard from, measured on the node.
-   * Relative, so no clock agreement between machines is needed. Bounded above
-   * by the node's 7s presence TTL. */
-  ageMs: number;
-}
-
-/** One delta from `subscribe`. Carries no age — a delta is fresh at receipt.
- * `state` is absent on a removal; `removed` is ABSENT (not false) on an upsert. */
+/** One entry from `subscribe`. `state` is absent on a removal; `removed` is
+ * ABSENT (not false) on an upsert.
+ *
+ * On subscribing to a context, the node replays that context's current
+ * presence to this connection as ordinary `Ephemeral` events (same shape as a
+ * live delta), before any live deltas. `ageMs` distinguishes a replayed seed
+ * entry from a live one: it is ABSENT on a live delta (fresh at receipt) and
+ * PRESENT on a replayed entry, giving milliseconds since that author was last
+ * heard from, measured on the node. Relative, so no clock agreement between
+ * machines is needed. Bounded above by the node's 7s presence TTL. */
 export interface EphemeralEntry<T> {
   author: string;
   state?: T;
   removed?: boolean;
+  ageMs?: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ export type {
   MigrationCompletedData,
 } from './events/index.js';
 
+// Ephemeral presence (cursors / typing / online)
+export { EphemeralClient, jsonCodec } from './ephemeral/index.js';
+export type { Codec, EphemeralEntry, EphemeralSnapshotEntry } from './ephemeral/index.js';
+
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud/index.js';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ export type {
 
 // Ephemeral presence (cursors / typing / online)
 export { EphemeralClient, jsonCodec } from './ephemeral/index.js';
-export type { Codec, EphemeralEntry, EphemeralSnapshotEntry } from './ephemeral/index.js';
+export type { Codec, EphemeralEntry } from './ephemeral/index.js';
 
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud/index.js';

--- a/src/mero-js.ts
+++ b/src/mero-js.ts
@@ -10,6 +10,7 @@ import type { AuthCallbackResult, AuthLoginOptions } from './auth/index.js';
 import { RpcClient } from './rpc/index.js';
 import { SseClient } from './events/sse.js';
 import { WsClient } from './events/ws.js';
+import { EphemeralClient } from './ephemeral/index.js';
 
 export interface MeroJsConfig {
   /** Base URL for the Calimero node */
@@ -90,6 +91,7 @@ export class MeroJs {
   private sseClient: SseClient | null = null;
   private wsClient: WsClient | null = null;
   private wsWarned = false;
+  private ephemeralClient?: EphemeralClient;
 
   constructor(config: MeroJsConfig) {
     this.config = {
@@ -196,6 +198,22 @@ export class MeroJs {
       });
     }
     return this.sseClient;
+  }
+
+  /**
+   * Get the ephemeral-presence client (lazy initialized).
+   *
+   * Shares this instance's SSE client, so `subscribe` reuses the one event
+   * stream rather than opening a second connection.
+   */
+  get ephemeral(): EphemeralClient {
+    if (!this.ephemeralClient) {
+      this.ephemeralClient = new EphemeralClient({
+        httpClient: this.httpClient,
+        sse: this.events,
+      });
+    }
+    return this.ephemeralClient;
   }
 
   /**

--- a/src/rpc/index.ts
+++ b/src/rpc/index.ts
@@ -45,6 +45,33 @@ interface JsonRpcResponse {
   };
 }
 
+/**
+ * POST a JSON-RPC call and unwrap `result`, converting an `error` payload into
+ * an `RpcError`. The node returns `{ type, data }` (not always `{ code,
+ * message }`), so this is the one place that normalization lives — every
+ * JSON-RPC caller in this SDK shares it rather than re-deriving a bare
+ * `Error(message)` and dropping the typed detail.
+ */
+export async function jsonRpcCall<T>(
+  httpClient: HttpClient,
+  method: string,
+  params: unknown,
+): Promise<T> {
+  const response = await httpClient.post<JsonRpcResponse>('/jsonrpc', {
+    jsonrpc: '2.0',
+    id: 1,
+    method,
+    params,
+  });
+
+  if (response.error) {
+    const err = response.error;
+    throw new RpcError(err.code ?? -1, err.message ?? err.type ?? 'RPC error', err.data, err.type);
+  }
+
+  return response.result as T;
+}
+
 export class RpcClient {
   private httpClient: HttpClient;
 
@@ -53,34 +80,17 @@ export class RpcClient {
   }
 
   async execute<T = unknown>(params: ExecuteParams): Promise<T> {
-    const body = {
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'execute',
-      params: {
-        contextId: params.contextId,
-        method: params.method,
-        argsJson: params.argsJson ?? {},
-      },
-    };
+    const result = await jsonRpcCall<JsonRpcResponse['result']>(this.httpClient, 'execute', {
+      contextId: params.contextId,
+      method: params.method,
+      argsJson: params.argsJson ?? {},
+    });
 
-    const response = await this.httpClient.post<JsonRpcResponse>(
-      '/jsonrpc',
-      body,
-    );
-
-    if (response.error) {
-      const err = response.error;
-      const code = err.code ?? -1;
-      const message = err.message ?? err.type ?? 'RPC error';
-      throw new RpcError(code, message, err.data, err.type);
+    if (result && 'output' in result) {
+      return result.output as T;
     }
 
-    if (response.result && 'output' in response.result) {
-      return response.result.output as T;
-    }
-
-    return response.result as T;
+    return result as T;
   }
 
   /**

--- a/tests/e2e/ephemeral.test.ts
+++ b/tests/e2e/ephemeral.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Ephemeral-presence E2E: the cross-repo contract test for `mero.ephemeral`
+ * against a REAL merod (the released binary CI downloads).
+ *
+ * Core pins its own half with Rust serde tests and a two-node merobox e2e; what
+ * has never been checked is whether THIS package speaks the protocol correctly
+ * to a live node — that `set` is accepted with the params the node expects, and
+ * that the SSE `Ephemeral` events it emits carry the exact field
+ * presence/absence `subscribe` reads.
+ *
+ * Single-node tier: everything below is client-side contract, so one node with
+ * one owned identity is enough. (TTL eviction needs a second node — see the
+ * skipped test at the bottom.)
+ *
+ * NOT-SUPPORTED POLICY: if the node under test predates presence, this suite
+ * FAILS LOUDLY in `beforeAll` rather than skipping. CI always points at the
+ * newest core release, so an unsupported node means a rollback or a dropped
+ * endpoint — exactly the regression this file exists to catch. A skip would
+ * still leave CI green (the other e2e suites satisfy its "[1-9] passed" guard),
+ * which is precisely the vacuous pass we must not produce.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
+
+const NODE_URL = resolveBaseUrl();
+const CREDS = resolveCreds();
+const RUN = runId();
+
+/** Raw shape of the node's `Ephemeral` event payload, before `subscribe` normalizes it. */
+interface RawEphemeral {
+  author?: string;
+  state?: number[];
+  removed?: boolean;
+  ageMs?: number;
+}
+interface RawEvent {
+  contextId?: string;
+  type?: string;
+  data?: RawEphemeral;
+}
+
+/** The presence slice this suite publishes; `nonce` makes each `set` identifiable. */
+interface Slice {
+  nonce: string;
+  cursor: { line: number; col: number };
+}
+
+let mero: MeroJs;
+let applicationId: string;
+let namespaceId: string;
+let contextId: string;
+/** Every raw `Ephemeral` event for our context, recorded straight off the SSE stream. */
+const rawEvents: RawEvent[] = [];
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Poll `check` until it returns a value, or throw after `timeoutMs`. */
+async function waitFor<T>(
+  check: () => T | undefined,
+  timeoutMs: number,
+  what: string,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const found = check();
+    if (found !== undefined) return found;
+    if (Date.now() > deadline) throw new Error(`timed out after ${timeoutMs}ms waiting for ${what}`);
+    await sleep(100);
+  }
+}
+
+/** Resolve once the SSE stream is live (the node has sent its session id), so a
+ * later `subscribe` is actually registered before we publish. */
+async function awaitSseConnected(client: MeroJs, timeoutMs = 30000): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('SSE did not connect')), timeoutMs);
+    client.events.on('connect', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+    void client.events.connect();
+  });
+}
+
+beforeAll(async () => {
+  mero = new MeroJs({ baseUrl: NODE_URL });
+  await mero.authenticate(CREDS);
+  applicationId = await ensureApplication(mero);
+  const ns = await mero.admin.createNamespace({ applicationId, alias: `eph-${RUN}` });
+  namespaceId = ns.namespaceId;
+  const ctx = await mero.admin.createContext({ applicationId, groupId: namespaceId });
+  contextId = ctx.contextId;
+
+  // Support probe. A node without presence answers `set_ephemeral` with a
+  // method-not-found style RPC error; turn that into an unmistakable failure
+  // instead of letting every assertion below fail with a cryptic message.
+  try {
+    await mero.ephemeral.set<Slice>(contextId, { nonce: 'probe', cursor: { line: 0, col: 0 } });
+  } catch (err) {
+    throw new Error(
+      'set_ephemeral was rejected by the node under test — this merod appears to ' +
+        'predate ephemeral presence (needs core >= 0.11.0-rc.24). Failing loudly ' +
+        `rather than skipping, so a rollback cannot pass silently. Underlying error: ${String(err)}`,
+    );
+  }
+
+  // Record every raw Ephemeral frame for this context. `subscribe` normalizes
+  // the payload, so the raw stream is the only place to assert what the node
+  // actually put on the wire (fields absent vs. present-and-falsy).
+  mero.events.on('event', (event: unknown) => {
+    const e = event as RawEvent;
+    if (e.type === 'Ephemeral' && e.contextId === contextId) rawEvents.push(e);
+  });
+  await awaitSseConnected(mero);
+}, 120000);
+
+afterAll(async () => {
+  if (namespaceId) await mero?.admin.deleteNamespace(namespaceId).catch(() => {});
+  mero?.close();
+}, 60000);
+
+describe('E2E — ephemeral presence (single node)', () => {
+  it('set publishes without an author — the node resolves it server-side', async () => {
+    const captured: Array<Record<string, unknown>> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+      if (url.includes('/jsonrpc') && typeof init?.body === 'string') {
+        const body = JSON.parse(init.body) as { method?: string; params?: Record<string, unknown> };
+        if (body.method === 'set_ephemeral') captured.push(body.params ?? {});
+      }
+      return realFetch(input, init);
+    };
+
+    try {
+      // No throw == the node accepted it (`set` surfaces any RPC error).
+      await mero.ephemeral.set<Slice>(contextId, {
+        nonce: 'author-check',
+        cursor: { line: 1, col: 2 },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+
+    expect(captured).toHaveLength(1);
+    const params = captured[0];
+    expect(params.contextId).toBe(contextId);
+    expect(Array.isArray(params.state)).toBe(true);
+    // The write is single-writer by construction: a client cannot assert an
+    // author, so it must not send one.
+    expect(Object.keys(params)).toEqual(['contextId', 'state']);
+    expect(params).not.toHaveProperty('author');
+  });
+
+  it('subscribe delivers the live delta: state decoded, removed false, NO ageMs', async () => {
+    const received: Array<{ author: string; state?: Slice; removed?: boolean; ageMs?: number }> = [];
+    const unsubscribe = mero.ephemeral.subscribe<Slice>(contextId, (entry) => received.push(entry));
+    // The subscription is registered on the live stream and any replay of prior
+    // state has drained before we publish the delta we assert on.
+    await sleep(2000);
+
+    const nonce = `live-${RUN}`;
+    const beforeRaw = rawEvents.length;
+    await mero.ephemeral.set<Slice>(contextId, { nonce, cursor: { line: 42, col: 7 } });
+
+    const entry = await waitFor(
+      () => received.find((e) => e.state?.nonce === nonce),
+      30000,
+      'the live presence delta',
+    );
+    unsubscribe();
+
+    // The default JSON codec round-trips the slice through the node's byte array.
+    expect(entry.state).toEqual({ nonce, cursor: { line: 42, col: 7 } });
+    expect(entry.author).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/); // bs58 identity key
+    // `subscribe` hands callers a real boolean even though the wire omits the field.
+    expect(entry.removed).toBe(false);
+    // A live delta is fresh at receipt: `ageMs` must be genuinely ABSENT, not 0
+    // — the two mean different things downstream.
+    expect('ageMs' in entry).toBe(false);
+    expect(entry.ageMs).toBeUndefined();
+
+    // Same claims against the untouched wire frame: this is the node's half of
+    // the contract, not our normalization.
+    const raw = rawEvents
+      .slice(beforeRaw)
+      .find((e) => e.data?.state && JSON.stringify(e.data.state).length > 0 && !e.data.removed);
+    expect(raw).toBeDefined();
+    expect('removed' in (raw?.data ?? {})).toBe(false); // absent on upsert, not `false`
+    expect('ageMs' in (raw?.data ?? {})).toBe(false); // absent on a live delta, not `0`
+    expect(raw?.data?.author).toBe(entry.author);
+  });
+
+  it('replay-on-subscribe seeds a fresh subscriber, and the seed carries ageMs', async () => {
+    const nonce = `replay-${RUN}`;
+    await mero.ephemeral.set<Slice>(contextId, { nonce, cursor: { line: 3, col: 9 } });
+
+    // A second client: a brand-new SSE connection, which is what triggers the
+    // node's replay of the context's current presence. (There is deliberately
+    // no `get` — subscribing IS the read path.)
+    const observer = new MeroJs({ baseUrl: NODE_URL });
+    try {
+      await observer.authenticate(CREDS);
+      const seen: Array<{ author: string; state?: Slice; ageMs?: number }> = [];
+      const unsubscribe = observer.ephemeral.subscribe<Slice>(contextId, (e) => seen.push(e));
+
+      const seed = await waitFor(
+        () => seen.find((e) => e.ageMs !== undefined),
+        30000,
+        'the replayed seed entry',
+      );
+      unsubscribe();
+
+      // The seed is real presence, not an empty marker, and its age is a
+      // node-measured relative number bounded by the 7s TTL.
+      expect(seed.state?.nonce).toBeTruthy();
+      expect(typeof seed.ageMs).toBe('number');
+      expect(seed.ageMs).toBeGreaterThanOrEqual(0);
+      expect(seed.author).toBeTruthy();
+    } finally {
+      observer.close();
+    }
+  });
+
+  it('the unsubscribe function detaches — no further handler calls', async () => {
+    let calls = 0;
+    const unsubscribe = mero.ephemeral.subscribe<Slice>(contextId, () => {
+      calls += 1;
+    });
+    await mero.ephemeral.set<Slice>(contextId, { nonce: `unsub-${RUN}`, cursor: { line: 0, col: 0 } });
+    await waitFor(() => (calls > 0 ? true : undefined), 30000, 'the first handler call');
+
+    unsubscribe();
+    const afterDetach = calls;
+
+    // Keep the stream busy: further sets (plus the node's own heartbeat) would
+    // reach a still-attached listener.
+    await mero.ephemeral.set<Slice>(contextId, { nonce: `unsub2-${RUN}`, cursor: { line: 1, col: 1 } });
+    await sleep(3000);
+    await mero.ephemeral.set<Slice>(contextId, { nonce: `unsub3-${RUN}`, cursor: { line: 2, col: 2 } });
+    await sleep(3000);
+
+    expect(calls).toBe(afterDetach);
+  });
+
+  // TTL eviction (a `removed: true` event ~7s after an author goes quiet) is NOT
+  // testable here: the node heartbeats its OWN local entry, so a local slice
+  // never expires while the node runs. Observing expiry needs a second node whose
+  // peer entry can go stale — core covers that in its two-node merobox e2e. Left
+  // skipped rather than omitted so the gap is visible, and not faked with a stub.
+  it.skip('evicts an author after the 7s TTL (needs 2 nodes — covered by core e2e)', () => {});
+});


### PR DESCRIPTION
## `mero.ephemeral` — ephemeral presence client

Client for Calimero's ephemeral-presence channel: transient encrypted state (cursors, typing, online) that gossips between nodes without touching the DAG.

Depends on the node-side feature in calimero-network/core#3427.

### API

```ts
mero.ephemeral.set<T>(contextId, state, codec?): Promise<void>
mero.ephemeral.get<T>(contextId, codec?): Promise<EphemeralSnapshotEntry<T>[]>   // { author, state, ageMs }[]
mero.ephemeral.subscribe<T>(contextId, handler, codec?): () => void              // returns unsubscribe
```

`set` takes **no author** — you can only write your own slot, and the node resolves the author server-side from its owned context identity. That's a security property, not an omission. `get`/`subscribe` return everyone's slots, so each carries its `author`.

Default codec is JSON over a byte array (the wire carries `state` as `number[]`, not a string). Any `Codec<T>` can be substituted; the node never deserializes the slice.

### `subscribe` adds no transport

It's a typed filter on `type === 'Ephemeral'` over the **existing** `MeroJs.events` SSE stream, and the `mero.ephemeral` getter shares this instance's `SseClient` — so no second connection is opened.

### Wire contract

Fixtures are taken verbatim from a live 2-node capture, so the mocks can't drift from what core emits:

```jsonc
get_ephemeral -> { entries: { "<author>": { state: [1,2,3], ageMs: 447 } } }  // author-keyed map, has age
event         -> { contextId, type: "Ephemeral", data: { author, state?, removed? } }  // delta, no age
```

`removed` is **absent** on an upsert (not `false`) and `state` is absent on a removal — both are `skip_serializing_if` in core. `subscribe` normalizes `removed` to a real boolean so callers don't have to know the rule, and never decodes a missing `state`.

### Tests

**293 passed, 1 skipped.** Lint + typecheck clean. Coverage includes the absent-`removed` upsert, removal without `state`, unsubscribe actually detaching, and a guard that the nested `state` byte array survives `SseClient`'s byte-array auto-decode (which fires only on an array-valued `data`; presence `data` is an object).

### Release ordering

This ships first. `mero-react`'s `useEphemeral` (calimero-network/mero-react#TBD) carries local structural type copies until a release of this package publishes `Codec` / `EphemeralClient`, at which point its dependency floor gets bumped and the copies deleted.
