### PR TITLE
feat(admin): surface the account each migration-status row speaks for

### DIFF
--- a/src/__contract__/wire.contract.test.ts
+++ b/src/__contract__/wire.contract.test.ts
@@ -23,6 +23,10 @@ import type {
   CreateContextRequest,
   CreateContextResponseData,
   GroupUpgradeStatus,
+  MemberMigrationReport,
+  MemberMigrationStatusEntry,
+  MigrationStatus,
+  MigrationStatusRollup,
   ReparentGroupRequest,
   ReparentGroupResponseData,
   UpgradeGroupResponseData,
@@ -48,9 +52,9 @@ interface Spec {
   optional: string[];
   /** Core-optional fields the SDK intentionally does not model (no drift). */
   ignoredCoreKeys?: string[];
-  /** Envelope key to descend into first. Core wraps some admin responses in
-   * `data`; the SDK type models the inner object. */
-  envelope?: string;
+  /** Dotted path to descend into before comparing: an envelope key (`data`),
+   * a nested object (`rollup`), or an array element (`members.1`). */
+  path?: string;
 }
 
 const ctxReq = key<CreateContextRequest>();
@@ -60,6 +64,10 @@ const reRes = key<ReparentGroupResponseData>();
 const exec = key<ExecuteParams>();
 const upRes = key<UpgradeGroupResponseData>();
 const upStatus = key<GroupUpgradeStatus>();
+const mStatus = key<MigrationStatus>();
+const mRollup = key<MigrationStatusRollup>();
+const mEntry = key<MemberMigrationStatusEntry>();
+const mReport = key<MemberMigrationReport>();
 
 // `jsonrpc/execute.res.json` is deliberately absent: its SDK counterpart is an
 // unexported inline type whose index signature makes `key<T>()` accept any
@@ -104,7 +112,7 @@ const SPECS: Spec[] = [
   {
     type: 'UpgradeGroupResponseData',
     file: 'groups/upgrade.res.json',
-    envelope: 'data',
+    path: 'data',
     required: [upRes('groupId'), upRes('status')],
     optional: [
       upRes('localContextsTotal'),
@@ -115,7 +123,7 @@ const SPECS: Spec[] = [
   {
     type: 'GroupUpgradeStatus',
     file: 'groups/upgrade_status.res.json',
-    envelope: 'data',
+    path: 'data',
     required: [
       upStatus('fromVersion'),
       upStatus('toVersion'),
@@ -130,7 +138,71 @@ const SPECS: Spec[] = [
       upStatus('completedAt'),
     ],
   },
+  {
+    type: 'MigrationStatus',
+    file: 'groups/migration_status.res.json',
+    required: [
+      mStatus('targetVersion'),
+      mStatus('expectedMembers'),
+      mStatus('rollup'),
+      mStatus('members'),
+    ],
+    optional: [mStatus('cohortPinnedAtHlc'), mStatus('fleetCompletedAt')],
+  },
+  {
+    type: 'MigrationStatusRollup',
+    file: 'groups/migration_status.res.json',
+    path: 'rollup',
+    required: [
+      mRollup('migrated'),
+      mRollup('inProgress'),
+      mRollup('unknown'),
+      mRollup('failed'),
+      mRollup('total'),
+      mRollup('allMigrated'),
+      mRollup('membersPendingSignature'),
+    ],
+    optional: [],
+  },
+  // The fixture's second member is the one carrying every optional at once: an
+  // account, a report, and a `migrationFailed` inside it.
+  {
+    type: 'MemberMigrationStatusEntry',
+    file: 'groups/migration_status.res.json',
+    path: 'members.1',
+    required: [mEntry('peer'), mEntry('state')],
+    optional: [mEntry('account'), mEntry('report')],
+  },
+  {
+    type: 'MemberMigrationReport',
+    file: 'groups/migration_status.res.json',
+    path: 'members.1.report',
+    required: [
+      mReport('schemaVersion'),
+      mReport('residueAuto'),
+      mReport('syncedUpToHlc'),
+      mReport('reportedAt'),
+      mReport('authoredRemaining'),
+    ],
+    optional: [mReport('migrationFailed')],
+    // Always 0 on the wire and slated for removal once the client-py floor moves.
+    ignoredCoreKeys: ['residueIdentity'],
+  },
 ];
+
+/** Resolves a Spec's dotted `path` against the parsed fixture. */
+function descend(
+  raw: unknown,
+  path?: string,
+): Record<string, unknown> | undefined {
+  if (!path) return raw as Record<string, unknown>;
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (value, k) => (value as Record<string, unknown> | undefined)?.[k],
+      raw,
+    ) as Record<string, unknown> | undefined;
+}
 
 describe('wire contract (core fixtures ↔ SDK types)', () => {
   if (!WIRE_DIR) {
@@ -143,8 +215,10 @@ describe('wire contract (core fixtures ↔ SDK types)', () => {
       const raw = JSON.parse(
         readFileSync(join(WIRE_DIR, spec.file), 'utf8'),
       ) as Record<string, unknown>;
-      const fixture = (spec.envelope ? raw[spec.envelope] : raw) as Record<string, unknown>;
-      expect(fixture, `fixture ${spec.file} has no '${spec.envelope}' envelope`).toBeTruthy();
+      const fixture = descend(raw, spec.path);
+      if (!fixture) {
+        throw new Error(`fixture ${spec.file} has nothing at '${spec.path}'`);
+      }
       const fixtureKeys = Object.keys(fixture);
       const known = new Set([
         ...spec.required,

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -1073,13 +1073,17 @@ describe('AdminApiClient', () => {
           migrated: 2,
           inProgress: 0,
           unknown: 1,
+          failed: 0,
           total: 3,
           allMigrated: false,
           membersPendingSignature: 1,
         },
+        // Two rows for one account: the cohort is replicas, not people. The
+        // third has no report at all, which is how core renders `unknown`.
         members: [
           {
             peer: 'aa',
+            account: 'ac'.repeat(32),
             report: {
               schemaVersion: 2,
               residueAuto: 0,
@@ -1091,6 +1095,7 @@ describe('AdminApiClient', () => {
           },
           {
             peer: 'bb',
+            account: 'ac'.repeat(32),
             report: {
               schemaVersion: 1,
               residueAuto: 0,
@@ -1100,14 +1105,15 @@ describe('AdminApiClient', () => {
             },
             state: 'in_progress',
           },
-          { peer: 'cc', report: null, state: 'unknown' },
+          { peer: 'cc', account: 'bd'.repeat(32), state: 'unknown' },
         ],
       };
       mock.setMockResponse('GET', '/admin-api/groups/ns1/migration-status', body);
       const res = await client.getMigrationStatus('ns1');
       expect(res.rollup.membersPendingSignature).toBe(1);
       expect(res.members[1].report?.authoredRemaining).toBe(2);
-      expect(res.members[2].report).toBeNull();
+      expect(res.members[0].account).toBe(res.members[1].account);
+      expect(res.members[2].report).toBeUndefined();
     });
 
     it('getCascadeStatus unwraps the data array', async () => {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -604,9 +604,15 @@ export interface MemberMigrationReport {
 }
 
 export interface MemberMigrationStatusEntry {
+  /** The reporting device's signing KEY, bs58. One account with two devices
+   * appears as two rows: the cohort is replicas, not people. */
   peer: string;
-  /** Freshest reported facts, or `null` when the member's state is `unknown`. */
-  report: MemberMigrationReport | null;
+  /** The ACCOUNT `peer` speaks for, 64 hex - join it to `listGroupMembers` to
+   * name a person. Absent from nodes predating the field. */
+  account?: string;
+  /** Freshest reported facts. Omitted (not `null`) when the member's state is
+   * `unknown`, so test falsiness rather than `=== null`. */
+  report?: MemberMigrationReport | null;
   state: MemberMigrationState;
 }
 


### PR DESCRIPTION
## Summary

The migration rollup keys its per-member rows by device signing key. Core added the **account** each device speaks for (calimero-network/core#3558), which is what joins a row to the account-keyed `listGroupMembers` and lets a UI name a person instead of printing a device key. Nothing in this SDK declared it, so it was unreachable.

- `MemberMigrationStatusEntry.account?: string` - the account, 64 hex; absent from nodes predating the field.
- `report` becomes optional. Core omits the key for an `unknown` member rather than sending null, so the required `report: T | null` made `=== null` look like a safe check and the unit mock asserted a shape no node emits.
- Contract specs for the four migration-status types, so both halves of the canary cover them: the compile-time key binding that `typecheck:contract` runs in CI, and the fixture comparison against a core checkout. `Spec.envelope` becomes `Spec.path`, a dotted path, so a spec can reach a nested row (`members.1.report`).

`residueIdentity` stays undeclared on purpose - always 0 and slated for removal - recorded as `ignoredCoreKeys` rather than left as invisible drift.

Type-level breaking for a consumer that reads `entry.report` without a falsiness check. No `!` marker, per the standing rule on auto-publishing majors here.

Paired core PR (adds the fixture these specs read): calimero-network/core#3562. Merge that first - a spec pointing at a fixture core has not committed yet cannot resolve.

## Test plan

- `pnpm test:unit` - 295 passed, 1 skipped. The migration-status mock now carries `account` (two rows sharing one account, since the cohort is replicas not people) and omits `report` for the unknown member, asserting `toBeUndefined()`.
- `pnpm lint`, `pnpm typecheck`, `pnpm typecheck:contract`, `pnpm typecheck:consumer`, `pnpm build` - clean.
- `CALIMERO_CORE_DIR=<core> pnpm test:contract` against the paired core branch - 11 passed.
- Both gates verified by breaking them: dropping `mEntry('account')` from the spec fails with `core wire key 'account' is not declared by SDK type MemberMigrationStatusEntry`; removing the field from the type fails `typecheck:contract` with `TS2345: Argument of type '"account"' is not assignable to parameter of type '"peer" | "report" | "state"'`. Both restored and green.