### PR TITLE
feat(account): canonicalise account ids, and give SSE failures their reason

### DIFF
--- a/src/account/index.test.ts
+++ b/src/account/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { sameAccount, toAccountBase58, toAccountHex } from './index.js';
+
+// Captured from a live merod 0.11.0-rc.24 node: the SAME two members, served
+// as hex by `GET /admin-api/groups/{id}/members` and as base58 by the
+// contract's `get_profiles`. If these ever stop matching, the two encodings
+// have diverged and every cross-source comparison in every app is wrong.
+const ALICE_HEX =
+  'e8b65145da3670b152e06eb3e2c00a5b41ca8907aac0a4ef24486bffa6283670';
+const ALICE_B58 = 'GfQq3fL5PC9Lw4fV3EAFQmoaoGyWMig2GvQgp3u3ZYeK';
+const BOB_HEX =
+  '7528078a29c19803bbe1e370410b58992c0d1e436bec701ed33a4b3305bc916c';
+const BOB_B58 = '8tL6y7jzsTyff1UdKFzW67mMP91GGQCGSAzugpX6poKy';
+
+describe('account id encoding', () => {
+  it('maps between the encodings core actually serves', () => {
+    expect(toAccountBase58(ALICE_HEX)).toBe(ALICE_B58);
+    expect(toAccountHex(ALICE_B58)).toBe(ALICE_HEX);
+    expect(toAccountBase58(BOB_HEX)).toBe(BOB_B58);
+    expect(toAccountHex(BOB_B58)).toBe(BOB_HEX);
+  });
+
+  it('is idempotent, so a value can be canonicalised more than once', () => {
+    expect(toAccountHex(toAccountHex(ALICE_B58))).toBe(ALICE_HEX);
+    expect(toAccountBase58(toAccountBase58(BOB_HEX))).toBe(BOB_B58);
+  });
+
+  it('accepts uppercase hex and normalises it', () => {
+    expect(toAccountHex(ALICE_HEX.toUpperCase())).toBe(ALICE_HEX);
+    expect(sameAccount(ALICE_HEX.toUpperCase(), ALICE_B58)).toBe(true);
+  });
+
+  it('recognises one account across both encodings', () => {
+    expect(sameAccount(ALICE_HEX, ALICE_B58)).toBe(true);
+    expect(sameAccount(ALICE_B58, ALICE_HEX)).toBe(true);
+    expect(sameAccount(ALICE_HEX, BOB_B58)).toBe(false);
+  });
+
+  it('round-trips a value with leading zero bytes', () => {
+    // Leading zeros are where naive base58 implementations lose data: each
+    // zero byte must survive as a leading '1'.
+    const hex = '00'.repeat(4) + 'ab'.repeat(28);
+    const b58 = toAccountBase58(hex);
+    expect(b58.startsWith('1111')).toBe(true);
+    expect(toAccountHex(b58)).toBe(hex);
+  });
+
+  it('leaves anything that is not a 32-byte account untouched', () => {
+    // A device key is base58 but not an account; an alias is neither. Both
+    // must survive intact rather than being mangled or blanked.
+    const deviceKey = '5uBHcg3vyX6eAFgkNbREtftG3U6KmD6qjoBf53BmYjeR';
+    expect(toAccountHex(deviceKey)).toBe(toAccountHex(deviceKey));
+    expect(toAccountHex('member-alias')).toBe('member-alias');
+    expect(toAccountBase58('member-alias')).toBe('member-alias');
+    expect(toAccountHex('not valid base58 !!')).toBe('not valid base58 !!');
+  });
+
+  it('treats empty and nullish input as empty, never as a match', () => {
+    expect(toAccountHex(null)).toBe('');
+    expect(toAccountHex(undefined)).toBe('');
+    expect(toAccountBase58('')).toBe('');
+    expect(sameAccount('', '')).toBe(false);
+    expect(sameAccount(null, ALICE_HEX)).toBe(false);
+  });
+});

--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -1,0 +1,148 @@
+/**
+ * Account id encoding.
+ *
+ * Core names the same account in two encodings, and the split is deliberate:
+ * the admin API serves and requires **64 hex characters**, while contract data
+ * (`sender`, `get_profiles`, anything stamped by `env::account_id()`) carries
+ * **base58**. They are rendered differently on purpose, so that handing one
+ * where the other is expected fails loudly instead of resolving to the wrong
+ * principal.
+ *
+ * The cost is that any client reading a member from the admin API and
+ * comparing it against a message sender is comparing two spellings of the same
+ * value. A raw `===` silently never matches, and passing a contract-sourced id
+ * to an admin route answers `400 Invalid account format: expected 64 hex
+ * characters (32 bytes)`. Both failure modes are quiet enough to ship.
+ *
+ * These helpers canonicalise at that boundary. They convert accounts and
+ * nothing else: a device key, an alias or any other value is returned
+ * unchanged, because converting is this module's job and destroying what it
+ * cannot convert is not.
+ */
+
+const BASE58_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/** A 32-byte account rendered as 64 hex characters. */
+const HEX_ACCOUNT = /^[0-9a-f]{64}$/i;
+
+/** Bytes → base58. Leading zero bytes become leading '1's, as in bitcoin base58. */
+function encodeBase58(bytes: Uint8Array): string {
+  if (bytes.length === 0) return '';
+
+  const digits: number[] = [0];
+  for (const byte of bytes) {
+    let carry = byte;
+    for (let i = 0; i < digits.length; i++) {
+      carry += digits[i]! << 8;
+      digits[i] = carry % 58;
+      carry = (carry / 58) | 0;
+    }
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = (carry / 58) | 0;
+    }
+  }
+
+  let out = '';
+  for (const byte of bytes) {
+    if (byte !== 0) break;
+    out += BASE58_ALPHABET[0];
+  }
+  for (let i = digits.length - 1; i >= 0; i--) {
+    out += BASE58_ALPHABET[digits[i]!];
+  }
+  return out;
+}
+
+/** base58 → bytes. Returns null when the input is not valid base58. */
+function decodeBase58(value: string): Uint8Array | null {
+  if (value.length === 0) return null;
+
+  const bytes: number[] = [0];
+  for (const char of value) {
+    const index = BASE58_ALPHABET.indexOf(char);
+    if (index < 0) return null;
+
+    let carry = index;
+    for (let i = 0; i < bytes.length; i++) {
+      carry += bytes[i]! * 58;
+      bytes[i] = carry & 0xff;
+      carry >>= 8;
+    }
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  let leadingZeros = 0;
+  for (const char of value) {
+    if (char !== BASE58_ALPHABET[0]) break;
+    leadingZeros++;
+  }
+
+  return Uint8Array.from([
+    ...new Array<number>(leadingZeros).fill(0),
+    ...bytes.reverse(),
+  ]);
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = '';
+  for (const byte of bytes) out += byte.toString(16).padStart(2, '0');
+  return out;
+}
+
+function fromHex(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Canonicalise an account id to hex — the form every admin route expects.
+ *
+ * Returns the input unchanged if it is not a 32-byte account, so a device key
+ * or an alias survives a call to this function intact.
+ */
+export function toAccountHex(id: string | null | undefined): string {
+  const trimmed = (id ?? '').trim();
+  if (!trimmed) return '';
+  if (HEX_ACCOUNT.test(trimmed)) return trimmed.toLowerCase();
+
+  const decoded = decodeBase58(trimmed);
+  if (!decoded || decoded.length !== 32) return trimmed;
+  return toHex(decoded);
+}
+
+/**
+ * Canonicalise an account id to base58 — the form the contract stamps on
+ * `sender` and keys `get_profiles` by.
+ *
+ * Returns the input unchanged if it is not a 32-byte account.
+ */
+export function toAccountBase58(id: string | null | undefined): string {
+  const trimmed = (id ?? '').trim();
+  if (!trimmed) return '';
+  if (!HEX_ACCOUNT.test(trimmed)) return trimmed;
+  return encodeBase58(fromHex(trimmed));
+}
+
+/**
+ * True when both ids name the same account, whichever encoding each is in.
+ *
+ * This is the comparison to reach for when checking a contract-sourced
+ * `sender` against an admin-sourced member id. Two ids that are not accounts
+ * compare false rather than accidentally matching as raw strings.
+ */
+export function sameAccount(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  const left = toAccountHex(a);
+  const right = toAccountHex(b);
+  return HEX_ACCOUNT.test(left) && left === right;
+}

--- a/src/events/sse.test.ts
+++ b/src/events/sse.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SseClient } from './sse.js';
+import { AuthRevokedError, HTTPError } from '../http-client/index.js';
 import type { GroupMigrationEventData } from './group.js';
 
 describe('SseClient', () => {
@@ -402,3 +403,81 @@ describe('SseClient', () => {
 
 // Need to import afterEach
 import { afterEach } from 'vitest';
+
+describe('SseClient connect failures carry the auth reason', () => {
+  // A bare `Error("SSE connection failed: 401")` forced callers to string-match
+  // the status. The only safe reading of a bare 401 is "fatal", so consumers
+  // logged the user out on a routine reconnect after the access token aged out
+  // — discarding a refresh token that was still valid.
+  const make = () =>
+    new SseClient({
+      baseUrl: 'http://localhost:4001',
+      getAuthToken: async () => 'test-token',
+      reconnectDelayMs: 100,
+    });
+
+  const respond = (status: number, statusText: string, authError?: string) => {
+    const headers = new Headers();
+    if (authError) headers.set('x-auth-error', authError);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status, statusText, headers })),
+    );
+  };
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('throws AuthRevokedError when the token family is gone', async () => {
+    respond(401, 'Unauthorized', 'token_reuse');
+    const client = make();
+    // `connect()` reports failures through the `error` event rather than
+    // rejecting, so the typed error has to survive that hop intact.
+    let err: unknown;
+    client.on('error', (e: unknown) => {
+      err = e;
+    });
+    await client.connect();
+    client.close();
+
+    expect(err).toBeInstanceOf(AuthRevokedError);
+    expect((err as AuthRevokedError).reason).toBe('token_reuse');
+  });
+
+  it('throws a plain HTTPError for an expired token, which is recoverable', async () => {
+    respond(401, 'Unauthorized', 'token_expired');
+    const client = make();
+    // `connect()` reports failures through the `error` event rather than
+    // rejecting, so the typed error has to survive that hop intact.
+    let err: unknown;
+    client.on('error', (e: unknown) => {
+      err = e;
+    });
+    await client.connect();
+    client.close();
+
+    // Recoverable: the caller should refresh and reconnect, NOT log out.
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err).not.toBeInstanceOf(AuthRevokedError);
+    expect((err as HTTPError).headers.get('x-auth-error')).toBe('token_expired');
+  });
+
+  it('throws HTTPError for a non-auth failure', async () => {
+    respond(503, 'Service Unavailable');
+    const client = make();
+    // `connect()` reports failures through the `error` event rather than
+    // rejecting, so the typed error has to survive that hop intact.
+    let err: unknown;
+    client.on('error', (e: unknown) => {
+      err = e;
+    });
+    await client.connect();
+    client.close();
+
+    expect(err).toBeInstanceOf(HTTPError);
+    expect(err).not.toBeInstanceOf(AuthRevokedError);
+    expect((err as HTTPError).status).toBe(503);
+  });
+});
+

--- a/src/events/sse.ts
+++ b/src/events/sse.ts
@@ -1,5 +1,13 @@
 import type { GroupMembershipEventData, GroupMigrationEventData } from './group.js';
 import { isGroupMigrationEvent } from './group.js';
+import { AuthRevokedError, HTTPError } from '../http-client/index.js';
+
+/**
+ * `x-auth-error` reasons that mean the whole token family is gone, mirroring
+ * the request path in `web-client.ts`. Anything else — `token_expired` above
+ * all — is recoverable by refreshing and reconnecting.
+ */
+const TERMINAL_AUTH_ERRORS = new Set(['token_reuse', 'token_revoked']);
 
 export type { GroupMembershipEventData, GroupMigrationEventData };
 
@@ -139,7 +147,8 @@ export class SseClient {
 
     try {
       const token = await this.getAuthToken();
-      const response = await fetch(`${this.baseUrl}/sse`, {
+      const url = `${this.baseUrl}/sse`;
+      const response = await fetch(url, {
         headers: {
           'Authorization': `Bearer ${token}`,
           'Accept': 'text/event-stream',
@@ -148,7 +157,37 @@ export class SseClient {
       });
 
       if (!response.ok) {
-        throw new Error(`SSE connection failed: ${response.status}`);
+        // Throw the same typed errors the request path throws. A bare
+        // `Error("SSE connection failed: 401")` forced callers to string-match
+        // the status and guess what it meant, and the honest guess — treat any
+        // 401 as fatal — logs the user out on a routine reconnect after the
+        // access token ages out, discarding a refresh token that was still
+        // good. The distinction is in the header; surface it.
+        const authError = response.headers.get('x-auth-error');
+        const bodyText = await response.text().catch(() => undefined);
+
+        if (
+          response.status === 401 &&
+          authError &&
+          TERMINAL_AUTH_ERRORS.has(authError)
+        ) {
+          throw new AuthRevokedError(
+            authError,
+            response.status,
+            response.statusText,
+            url,
+            response.headers,
+            bodyText,
+          );
+        }
+
+        throw new HTTPError(
+          response.status,
+          response.statusText,
+          url,
+          response.headers,
+          bodyText,
+        );
       }
 
       if (!response.body) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,13 @@ export * from './admin-api/index.js';
 export { parseAuthCallback, buildAuthLoginUrl } from './auth/index.js';
 export type { AuthCallbackResult, AuthLoginOptions } from './auth/index.js';
 
+// Account id encoding (hex on the admin API, base58 in contract data)
+export {
+  toAccountHex,
+  toAccountBase58,
+  sameAccount,
+} from './account/index.js';
+
 // Token store
 export { MemoryTokenStore, LocalStorageTokenStore } from './token-store/index.js';
 export type { TokenStore } from './token-store/index.js';


### PR DESCRIPTION
Two gaps that currently force every consumer to hand-roll around the SDK.

## 1. Account id encoding

Core names the same account two ways:

| source | encoding |
|---|---|
| admin API (`listGroupMembers`, `setMemberMetadata`, …) | **64 hex** |
| contract data (`sender`, `get_profiles`, `env::account_id()`) | **base58** |

The split is deliberate — the types in this package say so, *"rendered differently so a mix-up fails loudly instead of resolving to the wrong principal."* But it leaves every client comparing two spellings of one value, and **both failure modes are silent**:

- `memberId === msg.sender` never matches
- passing a contract id to an admin route → `400 Invalid account format: expected 64 hex characters (32 bytes)`

Adds `toAccountHex`, `toAccountBase58`, `sameAccount`.

They convert **accounts and nothing else** — a device key, an alias, a test placeholder comes back untouched. Converting is the helper's job; destroying what it cannot convert is not.

**Base58 is implemented inline, not pulled in.** This package has zero runtime dependencies and should keep it that way.

Three apps hand-roll this today: mero-chat-pwa, mero-pixart (`app/src/api/rpc.ts`), mero-design (`app/src/api/rpc.ts`).

## 2. SSE failures lost their reason

`SseClient` threw a bare `Error("SSE connection failed: " + status)`, so `x-auth-error` never reached the caller.

The only safe reading of an untyped 401 is "fatal" — which is exactly what consumers did. mero-react called `logout()` on any 401 from the stream, so a **routine reconnect** after the access token aged out (sleep/wake, network blip, PWA resume) wiped the token store and threw away a refresh token that was still valid. The stream authenticates only at connect, so this fires on reconnect, not at expiry — which is why it reads as random.

It now throws the same types the request path already throws:

- `AuthRevokedError` when `x-auth-error` says the family is gone (`token_reuse`, `token_revoked`)
- `HTTPError` otherwise — carrying status and headers, so `token_expired` is visibly recoverable

No new error types; `web-client.ts` already had both, and the terminal-reason set mirrors it.

Note `connect()` reports through the `error` event rather than rejecting, so the typed error has to survive that hop — the tests assert exactly that.

## Verification

`tsc` clean · build clean · **305 passing** (+10)

Account tests use a real pair captured from a live merod `0.11.0-rc.24` node:

```
e8b65145…3670  ==  GfQq3fL5…ZYeK
7528078a…916c  ==  8tL6y7jz…poKy
```

so the encodings can't silently diverge. Leading-zero round-trips are covered too — that's where naive base58 loses bytes.

## Context

First of three PRs; merge order is **mero-js → mero-react → mero-chat-pwa**. mero-react's SSE handler gets sharper once this ships (it can stop guessing), and mero-chat-pwa drops its local copy of the account helpers.
