### PR TITLE
feat(admin): add getNodeIdentity, deprecate getNamespaceIdentity

### DIFF
--- a/docs/src/content/docs/guides/groups-and-governance.mdx
+++ b/docs/src/content/docs/guides/groups-and-governance.mdx
@@ -24,7 +24,7 @@ const { namespaceId } = await sdk.admin.createNamespace({
 
 const { namespaces } = await sdk.admin.listNamespaces();
 const ns = await sdk.admin.getNamespace(namespaceId);
-const identity = await sdk.admin.getNamespaceIdentity(namespaceId);
+const identity = await sdk.admin.getNodeIdentity();
 ```
 
 Invite and join:

--- a/docs/src/content/docs/reference/admin-api.mdx
+++ b/docs/src/content/docs/reference/admin-api.mdx
@@ -114,7 +114,7 @@ A standalone helper `compareSemver(a, b): number` sorts version strings ascendin
 | --- | --- |
 | `listNamespaces(): Promise<ListNamespacesResponseData>` | `GET /namespaces` |
 | `getNamespace(namespaceId): Promise<Namespace>` | `GET /namespaces/{namespaceId}` |
-| `getNamespaceIdentity(namespaceId): Promise<NamespaceIdentity>` | `GET /namespaces/{namespaceId}/identity` |
+| `getNamespaceIdentity(namespaceId): Promise<NamespaceIdentity>` — **deprecated**, use `getNodeIdentity()` | delegates to `GET /identity` |
 | `listNamespacesForApplication(applicationId): Promise<ListNamespacesResponseData>` | `GET /namespaces/for-application/{applicationId}` |
 | `createNamespace(request): Promise<CreateNamespaceResponseData>` | `POST /namespaces` |
 | `deleteNamespace(namespaceId, request?): Promise<DeleteNamespaceResponseData>` | `DELETE /namespaces/{namespaceId}` |
@@ -203,6 +203,7 @@ A standalone helper `compareSemver(a, b): number` sorts version strings ascendin
 
 | Method | Endpoint |
 | --- | --- |
+| `getNodeIdentity(): Promise<NodeIdentity>` | `GET /identity` |
 | `getPeersCount(): Promise<{ count: number }>` | `GET /peers` |
 | `getNetworkStatus(): Promise<unknown>` | `GET /network/status` |
 | `getUsage(): Promise<unknown>` | `GET /usage` |

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -608,10 +608,53 @@ describe('AdminApiClient', () => {
       expect(result.namespaceId).toBe('ns-1');
     });
 
-    it('getNamespaceIdentity unwraps data', async () => {
-      mock.setMockResponse('GET', '/admin-api/namespaces/ns-1/identity', { data: { namespaceId: 'ns-1', publicKey: 'pk-1' } });
-      const result = await client.getNamespaceIdentity('ns-1');
-      expect(result).toEqual({ namespaceId: 'ns-1', publicKey: 'pk-1' });
+    it('getNodeIdentity unwraps data', async () => {
+      const identity = {
+        accountId: 'ac-1',
+        deviceId: 'dv-1',
+        publicKey: 'pk-1',
+        accountRootPublicKey: 'rt-1',
+      };
+      mock.setMockResponse('GET', '/admin-api/identity', { data: identity });
+      const result = await client.getNodeIdentity();
+      expect(result).toEqual(identity);
+    });
+
+    it('getNodeIdentity reports a node that has enrolled nowhere', async () => {
+      // `deviceId: null` is a real answer, not a missing one: the account exists
+      // as soon as the node has a root, and a join is what adds the device that
+      // speaks for it. Tolerating it here is what keeps a pre-join read from
+      // looking like a failure.
+      mock.setMockResponse('GET', '/admin-api/identity', {
+        data: { accountId: 'ac-1', deviceId: null, publicKey: 'pk-1', accountRootPublicKey: 'rt-1' },
+      });
+      expect((await client.getNodeIdentity()).deviceId).toBeNull();
+    });
+
+    it('getNamespaceIdentity answers from the node-level route', async () => {
+      // The deprecated shape, kept working by delegation rather than by calling
+      // the superseded per-namespace endpoint. Nothing it returns varies by
+      // namespace, so `namespaceId` is the argument echoed back — asserted, so
+      // that stays a deliberate contract and not an accident of the reshape.
+      mock.setMockResponse('GET', '/admin-api/identity', {
+        data: { accountId: 'ac-1', deviceId: 'dv-1', publicKey: 'pk-1', accountRootPublicKey: 'rt-1' },
+      });
+      expect(await client.getNamespaceIdentity('ns-1')).toEqual({
+        namespaceId: 'ns-1',
+        publicKey: 'pk-1',
+        account: 'ac-1',
+      });
+    });
+
+    it('getNamespaceIdentity gives the same answer for every namespace', async () => {
+      // The claim the deprecation rests on. If these ever differed, the
+      // parameter would be load-bearing and dropping it would lose information.
+      mock.setMockResponse('GET', '/admin-api/identity', {
+        data: { accountId: 'ac-1', deviceId: 'dv-1', publicKey: 'pk-1', accountRootPublicKey: 'rt-1' },
+      });
+      const [a, b] = [await client.getNamespaceIdentity('ns-a'), await client.getNamespaceIdentity('ns-b')];
+      expect(a.account).toBe(b.account);
+      expect(a.publicKey).toBe(b.publicKey);
     });
 
     it('listNamespacesForApplication unwraps data', async () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -58,6 +58,7 @@ import type {
   SubgroupEntry,
   Namespace,
   NamespaceIdentity,
+  NodeIdentity,
   GroupInfoResponseData,
   DeleteGroupRequest,
   DeleteGroupResponseData,
@@ -611,13 +612,40 @@ export class AdminApiClient {
     return unwrap(await this.httpClient.get<{ data: Namespace }>(`/admin-api/namespaces/${namespaceId}`));
   }
 
+  /**
+   * Who this node is — the account it writes as, the device it is, the key it
+   * signs with, and the account root a second device pairs against.
+   *
+   * Takes no namespace, and that is the point: one root key is one account
+   * everywhere, and a node signs with one key, so none of it varies by
+   * namespace.
+   */
+  async getNodeIdentity(): Promise<NodeIdentity> {
+    return unwrap(await this.httpClient.get<{ data: NodeIdentity }>('/admin-api/identity'));
+  }
+
+  /**
+   * @deprecated Use {@link getNodeIdentity} instead. Every field this returns is
+   * node-level, so the namespace was only ever decoration — it now delegates to
+   * the node-level route and reshapes the answer.
+   *
+   * Three consequences of that delegation, all visible to a caller who relied on
+   * the old route's behaviour:
+   *
+   * - **No participation gate.** The namespace route answered 404 when this node
+   *   had never joined the namespace; this answers whatever the node's identity
+   *   is, regardless. If you were using it to ask "am I in this namespace?", ask
+   *   {@link listNamespaces} instead — that is the question you were really
+   *   asking.
+   * - **`namespaceId` is echoed verbatim.** The old route resolved a subgroup id
+   *   to its root namespace and returned that; passing a subgroup id here gives
+   *   the subgroup id back.
+   * - **404 means something else.** Previously "not my namespace", now "this node
+   *   holds no account root yet".
+   */
   async getNamespaceIdentity(namespaceId: string): Promise<NamespaceIdentity> {
-    // Core returns this endpoint flat ({ namespaceId, publicKey }), not under
-    // `data`. Tolerate both so it works whether or not the envelope is present.
-    const r = await this.httpClient.get<NamespaceIdentity & { data?: NamespaceIdentity }>(
-      `/admin-api/namespaces/${namespaceId}/identity`,
-    );
-    return (r?.data ?? r) as NamespaceIdentity;
+    const node = await this.getNodeIdentity();
+    return { namespaceId, publicKey: node.publicKey, account: node.accountId };
   }
 
   async listNamespacesForApplication(applicationId: string): Promise<ListNamespacesResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -406,7 +406,59 @@ export interface Namespace {
 
 export type ListNamespacesResponseData = Namespace[];
 
+/**
+ * Who this node is: the account it writes as, the device it is, and the key it
+ * signs with.
+ *
+ * Every field is node-level. One root key means one account, everywhere, and a
+ * node signs with one key — so none of this varies by namespace, which is why
+ * the endpoint behind it takes none.
+ */
+export interface NodeIdentity {
+  /**
+   * The account this node writes as, 64 hex characters. This — not
+   * `publicKey` — is what member-addressing endpoints take, and what
+   * `listGroupMembers` entries are keyed by, so it is how a caller locates
+   * itself in a member list.
+   */
+  accountId: string;
+  /**
+   * The device this node is, 64 hex characters, or `null` before it has
+   * enrolled anywhere.
+   *
+   * `null` is a real answer rather than a missing one: the account id above
+   * exists as soon as the node has a root, and enrolment — which a join
+   * performs — is what adds the device that speaks for it.
+   */
+  deviceId: string | null;
+  /**
+   * The key this node signs ops with, base58.
+   *
+   * The device's signing key, not the account root: the root signs
+   * certificates and never an op, so a signature on the wire verifies against
+   * this one.
+   */
+  publicKey: string;
+  /**
+   * The epoch-0 root **public** key of this node's account, 64 hex characters.
+   *
+   * What a second device needs to pair into this account, and public by
+   * construction — it is hashed into `accountId` and travels in every genesis.
+   * The private root never leaves the node over HTTP.
+   *
+   * Optional because a node at or below `0.11.0-rc.22` does not send it: the
+   * field landed after that release. Required in the type would make this SDK
+   * claim something the node the caller chose may not report.
+   */
+  accountRootPublicKey?: string;
+}
+
+/**
+ * @deprecated Use {@link AdminApiClient.getNodeIdentity} instead. Nothing here
+ * varies by namespace, so the parameter could only ever be decoration.
+ */
 export interface NamespaceIdentity {
+  /** Echoed back from the argument; it does not describe the identity. */
   namespaceId: string;
   /** The key this node signs with, base58. */
   publicKey: string;

--- a/tests/e2e/admin-api.test.ts
+++ b/tests/e2e/admin-api.test.ts
@@ -124,7 +124,18 @@ describe('Admin API E2E — Namespace Model', () => {
       expect(ns.targetApplicationId).toBe(applicationId);
     });
 
+    it('should get the node identity', async () => {
+      const identity = await mero.admin.getNodeIdentity();
+      expect(identity.accountId).toBeTruthy();
+      expect(identity.publicKey).toBeTruthy();
+      // `accountRootPublicKey` is deliberately not asserted: it landed after
+      // `0.11.0-rc.22`, and this suite runs against the RELEASED merod. Asserting
+      // it would fail on the very nodes a caller is most likely to have.
+    });
+
     it('should get namespace identity', async () => {
+      // Deprecated, and covered because it still has callers: it must keep
+      // answering from the node-level route, with the argument echoed back.
       const identity = await mero.admin.getNamespaceIdentity(namespaceId);
       expect(identity.namespaceId).toBe(namespaceId);
       expect(identity.publicKey).toBeTruthy();


### PR DESCRIPTION
`getNamespaceIdentity(namespaceId)` was this SDK's only way to report which account a node writes as, and its shape says the answer varies by namespace. It does not.

One root key is one account everywhere, and a node signs with one key, so every field the per-namespace route returns is node-level. Core says so in the handler itself:

> **Superseded by `GET /admin-api/identity`.** Every field it returns is node-level — one root key is one account everywhere, and a node signs with one key — so the namespace in the path cannot change the answer. What it still does is gate on participation… Kept because 44 merobox scenarios drive it through the `get_namespace_identity` step.

And the store confirms the mechanism — `identity_record` reads a singleton `NodeIdentity` row after a participation check: *"The keypair itself is node-level — one node signs with one key — so reading it alone would answer 'yes, here it is' for every namespace on earth."*

## What this adds

`getNodeIdentity(): Promise<NodeIdentity>` over `GET /admin-api/identity`, which also reaches two fields the namespace route never returned:

| field | |
| --- | --- |
| `accountId` | the account this node writes as — what member-addressing endpoints take |
| `deviceId` | the device it is, or `null` before it has enrolled anywhere |
| `publicKey` | the key it signs ops with (the device's, not the account root's) |
| `accountRootPublicKey` | what a **second device pairs against** — unreachable from the old route |

`deviceId: null` is a real answer rather than a missing one: the account id exists as soon as the node has a root, and enrolment — which a join performs — is what adds the device that speaks for it.

## The deprecated method still works, via delegation

`getNamespaceIdentity` now calls `getNodeIdentity()` and reshapes the result, rather than hitting the superseded path. Its three behaviour changes are documented on the method instead of left to be discovered:

- **No participation gate.** The old route answered 404 for a namespace this node had never joined; this answers regardless. Callers using it as "am I in this namespace?" should ask `listNamespaces()` — that was the real question.
- **`namespaceId` is echoed verbatim.** The old route resolved a subgroup id to its root namespace and returned that.
- **404 means something else now** — "this node holds no account root yet", not "not my namespace".

## Version skew, handled deliberately

`accountRootPublicKey` is **optional** in the type, and the e2e does **not** assert it: it landed after `0.11.0-rc.22`, and both the CI e2e and most callers run against the released merod. A required field would make this SDK claim something the node the caller chose does not report. `GET /admin-api/identity` itself exists in rc.22, so the new binding works against the current release — checked against that tag's `service.rs`, not assumed.

## Verification

| gate | result |
| --- | --- |
| `pnpm typecheck` | ✓ |
| `pnpm typecheck:consumer` (after `pnpm build`) | ✓ |
| `pnpm typecheck:contract` | ✓ |
| `pnpm test:unit` | ✓ 279 passed, 1 skipped |
| `pnpm lint` | ✓ 0 errors (2 pre-existing warnings in `docs/src/scripts`) |
| `cd docs && npm run check` | ✓ 22 pages, internal links OK |

Four new unit tests cover the unwrap, the `deviceId: null` case, the delegation (including that `namespaceId` is echoed), and — the claim the deprecation rests on — that two different namespaces give the same answer. A new e2e hits the node-level route; the existing `getNamespaceIdentity` e2e is kept, because the deprecated method still has callers and must keep answering.

Related: calimero-network/core#3511 removes the matching stale claims on the core side (a dead `NamespaceAccountApiResponse` type whose field promised cross-namespace unlinkability, plus 18 references to the deleted `account create` command).

🤖 Generated with [Claude Code](https://claude.com/claude-code)