### PR TITLE
fix(admin)!: replace governanceOp with memberAccount on join responses

### DIFF
--- a/docs/src/content/docs/guides/groups-and-governance.mdx
+++ b/docs/src/content/docs/guides/groups-and-governance.mdx
@@ -32,9 +32,12 @@ Invite and join:
 ```typescript
 const invitation = await sdk.admin.createNamespaceInvitation(namespaceId);
 // on the joining node:
-const { groupId, memberIdentity } = await sdk.admin.joinNamespace(namespaceId, {
-  invitation,
-});
+// `memberAccount` is what the member-addressing calls below take;
+// `memberIdentity` is the key it signs with.
+const { groupId, memberIdentity, memberAccount } = await sdk.admin.joinNamespace(
+  namespaceId,
+  { invitation },
+);
 ```
 
 ## Groups, members & roles

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -706,10 +706,10 @@ describe('AdminApiClient', () => {
     it('joinNamespace sends structured invitation', async () => {
       const invitation = SIGNED_INVITATION;
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
-        data: { groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' },
+        data: { groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
       });
       const result = await client.joinNamespace('ns-1', { invitation, groupName: 'My NS' });
-      expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' });
+      expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) });
       expect(mock.getRequestBody('POST', '/admin-api/namespaces/ns-1/join')).toEqual({ invitation, groupName: 'My NS' });
     });
 
@@ -1202,10 +1202,10 @@ describe('AdminApiClient', () => {
 
     it('joinGroup sends invitation and unwraps response', async () => {
       mock.setMockResponse('POST', '/admin-api/groups/join', {
-        data: { groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' },
+        data: { groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
       });
       const result = await client.joinGroup({ invitation: mockInvitation, groupName: 'Lobby' });
-      expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', governanceOp: 'op-hex' });
+      expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) });
       expect(mock.getRequestBody('POST', '/admin-api/groups/join')).toEqual({
         invitation: mockInvitation,
         groupName: 'Lobby',

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -512,8 +512,14 @@ export interface JoinNamespaceRequest {
 
 export interface JoinNamespaceResponseData {
   groupId: string;
+  /** The key the joiner signs with, base58. */
   memberIdentity: string;
-  governanceOp: string;
+  /**
+   * The account that key joined as, 64 hex characters. This — not
+   * `memberIdentity` — is what every member-addressing endpoint takes, so it
+   * is how the caller addresses the member it just became.
+   */
+  memberAccount: string;
 }
 
 export interface CreateGroupInNamespaceRequest {
@@ -915,8 +921,14 @@ export interface JoinGroupRequest {
 
 export interface JoinGroupResponseData {
   groupId: string;
+  /** The key the joiner signs with, base58. */
   memberIdentity: string;
-  governanceOp: string;
+  /**
+   * The account that key joined as, 64 hex characters. This — not
+   * `memberIdentity` — is what every member-addressing endpoint takes, so it
+   * is how the caller addresses the member it just became.
+   */
+  memberAccount: string;
 }
 
 // ---- TEE ----

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -57,5 +57,10 @@ suite('Multi-node E2E — namespace invite/join', () => {
     // node-2 is now a member of the namespace (got its own member identity back).
     expect(joined.memberIdentity).toBeTruthy();
     expect(joined.groupId).toBeTruthy();
+    // The account it joined as, beside the key it signs with: this is what every
+    // member-addressing endpoint takes, and it renders as 64 hex, so a field
+    // wired to the bs58 key space instead would fail here rather than silently
+    // flow on into calls that then address nobody.
+    expect(joined.memberAccount).toMatch(/^[0-9a-f]{64}$/);
   });
 });


### PR DESCRIPTION
## What

`JoinGroupResponseData` and `JoinNamespaceResponseData` typed `governanceOp` as a required `string`. The node has never sent anything but `""` there.

The field is a remnant of a superseded relay model in which a joiner handed a signed op back for an orchestrator to forward to the inviting node. Direct request-response join replaced it, and the relay endpoint was never built — core#3450 removed the client method and DTOs behind it. Nothing in this SDK, or any consumer of it, reads the value; the only occurrences outside the type declarations were unit-test mocks inventing plausible values (`'op-hex'`) for a field that is always empty.

Both types were also missing `memberAccount`, which core has returned since the account/identity split and which is the one a caller actually needs — every member-addressing endpoint takes the account, not the signing key, so without it a freshly joined member cannot address itself.

## Changes

- `admin-types.ts` — `governanceOp` → `memberAccount` on both join response types, documented.
- Unit mocks now carry a 64-hex account rather than a token string.
- `tests/e2e/multinode.test.ts` asserts `memberAccount` matches `/^[0-9a-f]{64}$/`, so a field wired to the bs58 key space fails there instead of flowing on into calls that address nobody.
- Docs snippet updated.

## Ordering

This lands **before** the core removal (calimero-network/core#3485). Extra JSON keys are ignored, so this is safe against nodes that still send `governanceOp`.

`pnpm typecheck` / `test:unit` / `lint` green (lint: 2 pre-existing `no-explicit-any` warnings, untouched).

Refs calimero-network/core#3485

🤖 Generated with [Claude Code](https://claude.com/claude-code)