### PR TITLE
feat(admin)!: drop upgradePolicy from the Namespace and GroupInfo responses

### DIFF
--- a/docs/src/content/docs/reference/admin-api.mdx
+++ b/docs/src/content/docs/reference/admin-api.mdx
@@ -230,7 +230,6 @@ interface Namespace {
   namespaceId: string;
   appKey: string;
   targetApplicationId: string;
-  upgradePolicy: string;         // deprecated, always "LazyOnAccess"
   createdAt: number;
   name?: string;
   memberCount: number;
@@ -242,7 +241,6 @@ interface GroupInfo {              // = GroupInfoResponseData
   groupId: string;
   appKey: string;
   targetApplicationId: string;
-  upgradePolicy: string;         // deprecated, always "LazyOnAccess"
   memberCount: number;
   contextCount: number;
   defaultCapabilities: number;    // capability bitmask

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -595,14 +595,14 @@ describe('AdminApiClient', () => {
 
   describe('Namespace Management', () => {
     it('listNamespaces unwraps data', async () => {
-      const ns = { namespaceId: 'ns-1', appKey: 'key', targetApplicationId: 'app-1', upgradePolicy: 'manual', createdAt: 123, memberCount: 1, contextCount: 0, subgroupCount: 0 };
+      const ns = { namespaceId: 'ns-1', appKey: 'key', targetApplicationId: 'app-1', createdAt: 123, memberCount: 1, contextCount: 0, subgroupCount: 0 };
       mock.setMockResponse('GET', '/admin-api/namespaces', { data: [ns] });
       const result = await client.listNamespaces();
       expect(result).toEqual([ns]);
     });
 
     it('getNamespace unwraps data', async () => {
-      const ns = { namespaceId: 'ns-1', appKey: 'key', targetApplicationId: 'app-1', upgradePolicy: 'manual', createdAt: 123, memberCount: 1, contextCount: 0, subgroupCount: 0 };
+      const ns = { namespaceId: 'ns-1', appKey: 'key', targetApplicationId: 'app-1', createdAt: 123, memberCount: 1, contextCount: 0, subgroupCount: 0 };
       mock.setMockResponse('GET', '/admin-api/namespaces/ns-1', { data: ns });
       const result = await client.getNamespace('ns-1');
       expect(result.namespaceId).toBe('ns-1');

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -388,6 +388,12 @@ export interface Namespace {
   namespaceId: string;
   appKey: string;
   targetApplicationId: string;
+  /**
+   * Absent from nodes that have dropped the concept, always `"LazyOnAccess"` on
+   * every released one. Optional because this SDK talks to both; it carries no
+   * information either way. Delete once no supported release still sends it.
+   */
+  upgradePolicy?: string;
   createdAt: number;
   name?: string;
   memberCount: number;
@@ -643,6 +649,12 @@ export interface GroupInfo {
   groupId: string;
   appKey: string;
   targetApplicationId: string;
+  /**
+   * Absent from nodes that have dropped the concept, always `"LazyOnAccess"` on
+   * every released one. Optional because this SDK talks to both; it carries no
+   * information either way. Delete once no supported release still sends it.
+   */
+  upgradePolicy?: string;
   memberCount: number;
   contextCount: number;
   activeUpgrade?: GroupUpgradeStatus;

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -388,9 +388,6 @@ export interface Namespace {
   namespaceId: string;
   appKey: string;
   targetApplicationId: string;
-  /** @deprecated Always `"LazyOnAccess"`. Core keeps the key only for the
-   * released Python client and drops it once that floor moves. */
-  upgradePolicy: string;
   createdAt: number;
   name?: string;
   memberCount: number;
@@ -646,9 +643,6 @@ export interface GroupInfo {
   groupId: string;
   appKey: string;
   targetApplicationId: string;
-  /** @deprecated Always `"LazyOnAccess"`. Core keeps the key only for the
-   * released Python client and drops it once that floor moves. */
-  upgradePolicy: string;
   memberCount: number;
   contextCount: number;
   activeUpgrade?: GroupUpgradeStatus;

--- a/tests/e2e/wire.contract.test.ts
+++ b/tests/e2e/wire.contract.test.ts
@@ -107,7 +107,6 @@ const SPECS: Spec[] = [
       ns('namespaceId'),
       ns('appKey'),
       ns('targetApplicationId'),
-      ns('upgradePolicy'),
       ns('createdAt'),
       ns('memberCount'),
       ns('contextCount'),

--- a/tests/e2e/wire.contract.test.ts
+++ b/tests/e2e/wire.contract.test.ts
@@ -112,7 +112,7 @@ const SPECS: Spec[] = [
       ns('contextCount'),
       ns('subgroupCount'),
     ],
-    optional: [ns('name'), ns('appVersion')],
+    optional: [ns('name'), ns('appVersion'), ns('upgradePolicy')],
   },
   {
     type: 'CreateGroupInvitationResponseData',


### PR DESCRIPTION
Link 1 of retiring `UPGRADE_POLICY_COMPAT` in core — the follow-up calimero-network/core#3485 left queued.

## What

`Namespace.upgradePolicy` and `GroupInfo.upgradePolicy` were typed non-optional, but core fills them with the constant `"LazyOnAccess"` on every response via `UPGRADE_POLICY_COMPAT`. The concept itself went server-side in core#3393; what survived was a key kept alive for clients that declared it required — this SDK among them.

Core is now deleting the shim, so the type has to stop promising a value that carries no information.

## What is deliberately NOT changed

The **request** side stays. `createNamespace` and `createGroup` still inject `upgradePolicy: 'LazyOnAccess'` into the body, with the comments explaining why:

> every RELEASED node still declares the field required and rejects a body without it — `missing field 'upgradePolicy'`

That shim is gated on **which node releases are supported**, not on which clients exist, so it has a different and longer lifetime than the response field. Removing it needs a release-policy decision ("no supported release predates core#3393"), not an SDK coordination — so it is untouched here, and the six remaining `upgradePolicy` references in the test suite are its coverage.

## Ordering

Safe to land before core removes the field: this SDK reads responses structurally, and a node that still sends the key is simply ignored. Core's own struct has carried `#[serde(default)]` on it since before rc.21, so unlike the `governanceOp` chain there is no compiled-client gate here — `calimero-client-py` neither sends nor reads it, and merobox reads namespace data as plain dicts.

## Tests

`pnpm typecheck` clean, `pnpm test:unit` **284 passed / 1 skipped**, `pnpm lint` clean (2 pre-existing `no-explicit-any` warnings, untouched). Response mocks for `listNamespaces` / `getNamespace` no longer carry the key; docs updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)