### PR TITLE
fix(fleet): record a root lockfile at its repository-relative path

### DIFF
--- a/.github/scripts/bump-fleet.sh
+++ b/.github/scripts/bump-fleet.sh
@@ -430,7 +430,19 @@ bump_npm() {
   done
 
   for root in $roots; do
-    note "refreshing ${root#$DIR/}/pnpm-lock.yaml"
+    # $DIR is absolute, so a nested root strips to "app", "apps/desktop", and so
+    # on. A root that IS $DIR — the repository that keeps its lockfile at the top
+    # level — strips to itself, because there is no "$DIR/" prefix to remove. The
+    # recorded path then stayed absolute, and `git add --pathspec-from-file`,
+    # which reads paths as repository-relative, failed the whole bump with
+    #
+    #   fatal: pathspec 'home/runner/work/.../pnpm-lock.yaml' did not match any files
+    #
+    # tauri-app, app-registry and mero-issue-tracker are all shaped that way.
+    local rel="${root#$DIR}"; rel="${rel#/}"
+    local lock="${rel:+$rel/}pnpm-lock.yaml"
+
+    note "refreshing $lock"
     # --lockfile-only resolves and writes the lock without materialising
     # node_modules. --ignore-scripts because nothing here should run a
     # dependency's install hook on a release runner.
@@ -443,12 +455,11 @@ bump_npm() {
     # ERR_PNPM_NO_MATCHING_VERSION.
     if ! ( cd "$root" && pnpm install --lockfile-only --ignore-scripts ) \
         > "$TMPDIR_RUN/pnpm.log" 2>&1; then
-      note "pnpm failed refreshing ${root#$DIR/}/pnpm-lock.yaml:"
+      note "pnpm failed refreshing $lock:"
       sed 's/^/      /' "$TMPDIR_RUN/pnpm.log" >&2
-      die "lockfile refresh failed for ${root#$DIR/}"
+      die "lockfile refresh failed for $lock"
     fi
-    lock="${root#$DIR/}/pnpm-lock.yaml"
-    record_change "${lock#/}"
+    record_change "$lock"
   done
 }
 


### PR DESCRIPTION
The mero-js 13.2.2 fan-out failed outright for tauri-app:

```
fatal: pathspec 'home/runner/work/mero-js/mero-js/consumer/pnpm-lock.yaml' did not match any files
```

`--dir` is resolved to an absolute path early, so the lockfile's install root was
made repository-relative by stripping a `"$DIR/"` prefix. That prefix is only
there when the root is *nested* — `app/`, `apps/desktop/` — which is every
repository the fan-out happened to be exercised against. A repository whose
`pnpm-lock.yaml` sits at the top level has an install root that **is** `$DIR`,
nothing is stripped, and the path stays absolute; `${lock#/}` then filed the
leading slash off and handed it to `git add --pathspec-from-file`, which reads
its paths as repository-relative.

The commit step exits 128 there, so the bump is lost rather than arriving wrong:
no branch, no pull request, and the repository silently sits out that release.
**tauri-app, app-registry and mero-issue-tracker** are all shaped that way, and
mero-calendar has a root lockfile as well as a nested one.

### Verification

Two fixtures, one with the lockfile at the root and one under `app/`, run
through the script before and after:

| | before | after |
|---|---|---|
| root lockfile | `private/tmp/.../fx-root/pnpm-lock.yaml` → `git add` **exit 128** | `pnpm-lock.yaml` → **exit 0** |
| nested lockfile | `app/pnpm-lock.yaml` → exit 0 | `app/pnpm-lock.yaml` → exit 0 |

The before-case reproduces the CI error verbatim.

Independent of #111 — that one is the pnpm version, this one is the path. Both
are needed for a clean fan-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)