### PR TITLE
feat(admin)!: drop context identity alias methods

### DIFF
--- a/src/__contract__/wire.contract.test.ts
+++ b/src/__contract__/wire.contract.test.ts
@@ -87,8 +87,6 @@ const SPECS: Spec[] = [
     file: 'jsonrpc/execute.req.json',
     required: [exec('contextId'), exec('method')],
     optional: [exec('argsJson'), exec('executorPublicKey')],
-    // core defaults these; the SDK does not send them.
-    ignoredCoreKeys: ['substitute'],
   },
 ];
 

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -593,36 +593,6 @@ describe('AdminApiClient', () => {
     });
   });
 
-  describe('Context Identity Aliases', () => {
-    it('listContextIdentityAliases unwraps the alias -> identity map', async () => {
-      mock.setMockResponse('GET', '/admin-api/alias/list/identity/ctx-1', { data: { alice: 'pk-1' } });
-      const result = await client.listContextIdentityAliases('ctx-1');
-      expect(result).toEqual({ alice: 'pk-1' });
-    });
-
-    it('createContextIdentityAlias sends { alias, identity } with context in the path', async () => {
-      mock.setMockResponse('POST', '/admin-api/alias/create/identity/ctx-1', { data: {} });
-      const result = await client.createContextIdentityAlias('ctx-1', { alias: 'alice', identity: 'pk-1' });
-      expect(result).toEqual({});
-      expect(mock.getRequestBody('POST', '/admin-api/alias/create/identity/ctx-1')).toEqual({
-        alias: 'alice',
-        identity: 'pk-1',
-      });
-    });
-
-    it('lookupContextIdentityAlias unwraps data', async () => {
-      mock.setMockResponse('POST', '/admin-api/alias/lookup/identity/ctx-1/alice', { data: { value: 'pk-1' } });
-      const result = await client.lookupContextIdentityAlias('ctx-1', 'alice');
-      expect(result).toEqual({ value: 'pk-1' });
-    });
-
-    it('deleteContextIdentityAlias unwraps data', async () => {
-      mock.setMockResponse('POST', '/admin-api/alias/delete/identity/ctx-1/alice', { data: {} });
-      const result = await client.deleteContextIdentityAlias('ctx-1', 'alice');
-      expect(result).toEqual({});
-    });
-  });
-
   describe('Namespace Management', () => {
     it('listNamespaces unwraps data', async () => {
       const ns = { namespaceId: 'ns-1', appKey: 'key', targetApplicationId: 'app-1', upgradePolicy: 'manual', createdAt: 123, memberCount: 1, contextCount: 0, subgroupCount: 0 };

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -39,15 +39,10 @@ import type {
   GetBlobInfoResponseData,
   CreateContextAliasRequest,
   CreateApplicationAliasRequest,
-  CreateContextIdentityAliasRequest,
   CreateAliasResponseData,
   LookupAliasResponseData,
   DeleteAliasResponseData,
   ListAliasesResponseData,
-  ListContextIdentityAliasesResponseData,
-  CreateContextIdentityAliasResponseData,
-  LookupContextIdentityAliasResponseData,
-  DeleteContextIdentityAliasResponseData,
   ListNamespacesResponseData,
   CreateNamespaceRequest,
   CreateNamespaceResponseData,
@@ -604,52 +599,6 @@ export class AdminApiClient {
 
   async listApplicationAliases(): Promise<ListAliasesResponseData> {
     return unwrap(await this.httpClient.get<{ data: ListAliasesResponseData }>('/admin-api/alias/list/application'));
-  }
-
-  // ---- Context Identity Aliases ----
-
-  async listContextIdentityAliases(contextId: string): Promise<ListContextIdentityAliasesResponseData> {
-    return unwrap(
-      await this.httpClient.get<{ data: ListContextIdentityAliasesResponseData }>(
-        `/admin-api/alias/list/identity/${contextId}`,
-      ),
-    );
-  }
-
-  async createContextIdentityAlias(
-    contextId: string,
-    request: CreateContextIdentityAliasRequest,
-  ): Promise<CreateContextIdentityAliasResponseData> {
-    return unwrap(
-      await this.httpClient.post<{ data: CreateContextIdentityAliasResponseData }>(
-        `/admin-api/alias/create/identity/${contextId}`,
-        { alias: request.alias, identity: request.identity },
-      ),
-    );
-  }
-
-  async lookupContextIdentityAlias(
-    contextId: string,
-    name: string,
-  ): Promise<LookupContextIdentityAliasResponseData> {
-    return unwrap(
-      await this.httpClient.post<{ data: LookupContextIdentityAliasResponseData }>(
-        `/admin-api/alias/lookup/identity/${contextId}/${encodeURIComponent(name)}`,
-        {},
-      ),
-    );
-  }
-
-  async deleteContextIdentityAlias(
-    contextId: string,
-    name: string,
-  ): Promise<DeleteContextIdentityAliasResponseData> {
-    return unwrap(
-      await this.httpClient.post<{ data: DeleteContextIdentityAliasResponseData }>(
-        `/admin-api/alias/delete/identity/${contextId}/${encodeURIComponent(name)}`,
-        {},
-      ),
-    );
   }
 
   // ---- Namespace Management ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -306,15 +306,10 @@ export interface CreateApplicationAliasRequest {
   applicationId: string;
 }
 
-export interface CreateContextIdentityAliasRequest {
-  alias: string;
-  identity: string;
-}
-
 /**
  * Core's `ListAliasesResponse` is `{ data: BTreeMap<Alias<T>, T> }`, so once the
  * `data` envelope is stripped the payload is a flat `{ alias: id }` map — not a
- * list of entries. Applies to context, application and context-identity aliases.
+ * list of entries. Applies to context and application aliases.
  */
 export type ListAliasesResponseData = Record<string, string>;
 
@@ -325,17 +320,6 @@ export type DeleteAliasResponseData = Record<string, never>;
 export interface LookupAliasResponseData {
   value?: string;
 }
-
-// ---- Context identity aliases ----
-
-export type ListContextIdentityAliasesResponseData = ListAliasesResponseData;
-export type CreateContextIdentityAliasResponseData = Record<string, never>;
-
-export interface LookupContextIdentityAliasResponseData {
-  value?: string;
-}
-
-export type DeleteContextIdentityAliasResponseData = Record<string, never>;
 
 // ---- Shared invitation types ----
 

--- a/tests/e2e/wire.contract.test.ts
+++ b/tests/e2e/wire.contract.test.ts
@@ -73,7 +73,6 @@ let contextId: string;
 let memberPublicKey: string;
 const contextAlias = `wc-ctx-${RUN}`;
 const applicationAlias = `wc-app-${RUN}`;
-const identityAlias = `wc-id-${RUN}`;
 
 let applications: Application[] = [];
 let contexts: ContextWithGroup[] = [];
@@ -178,10 +177,6 @@ describe('live wire contract (merod responses ↔ SDK types)', () => {
 
     await mero.admin.createContextAlias({ alias: contextAlias, contextId });
     await mero.admin.createApplicationAlias({ alias: applicationAlias, applicationId });
-    await mero.admin.createContextIdentityAlias(contextId, {
-      alias: identityAlias,
-      identity: memberPublicKey,
-    });
 
     applications = (await mero.admin.listApplications()).apps;
     contexts = (await mero.admin.getContexts()).contexts;
@@ -227,13 +222,12 @@ describe('live wire contract (merod responses ↔ SDK types)', () => {
 
   // The three alias listings share one declared type, and it is not a keyed
   // record but a flat map — so it gets a shape check rather than a key table.
-  it('ListAliasesResponseData is a flat { alias: id } map (via listContextAliases, listApplicationAliases, listContextIdentityAliases)', async () => {
+  it('ListAliasesResponseData is a flat { alias: id } map (via listContextAliases, listApplicationAliases)', async () => {
     // The annotation is the compile-time half: the declared type has to *be* the
     // map core sends. It stops compiling if it goes back to a list of entries.
     const listings: Record<string, Record<string, string>> = {
       listContextAliases: await mero.admin.listContextAliases(),
       listApplicationAliases: await mero.admin.listApplicationAliases(),
-      listContextIdentityAliases: await mero.admin.listContextIdentityAliases(contextId),
     };
 
     for (const [via, listing] of Object.entries(listings)) {
@@ -249,6 +243,5 @@ describe('live wire contract (merod responses ↔ SDK types)', () => {
     // is the map core actually sends.
     expect(listings.listContextAliases[contextAlias]).toBe(contextId);
     expect(listings.listApplicationAliases[applicationAlias]).toBe(applicationId);
-    expect(listings.listContextIdentityAliases[identityAlias]).toBe(memberPublicKey);
   });
 });


### PR DESCRIPTION
## Summary

Paired with **calimero-network/core#3441**, which removes the four `/admin-api/alias/*/identity` routes. A node now uses one member identity across its contexts, so naming identities *per context* no longer describes anything real.

Removes from `AdminApiClient`:

- `listContextIdentityAliases`
- `createContextIdentityAlias`
- `lookupContextIdentityAlias`
- `deleteContextIdentityAlias`

plus `CreateContextIdentityAliasRequest` and the four `*ContextIdentityAliasResponseData` types, their unit tests, and the e2e wire-contract coverage that exercised them.

Also drops `ignoredCoreKeys: ['substitute']` from the contract spec — core removes that JSON-RPC field in the same change, so the entry named a field that no longer exists.

**Context and application aliases are unchanged.** Those are node-global and unaffected by the identity model.

## Why this is paired

Core's SDK E2E job caught this: without the SDK half, `tests/e2e/wire.contract.test.ts` calls `createContextIdentityAlias` and gets

```
HTTP 404 Not Found
url: 'http://localhost:2428/admin-api/alias/create/identity/D81ocJgt2ZPapHGkcG3gQtskDM5k9TrEuCdbtpmVhshG'
```

The `sdk-ref` pairing mechanism in `sdk-e2e.yml` exists for exactly this, so this branch shares its name with the core branch and the two go green together.

## Verification

- `pnpm typecheck` ✅
- `pnpm test:unit` ✅ — 276 passed, 1 skipped
- `pnpm test:contract` against the core branch ✅ — 5/5, confirming the fixtures round-trip with `substitute` removed

## Not touched

`tests/mocks/generated-handlers.ts` still carries MSW handlers for the four removed routes. That file is marked `DO NOT EDIT MANUALLY` and is generated from the `core-server-open-api` repo (last generated 2026-01-24); no test references those handlers, so they are inert. Worth sweeping when that generator next runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)