### PR TITLE
feat(admin): bind performIntent for delegated authorship

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -608,6 +608,54 @@ describe('AdminApiClient', () => {
       expect(result.namespaceId).toBe('ns-1');
     });
 
+    it('performIntent posts the author-side halves and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/contexts/ctx-1/intents', {
+        data: { rootHash: 'root-1', returns: null },
+      });
+
+      const result = await client.performIntent('ctx-1', {
+        method: 'set',
+        argsJson: { key: 'k', value: 'v' },
+        warrant: 'aabb',
+        authorProof: 'ccdd',
+      });
+
+      expect(result).toEqual({ rootHash: 'root-1', returns: null });
+      // Only the author's half goes out. The node attaches its own credential,
+      // so a caller never has to learn which of its processes runs the intent —
+      // and a re-key on its side does not void a warrant already issued.
+      expect(mock.getRequestBody('POST', '/admin-api/contexts/ctx-1/intents')).toEqual({
+        method: 'set',
+        argsJson: { key: 'k', value: 'v' },
+        warrant: 'aabb',
+        authorProof: 'ccdd',
+      });
+    });
+
+    it('performIntent leaves nested args untouched', async () => {
+      // The warrant commits to H(method, args), and the node recomputes that
+      // hash from what arrives. Anything this client did to the shape on the way
+      // out — reordering, stringifying, dropping a null — would make a warrant
+      // that verifies nowhere, and it would surface at the node as a bad
+      // signature rather than here as a serialization difference.
+      const argsJson = { outer: { inner: [1, null, 'x'] }, flag: false };
+      mock.setMockResponse('POST', '/admin-api/contexts/ctx-2/intents', {
+        data: { rootHash: 'root-2', returns: 'ok' },
+      });
+
+      await client.performIntent('ctx-2', {
+        method: 'nested',
+        argsJson,
+        warrant: 'aa',
+        authorProof: 'bb',
+      });
+
+      expect(
+        (mock.getRequestBody('POST', '/admin-api/contexts/ctx-2/intents') as { argsJson: unknown })
+          .argsJson,
+      ).toEqual(argsJson);
+    });
+
     it('getNodeIdentity unwraps data', async () => {
       const identity = {
         accountId: 'ac-1',

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -100,6 +100,8 @@ import type {
   TeeAttestResponseData,
   TeeVerifyQuoteRequest,
   TeeVerifyQuoteResponseData,
+  PerformIntentRequest,
+  PerformIntentResponseData,
 } from './admin-types.js';
 
 /**
@@ -646,6 +648,43 @@ export class AdminApiClient {
   async getNamespaceIdentity(namespaceId: string): Promise<NamespaceIdentity> {
     const node = await this.getNodeIdentity();
     return { namespaceId, publicKey: node.publicKey, account: node.accountId };
+  }
+
+  /**
+   * Ask this node to run one method on a member's behalf, under a warrant that
+   * member signed.
+   *
+   * The node executes and signs the envelope with its own key; the change is
+   * attributed to the **author**. Both halves travel together, so every peer
+   * re-checks that the member consented instead of trusting the relay.
+   *
+   * Three things have to be true first, and none is implied by the others:
+   *
+   * - the author's **account** is a member of the group owning the context —
+   *   their device joins nothing and is in no group's binding rows, which is
+   *   exactly the case a device certificate covers;
+   * - this node holds `CAN_AUTHOR_ON_BEHALF` on that group, which is implied by
+   *   neither membership nor admin;
+   * - the warrant has not been spent. It is single-use: presenting a valid one
+   *   twice is refused, because the signature stays valid forever and replay is
+   *   not forgery.
+   *
+   * A refusal comes back as a `403` carrying the reason — "an admin must grant
+   * CAN_AUTHOR_ON_BEHALF to …", or that the nonce is already spent — so a caller
+   * can tell which precondition failed rather than only that one did.
+   *
+   * This SDK does not mint warrants; see {@link PerformIntentRequest.warrant}.
+   */
+  async performIntent(
+    contextId: string,
+    request: PerformIntentRequest,
+  ): Promise<PerformIntentResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: PerformIntentResponseData }>(
+        `/admin-api/contexts/${contextId}/intents`,
+        request,
+      ),
+    );
   }
 
   async listNamespacesForApplication(applicationId: string): Promise<ListNamespacesResponseData> {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -417,6 +417,58 @@ export type ListNamespacesResponseData = Namespace[];
  * node signs with one key — so none of this varies by namespace, which is why
  * the endpoint behind it takes none.
  */
+/**
+ * A member's request that a node run one method on their behalf.
+ *
+ * Delegated authorship exists for a holder that cannot run the application
+ * itself — a device with only a signing key, which can neither compile the WASM
+ * nor decrypt the state. What makes the resulting write *theirs* is the warrant:
+ * a statement they signed, which travels with the change so every peer verifies
+ * they consented rather than taking the node's word.
+ */
+export interface PerformIntentRequest {
+  /** The method to run. */
+  method: string;
+  /** Its arguments, as the JSON the guest will receive. */
+  argsJson: unknown;
+  /**
+   * The author's consent: hex-encoded borsh of a `Warrant`.
+   *
+   * Opaque on purpose. Its canonical form is those bytes — the signature covers
+   * them — so re-describing the fields as JSON would create a second spelling
+   * that could disagree with what was signed.
+   *
+   * Mint it with `merod account warrant` or `meroctl context intent`. This SDK
+   * does not sign: doing so would need ed25519 and a borsh encoding kept
+   * byte-identical with the node's forever, and a one-byte drift is
+   * indistinguishable from a forgery.
+   */
+  warrant: string;
+  /**
+   * Hex-encoded borsh of the author's `AccountProof<DeviceCert>`, proving the
+   * key that signed the warrant is a device of the account it names.
+   *
+   * Only the author's own half. The node attaches its own credential, so a
+   * caller never learns which of the node's processes runs the intent — and a
+   * re-key on its side does not void a warrant already issued.
+   */
+  authorProof: string;
+}
+
+/** What a performed intent reports back. */
+export interface PerformIntentResponseData {
+  /**
+   * The context's scope root after the run — how a caller sees that it wrote.
+   *
+   * Worth asserting on rather than the status alone: an accepted intent that
+   * advanced no state is a real failure mode, and it is cheaper to catch here
+   * than on a later read of a value that was never written.
+   */
+  rootHash: string;
+  /** The method's own return value, if it had one. */
+  returns: unknown | null;
+}
+
 export interface NodeIdentity {
   /**
    * The account this node writes as, 64 hex characters. This — not

--- a/tests/e2e/delegated-intent.test.ts
+++ b/tests/e2e/delegated-intent.test.ts
@@ -1,0 +1,200 @@
+/**
+ * E2E for `performIntent` — a member with no node writing through a relay.
+ *
+ * This is the SDK-level coverage the endpoint was missing, and the reason it sat
+ * in core's `coverage-baseline.json`: that ratchet is fed by this suite, so no
+ * amount of merobox coverage moves it.
+ *
+ * The warrant is minted by real `merod`, not fabricated here. That is deliberate
+ * twice over:
+ *
+ * - This SDK does not sign, and should not: it would need ed25519 plus a borsh
+ *   encoding kept byte-identical with the node's forever, in a package that has
+ *   no runtime dependencies at all.
+ * - A test that called the endpoint with a made-up warrant would register
+ *   coverage and prove nothing — it would 4xx every time and the ratchet would
+ *   not notice. Coverage of a route is not coverage of what the route does.
+ *
+ * Requires MEROD_BINARY. Skipped without it, so a local run against an
+ * already-booted node does not fail on a missing binary.
+ */
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
+
+const NODE_URL = resolveBaseUrl();
+const { username: USERNAME, password: PASSWORD } = resolveCreds();
+const RUN = runId();
+const MEROD = process.env.MEROD_BINARY;
+
+/**
+ * A fixed BIP-39 phrase, so the author's ACCOUNT is deterministic.
+ *
+ * It owns nothing. It is here because this scenario needs an author whose
+ * account holds **no node at all** — the case delegated authorship exists for —
+ * and an account only exists where some root does. A node's own root would work
+ * and would need no phrase, but `sign-cert` reads it from the datastore and
+ * RocksDB's lock is exclusive, so it cannot be read while the node under test is
+ * serving this suite. `--from` opens no store, which is what makes it usable
+ * here.
+ */
+const AUTHOR_PHRASE =
+  'legal winner thank year wave sausage worth useful legal winner thank year ' +
+  'wave sausage worth useful legal winner thank year wave sausage worth title';
+
+interface MintedDevice {
+  credential: string;
+  account: string;
+  secret: string;
+}
+
+/** Run an offline `merod account` subcommand and return its stdout. */
+function merod(args: string[]): string {
+  return execFileSync(MEROD as string, ['--node', 'sdk-e2e-offline', ...args], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+}
+
+/**
+ * Mint a device for the phrase's account and certify it, offline.
+ *
+ * `--generate` mints the keypair and certifies it in one step, so the secret
+ * exists only in this output and never reaches the node — which is the whole
+ * point: a node holding it could forge writes in the member's name.
+ */
+function mintDevice(): MintedDevice {
+  const dir = mkdtempSync(join(tmpdir(), 'mero-warrant-'));
+  const phraseFile = join(dir, 'phrase');
+  writeFileSync(phraseFile, `${AUTHOR_PHRASE}\n`, { mode: 0o600 });
+
+  const out = merod(['account', 'sign-cert', '--generate', '--from', phraseFile]);
+  const lines = out.split('\n');
+
+  const credential = lines.find((l) => /^[0-9a-f]{100,}$/.test(l.trim()))?.trim();
+  const account = /^Account: +([0-9a-f]{64})$/m.exec(out)?.[1];
+  const secret = /^Secret: +([0-9a-f]{64})$/m.exec(out)?.[1];
+
+  // Named individually rather than one "parse failed": if `sign-cert` changes
+  // its output, the message should say which field went missing.
+  if (!credential) throw new Error(`sign-cert printed no credential:\n${out}`);
+  if (!account) throw new Error(`sign-cert printed no Account line:\n${out}`);
+  if (!secret) throw new Error(`sign-cert printed no Secret line:\n${out}`);
+
+  return { credential, account, secret };
+}
+
+describe.skipIf(!MEROD)('performIntent E2E — delegated authorship', () => {
+  let mero: MeroJs;
+  let contextId: string;
+  let namespaceId: string;
+  let relayAccount: string;
+  let device: MintedDevice;
+  /** One warrant, presented three times: refused, accepted, refused. */
+  let warrant: string;
+
+  beforeAll(async () => {
+    mero = new MeroJs({ baseUrl: NODE_URL });
+    await mero.authenticate({ username: USERNAME, password: PASSWORD });
+
+    const applicationId = await ensureApplication(mero);
+    const ns = await mero.admin.createNamespace({ applicationId, name: `deleg-${RUN}` });
+    namespaceId = ns.namespaceId;
+
+    const ctx = await mero.admin.createContext({ applicationId, groupId: namespaceId });
+    contextId = ctx.contextId;
+
+    relayAccount = (await mero.admin.getNodeIdentity()).accountId;
+    device = mintDevice();
+  }, 180_000);
+
+  it('adds the author by ACCOUNT — its device joins nothing', async () => {
+    // By account, not by key. The minted device is in no group's binding rows
+    // and never will be, which is exactly the case a certificate covers: a
+    // key-based membership check would refuse every write below.
+    await mero.admin.addGroupMembers(namespaceId, {
+      members: [{ identity: device.account, role: 'Member' }],
+    });
+  });
+
+  it('refuses the intent before the relay is granted authorship', async () => {
+    // The grant is implied by neither membership nor admin, and this is what
+    // proves it. Refused at the API, never published as a delta peers would drop.
+    //
+    // Minted once and reused below on purpose: the same bytes are refused, then
+    // accepted, then refused. That makes the grant the only thing that changed
+    // between the first two — a fresh warrant each time would not.
+    warrant = mintWarrant(1);
+
+    await expect(
+      mero.admin.performIntent(contextId, {
+        method: 'set',
+        argsJson: { key: 'delegated', value: `from-sdk-${RUN}` },
+        warrant,
+        authorProof: device.credential,
+      }),
+    ).rejects.toThrow(/CAN_AUTHOR_ON_BEHALF/);
+  }, 60_000);
+
+  it('performs the intent once the relay may author on behalf', async () => {
+    await mero.admin.setMemberCapabilities(namespaceId, relayAccount, {
+      // Bit 9 — authorship and nothing else, which is the posture the
+      // capability exists to make possible.
+      capabilities: 512,
+    });
+
+    const result = await mero.admin.performIntent(contextId, {
+      method: 'set',
+      argsJson: { key: 'delegated', value: `from-sdk-${RUN}` },
+      warrant,
+      authorProof: device.credential,
+    });
+
+    // The root, not merely a 2xx. An accepted intent that advanced no state is a
+    // real failure mode — it happened during core's own rollout, where the
+    // endpoint reported a null delta id for a run that wrote nothing.
+    expect(result.rootHash).toBeTruthy();
+  }, 60_000);
+
+  it('refuses a spent warrant', async () => {
+    // The very same warrant, now spent. Its signature is still perfectly valid:
+    // replay is not forgery, which is why the nonce ledger has to exist and why
+    // the envelope check cannot be what stops it.
+    await expect(
+      mero.admin.performIntent(contextId, {
+        method: 'set',
+        argsJson: { key: 'delegated', value: `from-sdk-${RUN}` },
+        warrant,
+        authorProof: device.credential,
+      }),
+    ).rejects.toThrow(/nonce/i);
+  }, 60_000);
+
+  /** A warrant over the same intent, at the given nonce. */
+  function mintWarrant(nonce: number): string {
+    return merod([
+      'account',
+      'warrant',
+      '--context',
+      contextId,
+      '--method',
+      'set',
+      '--args',
+      JSON.stringify({ key: 'delegated', value: `from-sdk-${RUN}` }),
+      '--executor',
+      relayAccount,
+      '--nonce',
+      String(nonce),
+      '--device-secret',
+      device.secret,
+      '--credential',
+      device.credential,
+    ]).trim();
+  }
+});


### PR DESCRIPTION
`POST /admin-api/contexts/:context_id/intents` (calimero-network/core#3636) had no client method, so it sits in core's `crates/server/coverage-baseline.json` as an accepted gap. That ratchet is fed by the **SDK e2e**, so no amount of merobox coverage moves it — this is the piece that can. Tracks calimero-network/core#3640.

## What it sends

The author's half only: the warrant, and the proof that its signing key is a device of the account it names. The node attaches its own credential, so a caller never learns which of its processes runs the intent — and a re-key on its side does not void a warrant already issued.

## Deliberately no minting

This SDK spends warrants; it does not sign them. Two reasons, and the second is the one that matters:

- Signing needs ed25519 **and** a borsh encoding kept byte-identical with the node's forever. A one-byte drift is indistinguishable from a forgery.
- This package has **no runtime dependencies at all** today. Adopting a crypto library is a decision on its own merits, not a side effect of adding an HTTP call.

`merod account warrant` and `meroctl context intent` mint. If browser-side signing becomes a product goal — and delegated authorship exists precisely for devices that cannot run a node, so it plausibly will — that deserves its own proposal.

For comparison, `calimero-client-py` *did* gain a `sign_warrant`, because `Warrant::sign` already existed in Rust and `calimero-account` was a one-line dependency. The asymmetry is real, not an oversight.

## The test worth reading

`performIntent leaves nested args untouched`. The warrant commits to `H(method, args)` and the node recomputes that hash from what arrives — so anything this client did to the shape on the way out (reordering, stringifying, dropping a `null`) would mint warrants that verify **nowhere**, and it would surface at the node as a bad signature rather than here as a serialization difference.

## Checked

- 309 tests pass, 1 skipped.
- `npm run lint`: 0 errors. The 5 warnings are pre-existing, in `docs/` and `src/account/` — files this does not touch.
- Builds and typechecks clean.

## One thing left alone on purpose

`package-lock.json` is **out of sync with `package.json` on master** — `conventional-changelog-conventionalcommits` 7.0.2 vs 9.3.1 — so `npm ci` fails there. I installed with `--no-save --package-lock=false` and verified the lockfile is byte-identical afterwards. Fixing that drift is worth doing, but it is unrelated to this and belongs in its own change.