### PR TITLE
fix(admin): read the namespace-join id under either spelling

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -706,11 +706,37 @@ describe('AdminApiClient', () => {
     it('joinNamespace sends structured invitation', async () => {
       const invitation = SIGNED_INVITATION;
       mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
-        data: { groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
+        data: { namespaceId: 'ns-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
       });
       const result = await client.joinNamespace('ns-1', { invitation, groupName: 'My NS' });
-      expect(result).toEqual({ groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) });
+      expect(result).toEqual({ namespaceId: 'ns-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) });
       expect(mock.getRequestBody('POST', '/admin-api/namespaces/ns-1/join')).toEqual({ invitation, groupName: 'My NS' });
+    });
+
+    // A node older than core 0.11.0-rc.25 spells this field `groupId`
+    // (core#3598 renamed it). The rename is invisible on the wire — the old
+    // field simply stops arriving — so without this normalisation
+    // `namespaceId` reads `undefined` and the failure surfaces wherever the
+    // caller uses it, not here.
+    it('joinNamespace binds namespaceId from a pre-rc.25 node that sent groupId', async () => {
+      mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
+        data: { groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
+      });
+      const result = await client.joinNamespace('ns-1', { invitation: SIGNED_INVITATION });
+      expect(result.namespaceId).toBe('g-1');
+      // The original field is left intact rather than deleted: a caller still
+      // reading it against an old node keeps working.
+      expect(result.groupId).toBe('g-1');
+    });
+
+    // The new spelling must win outright. A node that sent both — or a
+    // normalisation that ran unconditionally — must not overwrite it.
+    it('joinNamespace prefers namespaceId when the node sends both', async () => {
+      mock.setMockResponse('POST', '/admin-api/namespaces/ns-1/join', {
+        data: { namespaceId: 'ns-1', groupId: 'g-1', memberIdentity: 'pk-1', memberAccount: 'c'.repeat(64) },
+      });
+      const result = await client.joinNamespace('ns-1', { invitation: SIGNED_INVITATION });
+      expect(result.namespaceId).toBe('ns-1');
     });
 
     it('createGroupInNamespace sends request', async () => {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -705,13 +705,24 @@ export class AdminApiClient {
     namespaceId: string,
     request: JoinNamespaceRequest,
   ): Promise<JoinNamespaceResponseData> {
-    return unwrap(
+    const data = unwrap(
       await this.httpClient.post<{ data: JoinNamespaceResponseData }>(
         `/admin-api/namespaces/${namespaceId}/join`,
         request,
         { timeoutMs: 65000 },
       ),
     );
+
+    // core 0.11.0-rc.25 renamed this response's `groupId` to `namespaceId`
+    // (core#3598). Bind whichever spelling the node actually sent rather than
+    // picking one: the rename lands as `undefined` on the field the client
+    // reads, and nothing errors — no 4xx, no thrown parse — so a client that
+    // knows only one spelling fails much later and somewhere else. Normalising
+    // here means one mero-js works against nodes either side of that release.
+    if (data && data.namespaceId === undefined && data.groupId !== undefined) {
+      return { ...data, namespaceId: data.groupId };
+    }
+    return data;
   }
 
   async createGroupInNamespace(

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -514,7 +514,25 @@ export interface JoinNamespaceRequest {
 }
 
 export interface JoinNamespaceResponseData {
-  groupId: string;
+  /**
+   * The namespace that was joined.
+   *
+   * core `0.11.0-rc.25` renamed this field on the wire from `groupId`
+   * (core#3598). The endpoint had been sharing a response DTO with
+   * `POST /admin-api/groups/join`, which leaked the internal "a namespace is a
+   * root group" detail into the namespace API and meant a caller could not use
+   * one spelling across the family.
+   *
+   * {@link AdminClient.joinNamespace} fills this in from whichever spelling the
+   * node sent, so it is populated against nodes on either side of that release.
+   */
+  namespaceId: string;
+  /**
+   * @deprecated The pre-`0.11.0-rc.25` spelling of {@link namespaceId}. Present
+   * only when the node predates that release — read `namespaceId` instead,
+   * which is always set.
+   */
+  groupId?: string;
   /** The key the joiner signs with, base58. */
   memberIdentity: string;
   /**

--- a/tests/e2e/multinode.test.ts
+++ b/tests/e2e/multinode.test.ts
@@ -56,7 +56,15 @@ suite('Multi-node E2E — namespace invite/join', () => {
     });
     // node-2 is now a member of the namespace (got its own member identity back).
     expect(joined.memberIdentity).toBeTruthy();
-    expect(joined.groupId).toBeTruthy();
+    // `namespaceId`, not `groupId`: core 0.11.0-rc.25 renamed this field
+    // (core#3598). Asserted here rather than only in the unit tests because
+    // this runs against a real released merod, so it is what catches the next
+    // rename on the way in.
+    //
+    // Shape, not equality against the id we joined with: this field is the
+    // namespace id hex-encoded, while the id the caller passes in is base58, so
+    // the two are the same namespace in two different alphabets.
+    expect(joined.namespaceId).toMatch(/^[0-9a-f]{64}$/);
     // The account it joined as, beside the key it signs with: this is what every
     // member-addressing endpoint takes, and it renders as 64 hex, so a field
     // wired to the bs58 key space instead would fail here rather than silently


### PR DESCRIPTION
`Multi-node E2E (vs released merod)` has been red since rc.25 shipped, and it is
not flaky — mero-js cannot read the namespace-join response from a current node.

## What broke

core#3598, released in `0.11.0-rc.25` on 2026-08-21, renamed one field on
`POST /admin-api/namespaces/{id}/join`:

```diff
 {"data": {
-  "groupId": "7c9a0b…",
+  "namespaceId": "7c9a0b…",
    "memberIdentity": "4wBqpZ…",
    "memberAccount": "aa11bb…"
 }}
```

The endpoint had been sharing a response DTO with `POST /admin-api/groups/join`,
which leaked the internal "a namespace is a root group" detail into the
namespace API. `groups/join` correctly still returns `groupId`; only the
namespace endpoint moved.

mero-js 13.2.0 reads `groupId`. Against an rc.25 node that field is simply
absent, so it reads `undefined` — **no 4xx, no thrown parse, nothing logged**.
The failure surfaces wherever the caller eventually uses the id, not at the call
that produced it. `tests/e2e/multinode.test.ts:59` is where it happened to
surface here.

## The fix

`joinNamespace()` binds whichever spelling the node actually sent, so one
mero-js works against nodes either side of rc.25 rather than forcing a
lockstep upgrade. `namespaceId` is canonical and always populated;
`groupId` stays on the type as optional and `@deprecated` so callers still
reading it against an older node keep working.

That is the same shape of fix merobox took in `0.6.59`
(`fix(join): bind namespaceId whichever spelling the node sends`).

## Tests

- the existing unit test now asserts the rc.25 spelling
- a new test pins the pre-rc.25 wire shape, so the compatibility path cannot
  silently rot
- a new test pins that `namespaceId` wins when a node sends both, so the
  normalisation cannot overwrite the canonical field
- the e2e asserts `namespaceId` matches `^[0-9a-f]{64}$` rather than merely
  being truthy — this field is the namespace id **hex-encoded** while the id the
  caller passes in is base58, so it is the same namespace in two alphabets and
  asserting equality against the input would be wrong. The shape assertion still
  catches a field wired to the bs58 key space, which is the mistake worth
  guarding.

307 unit tests pass, typecheck clean.

## Worth checking separately

Anything else that reads this response is exposed to the same silent
`undefined`: `mero-react`, `swift-sdk`, `kotlin-sdk`, and the tauri desktop.

The reason this sat unnoticed for three days is structural, not anyone's
oversight: mero-js CI last ran on 2026-08-21 at 07:30 and rc.25 shipped at
15:19 that day. `E2E (vs released merod)` resolves whatever release is newest
at run time, so a core release can turn this repository red without a single
commit landing here — and it only becomes visible on the next PR to open.
