### PR TITLE
ci: open dependency bump PRs across the fleet on release

### DIFF
--- a/.github/fleet.json
+++ b/.github/fleet.json
@@ -1,0 +1,43 @@
+{
+  "_note": [
+    "Which repositories get an automatic dependency-bump pull request when this",
+    "repository publishes a release, and which surface each one has.",
+    "",
+    "  cargo — has logic/Cargo.toml pinning calimero-network/core by git tag",
+    "  npm   — declares @calimero-network/* packages in some package.json",
+    "",
+    "A repository's DEFAULT BRANCH is deliberately not recorded here. The fleet is",
+    "split roughly evenly between master and main, and a hand-maintained table of",
+    "which is which is exactly the kind of thing that goes stale and then fails",
+    "silently. The workflow checks out whatever the repository says its default",
+    "branch is and opens the pull request against that.",
+    "",
+    "Nor is the location of a repository's manifests recorded. bump-fleet.sh finds",
+    "every package.json that actually declares the dependency and walks up to the",
+    "nearest lockfile, so app/, apps/desktop/, packages/frontend/ and anything",
+    "added later all work without being listed."
+  ],
+
+  "consumers": [
+    { "repo": "mero-design", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-pixart", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-calendar", "surfaces": ["cargo", "npm"] },
+    { "repo": "merraria", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-blocks", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-issue-tracker", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-ar", "surfaces": ["cargo"] },
+    { "repo": "mero-tag", "surfaces": ["cargo"] },
+    { "repo": "scaffolding-e2e-application", "surfaces": ["cargo"] },
+    { "repo": "mero-stream", "surfaces": ["npm"] },
+    { "repo": "mero-meet", "surfaces": ["npm"] },
+    { "repo": "tauri-app", "surfaces": ["npm"] },
+    { "repo": "app-registry", "surfaces": ["npm"] }
+  ],
+
+  "_excluded": {
+    "battleships": "Pre-migration. Its contract does not compile against a current core (calimero_wasm_abi::emitter is gone) and its frontend is on mero-ui 0.3.x. Migrate it deliberately before adding it here.",
+    "auth-frontend": "Pre-migration, mero-ui 0.3.x.",
+    "mero-chat": "Abandoned 2026-08-19.",
+    "admin-dashboard": "Declares none of these packages."
+  }
+}

--- a/.github/scripts/bump-fleet.sh
+++ b/.github/scripts/bump-fleet.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+#
+# Rewrite a consumer repository's pinned Calimero dependency versions, in place.
+#
+# This script edits files and does NOTHING else: no git, no pull request, no
+# knowledge of GitHub. That separation is the point. The workflow that calls it
+# is only reachable by cutting a release, but this is runnable by hand against
+# any local checkout — which is the only honest way to see what a bump would do
+# before it lands as ten pull requests.
+#
+#   bump-fleet.sh --surface cargo --version 0.11.0-rc.26 --dir ../mero-design --no-lock --dry-run
+#   bump-fleet.sh --surface npm --pkg @calimero-network/mero-ui=1.5.1 --dir ../mero-meet --no-lock --dry-run
+#
+# Exit status is the contract with the caller:
+#
+#   0  files changed — open a pull request
+#   3  not applicable — this repository has nothing this surface touches
+#   4  already at the requested version — nothing to do
+#   1  something is wrong — do NOT open a pull request
+#
+# 3 and 4 are deliberately distinct from 0 and from each other. A fleet where
+# "nothing happened" and "this repo does not participate" look identical is a
+# fleet where a repo can silently fall out of the rollout and nobody notices.
+#
+# Portability: this runs on the macOS bash 3.2 a developer has and on the
+# ubuntu-latest bash a runner has. No mapfile, no associative arrays, no GNU-only
+# sed. Rewrites go through perl, which behaves the same in both places.
+
+set -euo pipefail
+
+SURFACE=""
+VERSION=""
+DIR=""
+DRY_RUN=0
+NO_LOCK=0
+ALLOW_MAJOR=0
+PKGS=""
+
+die() { printf '::error::%s\n' "$*" >&2; exit 1; }
+note() { printf '  %s\n' "$*" >&2; }
+head_note() { printf '%s\n' "$*" >&2; }
+
+usage() {
+  sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --surface) SURFACE="${2:-}"; shift 2 ;;
+    --version) VERSION="${2:-}"; shift 2 ;;
+    --dir) DIR="${2:-}"; shift 2 ;;
+    --pkg) PKGS="$PKGS ${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --no-lock) NO_LOCK=1; shift ;;
+    --allow-major) ALLOW_MAJOR=1; shift ;;
+    -h|--help) usage ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$SURFACE" ] || die "--surface is required (cargo|npm)"
+[ -n "$DIR" ] || die "--dir is required"
+[ -d "$DIR" ] || die "--dir '$DIR' is not a directory"
+
+# Canonical, so the lockfile-root walk below can compare paths and know when it
+# has reached the top of the repository.
+DIR=$(cd "$DIR" && pwd -P)
+
+# --dry-run finishes by throwing the edits away with `git checkout`, which would
+# take any unrelated work in the tree with them. Refuse rather than gamble with
+# someone's uncommitted afternoon. Untracked files are ignored — nothing here
+# removes those.
+if [ "$DRY_RUN" -eq 1 ]; then
+  if ! ( cd "$DIR" && git rev-parse --git-dir >/dev/null 2>&1 ); then
+    die "--dry-run needs '$DIR' to be a git checkout (it reverts by checking out)"
+  fi
+  if ! ( cd "$DIR" && git diff --quiet ); then
+    die "--dry-run refuses to run: '$DIR' has uncommitted changes to tracked files.
+Commit or stash them first — the revert at the end cannot tell them from ours."
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# cargo
+# ---------------------------------------------------------------------------
+#
+# Three separate edits live in logic/Cargo.toml, and a naive rewrite of the
+# first match gets one of the three:
+#
+#   [dependencies]      calimero-sdk / calimero-storage / calimero-storage-macros
+#                       / calimero-wasm-abi, each { git = ".../core", tag = "..." }
+#   [dev-dependencies]  a SECOND calimero-storage line, features = ["testing"]
+#   [package.metadata.calimero]
+#                       min-runtime-version — the floor a node checks before it
+#                       will accept the bundle at all. Not decoration.
+#
+# The git URL is spelled ".../core" in most repos and ".../core.git" in merraria
+# and mero-blocks, so the matcher tolerates both.
+
+bump_cargo() {
+  local manifest="$DIR/logic/Cargo.toml"
+
+  if [ ! -f "$manifest" ]; then
+    note "no logic/Cargo.toml — this repository has no contract to bump"
+    exit 3
+  fi
+
+  local current
+  current=$(perl -ne '
+    if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+        && m{tag\s*=\s*"([^"]*)"}) { print "$1\n"; exit }
+  ' "$manifest")
+
+  if [ -z "$current" ]; then
+    note "logic/Cargo.toml pins no calimero-network/core git dependency"
+    exit 3
+  fi
+
+  head_note "cargo: $current -> $VERSION"
+
+  if [ "$current" = "$VERSION" ]; then
+    note "already pinned to $VERSION"
+    exit 4
+  fi
+
+  NEW="$VERSION" perl -i -pe '
+    if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+        && m{tag\s*=\s*"}) {
+      s{(tag\s*=\s*")[^"]*(")}{$1$ENV{NEW}$2};
+    }
+    s{^(\s*min-runtime-version\s*=\s*")[^"]*(")}{$1$ENV{NEW}$2};
+  ' "$manifest"
+
+  # Verify by re-reading, not by trusting the rewrite. Checking for a literal
+  # occurrence of the old string would be wrong: comments legitimately mention
+  # older versions, and a stale sentence is not a reason to abort a release.
+  # What matters is that no core dependency still carries a different tag.
+  local stale
+  stale=$(NEW="$VERSION" perl -ne '
+    if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+        && m{tag\s*=\s*"([^"]*)"} && $1 ne $ENV{NEW}) { print "    line $.: $_" }
+  ' "$manifest")
+  [ -z "$stale" ] || die "logic/Cargo.toml still pins another core tag after the rewrite:
+$stale"
+
+  local rewritten
+  rewritten=$(NEW="$VERSION" perl -ne '
+    if (m{git\s*=\s*"https://github\.com/calimero-network/core(?:\.git)?"}
+        && m{tag\s*=\s*"\Q$ENV{NEW}\E"}) { $n++ }
+    END { print $n + 0 }
+  ' "$manifest")
+  [ "$rewritten" -gt 0 ] || die "rewrote no dependency lines — the manifest is not shaped as expected"
+  note "$rewritten dependency line(s) now pin $VERSION"
+
+  # min-runtime-version has to move WITH the tag. It trailed by one release
+  # across six repos after the rc.24 bump because it was edited by hand and the
+  # hand forgot. If the key exists it must now agree; if it does not exist,
+  # say so rather than silently shipping a bundle with no floor.
+  if grep -q 'min-runtime-version' "$manifest"; then
+    local floor
+    floor=$(perl -ne 'if (m{^\s*min-runtime-version\s*=\s*"([^"]*)"}) { print "$1\n"; exit }' "$manifest")
+    [ "$floor" = "$VERSION" ] || die "min-runtime-version is '$floor', expected '$VERSION'"
+    note "min-runtime-version now $VERSION"
+  else
+    note "WARNING: no min-runtime-version key — this bundle declares no runtime floor"
+  fi
+
+  if [ "$NO_LOCK" -eq 1 ]; then
+    note "skipping Cargo.lock refresh (--no-lock)"
+    return 0
+  fi
+
+  command -v cargo >/dev/null 2>&1 || die "cargo is not installed; re-run with --no-lock to edit the manifest only"
+
+  # deploy-bundle.yml reads the resolved core revision out of Cargo.lock and
+  # records it on the published release. A stale lockfile makes that provenance
+  # line name the wrong commit, so the lock is part of the bump, not an
+  # afterthought.
+  note "refreshing logic/Cargo.lock"
+  ( cd "$DIR/logic" && cargo generate-lockfile --quiet )
+}
+
+# ---------------------------------------------------------------------------
+# npm
+# ---------------------------------------------------------------------------
+#
+# Layouts differ and there is no table of them here on purpose. A table of "this
+# repo keeps its frontend at app/, that one at apps/desktop/" is a thing that
+# drifts silently. Instead: find every package.json that actually declares the
+# dependency, and for each, walk up to the nearest lockfile to find the install
+# root. That covers the standalone app/ repos, the pnpm workspaces (tauri-app,
+# app-registry, mero-issue-tracker), and anything added later, without being
+# told about any of them.
+
+find_lock_root() {
+  local d="$1"
+  while :; do
+    if [ -f "$d/pnpm-lock.yaml" ]; then printf '%s\n' "$d"; return 0; fi
+    if [ "$d" = "$DIR" ] || [ "$d" = "/" ]; then return 1; fi
+    d=$(dirname "$d")
+  done
+}
+
+bump_npm() {
+  [ -n "$PKGS" ] || die "--surface npm needs at least one --pkg name=version"
+
+  local manifests
+  manifests=$(find "$DIR" -name package.json \
+    -not -path '*/node_modules/*' -not -path '*/.git/*' | sort)
+  [ -n "$manifests" ] || { note "no package.json anywhere — nothing to bump"; exit 3; }
+
+  local changed_manifests=""
+  local touched=0
+  local applicable=0
+  local skipped_major=""
+
+  for spec in $PKGS; do
+    local name="${spec%%=*}"
+    local ver="${spec#*=}"
+    [ -n "$name" ] && [ -n "$ver" ] && [ "$name" != "$ver" ] \
+      || die "--pkg expects name=version, got '$spec'"
+
+    local new_major="${ver%%.*}"
+
+    printf '%s\n' "$manifests" | while IFS= read -r m; do
+      [ -n "$m" ] || continue
+      local current
+      current=$(NAME="$name" perl -ne '
+        if (m{"\Q$ENV{NAME}\E"\s*:\s*"([^"]*)"}) { print "$1\n"; exit }
+      ' "$m")
+      [ -n "$current" ] || continue
+      printf '%s\t%s\t%s\n' "$m" "$current" "$ver"
+    done > "$TMPDIR_RUN/hits.$$"
+
+    while IFS="$(printf '\t')" read -r m current _; do
+      [ -n "${m:-}" ] || continue
+      applicable=1
+
+      local rel="${m#$DIR/}"
+
+      if [ "$current" = "$ver" ]; then
+        note "$rel: $name already $ver"
+        continue
+      fi
+
+      # Keep whatever range operator the repo chose. Rewriting "^1.4.0" as
+      # "1.5.1" quietly converts a tracking range into a hard pin, and the
+      # repo never sees another patch release again.
+      local prefix
+      prefix=$(printf '%s' "$current" | sed 's/[0-9].*$//')
+      local current_digits
+      current_digits=$(printf '%s' "$current" | sed 's/^[^0-9]*//')
+      local current_major="${current_digits%%.*}"
+
+      case "$current_major" in
+        ''|*[!0-9]*)
+          note "$rel: $name is '$current', which this script will not try to interpret — skipped"
+          continue ;;
+      esac
+
+      # A major jump is a migration, not a bump. mero-js is at 13 while most of
+      # the fleet is on 7; opening that as an automatic pull request produces a
+      # PR that cannot pass CI, every release, forever. Report it and move on.
+      # --allow-major is for when someone is deliberately doing the migration.
+      if [ "$current_major" != "$new_major" ] && [ "$ALLOW_MAJOR" -eq 0 ]; then
+        note "$rel: $name $current -> $ver crosses a major — skipped (use --allow-major)"
+        skipped_major="$skipped_major $name:$current->$ver"
+        continue
+      fi
+
+      NAME="$name" VAL="$prefix$ver" perl -i -pe '
+        s{("\Q$ENV{NAME}\E"\s*:\s*")[^"]*(")}{$1$ENV{VAL}$2}g;
+      ' "$m"
+      note "$rel: $name $current -> $prefix$ver"
+      touched=$((touched + 1))
+      case " $changed_manifests " in
+        *" $m "*) ;;
+        *) changed_manifests="$changed_manifests $m" ;;
+      esac
+    done < "$TMPDIR_RUN/hits.$$"
+    rm -f "$TMPDIR_RUN/hits.$$"
+  done
+
+  if [ "$applicable" -eq 0 ]; then
+    note "no package.json declares any of the requested packages"
+    exit 3
+  fi
+
+  if [ "$touched" -eq 0 ]; then
+    if [ -n "$skipped_major" ]; then
+      note "every candidate was a major jump:$skipped_major"
+      exit 4
+    fi
+    note "everything is already at the requested version"
+    exit 4
+  fi
+
+  if [ "$NO_LOCK" -eq 1 ]; then
+    note "skipping lockfile refresh (--no-lock)"
+    return 0
+  fi
+
+  command -v pnpm >/dev/null 2>&1 || die "pnpm is not installed; re-run with --no-lock to edit manifests only"
+
+  local roots=""
+  for m in $changed_manifests; do
+    local root
+    if root=$(find_lock_root "$(dirname "$m")"); then
+      case " $roots " in
+        *" $root "*) ;;
+        *) roots="$roots $root" ;;
+      esac
+    else
+      note "WARNING: no pnpm-lock.yaml above ${m#$DIR/} — its lockfile will not be refreshed"
+    fi
+  done
+
+  for root in $roots; do
+    note "refreshing ${root#$DIR/}/pnpm-lock.yaml"
+    # --lockfile-only resolves and writes the lock without materialising
+    # node_modules. --ignore-scripts because nothing here should run a
+    # dependency's install hook on a release runner.
+    ( cd "$root" && pnpm install --lockfile-only --ignore-scripts >/dev/null )
+  done
+}
+
+TMPDIR_RUN=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_RUN"' EXIT
+
+case "$SURFACE" in
+  cargo)
+    [ -n "$VERSION" ] || die "--surface cargo needs --version"
+    bump_cargo
+    ;;
+  npm)
+    bump_npm
+    ;;
+  *) die "--surface must be cargo or npm (got '$SURFACE')" ;;
+esac
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  head_note ""
+  head_note "--dry-run: showing the diff and reverting it"
+  ( cd "$DIR" && git --no-pager diff --stat && echo && git --no-pager diff )
+  ( cd "$DIR" && git checkout -- . )
+fi
+
+exit 0

--- a/.github/workflows/fleet-bump.yml
+++ b/.github/workflows/fleet-bump.yml
@@ -1,0 +1,282 @@
+name: Fleet bump
+
+# Opens (or refreshes) one pull request per consumer repository, moving its
+# @calimero-network/* dependencies to the versions this repository just
+# published.
+#
+# All of the editing lives in .github/scripts/bump-fleet.sh, which knows nothing
+# about GitHub and is runnable by hand against a local checkout:
+#
+#   .github/scripts/bump-fleet.sh --surface npm \
+#       --pkg @calimero-network/mero-ui=1.5.1 --dir ../mero-meet --no-lock --dry-run
+#
+# This file is only the plumbing around it: mint a token, check the consumer
+# out, run the script, push a branch, open the pull request.
+#
+# Three things here are load-bearing and easy to undo by accident:
+#
+#   * The pull request is created with a GitHub App installation token, NOT with
+#     GITHUB_TOKEN. A pull request opened by GITHUB_TOKEN does not trigger the
+#     target repository's workflows, so every bump would arrive with no CI at
+#     all and read as green because nothing ran.
+#
+#   * `gh pr create` is called without --base. The fleet is split between
+#     `master` and `main`, and letting each repository name its own default
+#     branch removes a whole category of silent failure.
+#
+#   * Major jumps are skipped unless allow_major is set. Most of the fleet is on
+#     mero-js 7 and mero-react 4 while those packages are at 13 and 6; opening
+#     that automatically would produce a pull request that cannot pass CI, on
+#     every release, forever. Crossing a major is a migration someone does on
+#     purpose.
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: "Space-separated name=version pairs, e.g. '@calimero-network/mero-ui=1.5.1'"
+        required: true
+        type: string
+      label:
+        description: "Branch slug — the PR lands on chore/<label>"
+        required: true
+        type: string
+      only:
+        description: "Comma-separated subset of fleet.json repos (blank = all)"
+        required: false
+        default: ""
+        type: string
+      allow_major:
+        description: "Also bump dependencies across a major version"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Rewrite and print the diff, but push nothing"
+        required: false
+        default: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      packages:
+        description: "Space-separated name=version pairs, e.g. '@calimero-network/mero-ui=1.5.1'"
+        required: true
+        type: string
+      label:
+        description: "Branch slug — the PR lands on chore/<label>"
+        required: true
+        type: string
+      only:
+        description: "Comma-separated subset of fleet.json repos (blank = all)"
+        required: false
+        default: ""
+        type: string
+      allow_major:
+        description: "Also bump dependencies across a major version"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Rewrite and print the diff, but push nothing"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+# Never cancel: a cancelled run can leave a branch pushed with no pull request
+# opened against it. Queue instead.
+concurrency:
+  group: fleet-bump-${{ inputs.label }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Decide which repositories to touch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      repos: ${{ steps.pick.outputs.repos }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select the npm consumers
+        id: pick
+        env:
+          ONLY: ${{ inputs.only }}
+        run: |
+          set -euo pipefail
+          repos=$(jq -c --arg only "${ONLY:-}" '
+            [ .consumers[] | select(.surfaces | index("npm")) | .repo ]
+            | if $only == "" then .
+              else
+                ( $only | split(",") | map(sub("^ +";"") | sub(" +$";"")) ) as $want
+                | map(select(. as $r | $want | index($r)))
+              end
+          ' .github/fleet.json)
+          echo "repos=$repos" >> "$GITHUB_OUTPUT"
+          echo "Selected: $repos"
+          if [ "$repos" = "[]" ]; then
+            echo "::warning::No repositories selected — check the 'only' filter against .github/fleet.json"
+          fi
+
+  bump:
+    name: ${{ matrix.repo }}
+    needs: plan
+    if: needs.plan.outputs.repos != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # One repository failing must not stop the others from getting their
+      # pull request.
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJSON(needs.plan.outputs.repos) }}
+    steps:
+      - name: Check out this repository (for the bump script)
+        uses: actions/checkout@v4
+        with:
+          path: producer
+
+      # Scoped to the single repository this matrix leg touches, rather than to
+      # the whole fleet at once.
+      - name: Mint a token for ${{ matrix.repo }}
+        id: token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ matrix.repo }}
+
+      - name: Check out ${{ matrix.repo }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository_owner }}/${{ matrix.repo }}
+          token: ${{ steps.token.outputs.token }}
+          path: consumer
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      # Corepack, not a pinned pnpm: consumers pin their own pnpm through
+      # `packageManager` (8.15.0 through 11.20.0 across this fleet), and a
+      # lockfile written by the wrong major is a diff nobody wants to review.
+      - name: Enable corepack
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: corepack enable
+
+      - name: Rewrite the dependency ranges
+        id: bump
+        env:
+          PACKAGES: ${{ inputs.packages }}
+          ALLOW_MAJOR: ${{ inputs.allow_major }}
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: "0"
+        run: |
+          set -euo pipefail
+          args=""
+          for spec in $PACKAGES; do
+            args="$args --pkg $spec"
+          done
+          if [ "$ALLOW_MAJOR" = "true" ]; then
+            args="$args --allow-major"
+          fi
+
+          set +e
+          # shellcheck disable=SC2086
+          producer/.github/scripts/bump-fleet.sh --surface npm $args --dir consumer
+          code=$?
+          set -e
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          case "$code" in
+            0) echo "::notice::${{ matrix.repo }}: ranges rewritten" ;;
+            3) echo "::notice::${{ matrix.repo }}: declares none of these packages — skipped" ;;
+            4) echo "::notice::${{ matrix.repo }}: already current, or every candidate crossed a major" ;;
+            *) echo "::error::${{ matrix.repo }}: bump script failed"; exit "$code" ;;
+          esac
+
+      - name: Show the diff
+        if: steps.bump.outputs.code == '0'
+        working-directory: consumer
+        run: git --no-pager diff --stat
+
+      - name: Identify the app
+        if: steps.bump.outputs.code == '0' && inputs.dry_run != true
+        id: app
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          SLUG: ${{ steps.token.outputs.app-slug }}
+        run: echo "uid=$(gh api "/users/${SLUG}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Open or refresh the pull request
+        if: steps.bump.outputs.code == '0' && inputs.dry_run != true
+        working-directory: consumer
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PACKAGES: ${{ inputs.packages }}
+          LABEL: ${{ inputs.label }}
+          REPO: ${{ github.repository_owner }}/${{ matrix.repo }}
+          SOURCE: ${{ github.repository }}
+          SLUG: ${{ steps.token.outputs.app-slug }}
+          APP_UID: ${{ steps.app.outputs.uid }}
+        run: |
+          set -euo pipefail
+
+          branch="chore/$LABEL"
+          title="chore(deps): bump $(echo "$PACKAGES" | sed 's|@calimero-network/||g; s/=/@/g; s/  */, /g')"
+
+          git config user.name "${SLUG}[bot]"
+          git config user.email "${APP_UID}+${SLUG}[bot]@users.noreply.github.com"
+
+          git checkout -b "$branch"
+          git add -A
+          git commit \
+            -m "$title" \
+            -m "Generated by the fleet-bump workflow in $SOURCE."
+
+          # The branch name is deterministic and the branch is machine-owned, so
+          # a re-run replaces it rather than opening a second pull request.
+          # Do not hand-edit it: push a fix to a branch of your own instead.
+          git push --force origin "$branch"
+
+          if gh pr view "$branch" --repo "$REPO" >/dev/null 2>&1; then
+            echo "::notice::refreshed the existing pull request for $branch"
+            gh pr view "$branch" --repo "$REPO" --json url --jq .url >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Written to a file rather than a shell string: the block scalar this
+          # runs inside would eat a heredoc's terminator indentation.
+          cat > "$RUNNER_TEMP/pr-body.md" <<PR_BODY
+          Moves this repository onto the versions just published by
+          [$SOURCE](https://github.com/$SOURCE):
+
+          \`\`\`
+          $PACKAGES
+          \`\`\`
+
+          Rewritten automatically by \`fleet-bump\`. Every \`package.json\` that
+          actually declares one of these packages was updated — including ones in
+          workspace members — and the lockfile above each was refreshed with the
+          pnpm version that repository pins.
+
+          The existing range operator is preserved, so a \`^\` dependency stays a
+          \`^\` dependency. A bump that quietly converted a tracking range into a
+          hard pin would stop the repository ever seeing another patch release.
+
+          Dependencies that would have crossed a major version were **skipped**;
+          the job log lists them. Those are migrations, not bumps.
+          PR_BODY
+
+          gh pr create \
+            --repo "$REPO" \
+            --head "$branch" \
+            --title "$title" \
+            --body-file "$RUNNER_TEMP/pr-body.md"
+
+          gh pr view "$branch" --repo "$REPO" --json url --jq .url >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     name: Create Release and Publish
     runs-on: ubuntu-latest
+    outputs:
+      new_release: ${{ steps.semantic.outputs.new_release }}
+      version: ${{ steps.published.outputs.version }}
     permissions:
       contents: write
       id-token: write
@@ -62,6 +65,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_ENV: production
 
+      # Read from the tree rather than parsed out of semantic-release's log:
+      # this is the exact package.json the publish step below uploads, so it
+      # is by construction the version that reaches the registry.
+      - name: Read the published version
+        id: published
+        if: steps.semantic.outputs.new_release == 'true'
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "::notice::publishing $version"
+
       - name: Publish to npm with OIDC
         if: steps.semantic.outputs.new_release == 'true'
         run: npm publish --provenance --access public
@@ -71,3 +86,18 @@ jobs:
         run: |
           git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
           git push origin HEAD:master --follow-tags || true
+
+  # Opens the pull request that moves every consumer in .github/fleet.json onto
+  # the version just published. Majors are skipped by default -- see the header
+  # of fleet-bump.yml for why.
+  fleet-bump:
+    name: Open dependency bump PRs
+    needs: release
+    if: needs.release.outputs.new_release == 'true'
+    uses: ./.github/workflows/fleet-bump.yml
+    with:
+      packages: "@calimero-network/mero-js=${{ needs.release.outputs.version }}"
+      label: mero-js-${{ needs.release.outputs.version }}
+    # GH_APP_PRIVATE_KEY, which the called workflow uses to mint a
+    # per-repository installation token.
+    secrets: inherit


### PR DESCRIPTION
When this package publishes, every app in the fleet needs the same one-line
change to a `package.json` and its lockfile, and today somebody makes it by
hand in ten repositories. This opens those pull requests from the release
itself.

## Majors are skipped on purpose

Most of the fleet is on `mero-js` 7 and `mero-react` 4 while those packages are
at 13 and 6. Bumping across that automatically would produce a pull request
that cannot pass CI, on every release, forever. So a dependency that would
cross a major version is reported and skipped, and the run still opens a PR for
whatever else moved. `allow_major` is there for when someone is deliberately
doing the migration.

## How it is put together

Three files, plus a hook in `release.yml`:

| file | what it is |
|---|---|
| `.github/scripts/bump-fleet.sh` | all the editing. Knows nothing about GitHub. |
| `.github/fleet.json` | who gets a PR, and which surface each repo has |
| `.github/workflows/fleet-bump.yml` | plumbing: token, checkout, run script, push, open PR |

The split is the point. The script is runnable by hand against a local
checkout, so what a release is about to do to the fleet can be inspected
before it becomes ten pull requests:

```
.github/scripts/bump-fleet.sh --surface npm \
    --pkg @calimero-network/mero-ui=1.5.1 --dir ../mero-meet --no-lock --dry-run
```

`--dry-run` prints the diff and reverts it, and refuses to run at all if the
target has uncommitted changes to tracked files.

Exit status is the contract with the workflow: `0` changed, `3` not
applicable, `4` already current, `1` broken. "Nothing happened" and "this repo
does not participate" are deliberately different codes — a fleet where those
look the same is a fleet where a repo drops out of the rollout unnoticed.

## Details that are load-bearing

- **The PR is opened with a GitHub App token, not `GITHUB_TOKEN`.** A pull
  request created by `GITHUB_TOKEN` does not trigger the target repository's
  workflows. Every bump would arrive with no CI at all and read as green
  because nothing ran.
- **`gh pr create` is called without `--base`.** The fleet is split between
  `master` and `main`. Letting each repository name its own default branch
  deletes a category of silent failure rather than encoding it in a table that
  goes stale.
- **No manifest paths are hardcoded.** The script finds every `package.json`
  that actually declares the dependency and walks up to the nearest lockfile,
  so `app/`, `apps/desktop/`, `packages/frontend/` and anything added later all
  work without being listed.
- **Range operators are preserved.** `^1.4.0` becomes `^1.5.1`, not `1.5.1`.
  Silently converting a tracking range to a hard pin would stop the repo ever
  seeing another patch.
- **Corepack, not a pinned pnpm.** Consumers pin 8.15.0 through 11.20.0 via
  `packageManager`; a lockfile written by the wrong pnpm major is a diff nobody
  wants to review.

## This is inert until it is switched on

`vars.GH_APP_ID` and `secrets.GH_APP_PRIVATE_KEY` must exist in this repository
and the App must be installed on the consumer repositories with **contents:
write** and **pull requests: write**. Until then `fleet-bump` fails at the token
step and nothing else is affected — no release job depends on its result.

Run it by hand from the Actions tab first: it defaults to `dry_run: true` on
`workflow_dispatch`, and `only` takes a comma-separated subset so it can be
pointed at one repository.

## Verified locally

The script was run against real checkouts of every layout in the fleet before
this was opened — the standalone `app/` repos, the pnpm workspaces
(`tauri-app`, `app-registry`, `mero-issue-tracker`), a cargo-only repo, and a
repo that declares none of the packages. Exit codes, range preservation, the
major-version guard, and the lockfile refresh all behaved as described.
