### PR TITLE
fix(admin)!: drop registerGroupSigningKey

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -982,11 +982,6 @@ describe('AdminApiClient', () => {
       expect(result.memberCount).toBe(2);
     });
 
-    it('registerGroupSigningKey unwraps data', async () => {
-      mock.setMockResponse('POST', '/admin-api/groups/g-1/signing-key', { data: { publicKey: 'pk-123' } });
-      const result = await client.registerGroupSigningKey('g-1', { signingKey: 'sk-123' });
-      expect(result).toEqual({ publicKey: 'pk-123' });
-    });
   });
 
   describe('Group Upgrade', () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -84,8 +84,6 @@ import type {
   GetMetadataResponseData,
   SyncGroupRequest,
   SyncGroupResponseData,
-  RegisterGroupSigningKeyRequest,
-  RegisterGroupSigningKeyResponseData,
   UpgradeGroupRequest,
   UpgradeGroupResponseData,
   GroupUpgradeStatusResponseData,
@@ -937,18 +935,6 @@ export class AdminApiClient {
 
   async syncGroup(groupId: string, request?: SyncGroupRequest): Promise<SyncGroupResponseData> {
     return unwrap(await this.httpClient.post<{ data: SyncGroupResponseData }>(`/admin-api/groups/${groupId}/sync`, request ?? {}));
-  }
-
-  async registerGroupSigningKey(
-    groupId: string,
-    request: RegisterGroupSigningKeyRequest,
-  ): Promise<RegisterGroupSigningKeyResponseData> {
-    return unwrap(
-      await this.httpClient.post<{ data: RegisterGroupSigningKeyResponseData }>(
-        `/admin-api/groups/${groupId}/signing-key`,
-        request,
-      ),
-    );
   }
 
   async upgradeGroup(groupId: string, request: UpgradeGroupRequest): Promise<UpgradeGroupResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -803,14 +803,6 @@ export interface SyncGroupResponseData {
   contextCount: number;
 }
 
-export interface RegisterGroupSigningKeyRequest {
-  signingKey: string;
-}
-
-export interface RegisterGroupSigningKeyResponseData {
-  publicKey: string;
-}
-
 export interface UpgradeGroupRequest {
   targetApplicationId: string;
   requester?: string;

--- a/tests/e2e/coverage-sweep.test.ts
+++ b/tests/e2e/coverage-sweep.test.ts
@@ -94,7 +94,6 @@ describe('Admin API E2E — Route coverage sweep', () => {
   // NOTE: the full member lifecycle (add/list/role/capabilities/metadata/auto-follow/
   // remove) is deeply asserted in round-trip.test.ts.
   it('group proofs + signing key + updateApp + app uninstall', async () => {
-    await cover('signingKey', () => mero.admin.registerGroupSigningKey(groupId, {} as never));
     await cover('updateApp', () =>
       mero.admin.updateContextApplication(contextId, { applicationId, executorPublicKey: executor }),
     );


### PR DESCRIPTION
Core is deleting `POST /admin-api/groups/:group_id/signing-key` and the `GroupSigningKey` store it fed — see calimero-network/core#3439. A node holds **one** signing key; that endpoint took a private key over HTTP to populate a per-group cache of a key the node already had.

### Why this needs doing deliberately

Nothing here goes red when core merges. The unit test is mocked, so it passes against a route that no longer exists; the e2e coverage sweep calls it through `cover()`, which swallows errors by design. So the failure mode is silent: the method just starts 404ing in consumers' hands with CI still green.

### Changes

- `src/admin-api/admin-client.ts` — drop `registerGroupSigningKey`
- `src/admin-api/admin-types.ts` — drop `RegisterGroupSigningKeyRequest` / `RegisterGroupSigningKeyResponseData`
- `src/admin-api/admin-client.test.ts` — drop the mocked unit test
- `tests/e2e/coverage-sweep.test.ts` — drop the sweep entry

`pnpm typecheck`, `pnpm build` and `pnpm test:unit` (280 passed) are clean. `pnpm lint` reports 172 problems both with and without this change — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)