### PR TITLE
ci(fleet): add mero-chat-pwa as a consumer

### DIFF
--- a/.github/fleet.json
+++ b/.github/fleet.json
@@ -25,6 +25,7 @@
     { "repo": "merraria", "surfaces": ["cargo", "npm"] },
     { "repo": "mero-blocks", "surfaces": ["cargo", "npm"] },
     { "repo": "mero-issue-tracker", "surfaces": ["cargo", "npm"] },
+    { "repo": "mero-chat-pwa", "surfaces": ["cargo", "npm"] },
     { "repo": "mero-ar", "surfaces": ["cargo"] },
     { "repo": "mero-tag", "surfaces": ["cargo"] },
     { "repo": "scaffolding-e2e-application", "surfaces": ["cargo"] },

--- a/.github/scripts/bump-fleet.sh
+++ b/.github/scripts/bump-fleet.sh
@@ -321,12 +321,39 @@ bump_npm() {
     # --lockfile-only resolves and writes the lock without materialising
     # node_modules. --ignore-scripts because nothing here should run a
     # dependency's install hook on a release runner.
-    ( cd "$root" && pnpm install --lockfile-only --ignore-scripts >/dev/null )
+    #
+    # Captured rather than streamed, but replayed in full on failure. pnpm
+    # writes its diagnostics to stdout, so discarding it outright hides the
+    # single most likely failure in this script behind a bare non-zero exit —
+    # including the useful case where the requested version simply is not
+    # published yet, which reads as "the tooling is broken" if you cannot see
+    # ERR_PNPM_NO_MATCHING_VERSION.
+    if ! ( cd "$root" && pnpm install --lockfile-only --ignore-scripts ) \
+        > "$TMPDIR_RUN/pnpm.log" 2>&1; then
+      note "pnpm failed refreshing ${root#$DIR/}/pnpm-lock.yaml:"
+      sed 's/^/      /' "$TMPDIR_RUN/pnpm.log" >&2
+      die "lockfile refresh failed for ${root#$DIR/}"
+    fi
   done
 }
 
 TMPDIR_RUN=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_RUN"' EXIT
+
+# The --dry-run revert lives here rather than at the end of the happy path. A
+# dry run that dies partway — an unpublished version, a manifest this script
+# will not interpret — would otherwise leave the checkout modified, and the
+# clean-tree guard above then refuses to run again until someone tidies up by
+# hand. The guard proved the tree was clean before any edit, so reverting
+# everything tracked is safe on any exit path.
+cleanup() {
+  status=$?
+  rm -rf "$TMPDIR_RUN"
+  if [ "$DRY_RUN" -eq 1 ]; then
+    ( cd "$DIR" && git checkout -- . ) >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
 
 case "$SURFACE" in
   cargo)
@@ -341,9 +368,8 @@ esac
 
 if [ "$DRY_RUN" -eq 1 ]; then
   head_note ""
-  head_note "--dry-run: showing the diff and reverting it"
+  head_note "--dry-run: showing the diff, then reverting it"
   ( cd "$DIR" && git --no-pager diff --stat && echo && git --no-pager diff )
-  ( cd "$DIR" && git checkout -- . )
 fi
 
 exit 0


### PR DESCRIPTION
#107 merged just before the commit adding `mero-chat-pwa` was pushed, so master here carries the 13-repo list while core, mero-react and design-system carry 14.

`mero-chat-pwa` has both surfaces — `logic/Cargo.toml` pinning core by git tag, and `app/package.json` on mero-js 13 / mero-react 6 / mero-ui 1.5 — and was in neither the consumer list nor `_excluded`, so it would silently have received no bump pull requests from this repository.

Not to be confused with `mero-chat`, which stays excluded (abandoned 2026-08-19).