### PR TITLE
fix(fleet): let the pnpm probe find nothing without killing the step

### DIFF
--- a/.github/workflows/fleet-bump.yml
+++ b/.github/workflows/fleet-bump.yml
@@ -182,24 +182,48 @@ jobs:
         id: pnpm
         run: |
           set -euo pipefail
+
+          # Every probe below is allowed to find nothing, and saying so must not
+          # be fatal. `grep` exits 1 on no match, `xargs` reports that as 123,
+          # and `head -1` can SIGPIPE its producer into 141 — so under
+          # `set -euo pipefail` a repository that simply does not declare
+          # `packageManager` killed this step at exit 123 before either fallback
+          # below could run. That is not hypothetical: it took out 7 of the 12
+          # consumers on the 13.2.4 release, and the `version=9` floor has never
+          # once been reached. Hence `|| true` on each probe: absence is an
+          # answer, and only the last resort decides.
+
           # Shallowest first, and never inside node_modules: a vendored
           # dependency's own `packageManager` is not this repository's.
-          version=$(find consumer -name package.json \
-                      -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null \
-                    | awk -F/ '{print NF"\t"$0}' | sort -n | cut -f2- \
-                    | xargs grep -hoE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"' 2>/dev/null \
-                    | head -1 | sed 's/.*pnpm@//; s/"$//')
+          declared() {
+            find consumer -name package.json \
+                 -not -path '*/node_modules/*' -not -path '*/.git/*' 2>/dev/null \
+              | awk -F/ '{print NF"\t"$0}' | sort -n | cut -f2- \
+              | tr '\n' '\0' \
+              | xargs -0 --no-run-if-empty \
+                  grep -hoE '"packageManager"[[:space:]]*:[[:space:]]*"pnpm@[^"]+"' 2>/dev/null \
+              | sed -n '1s/.*pnpm@//;1s/"$//;1p'
+          }
+
+          # What the repository's own CI installs. `version:` sits a line or two
+          # under the `uses:`, so keep a little context and take the first hit.
+          from_ci() {
+            grep -rhA3 'pnpm/action-setup' consumer/.github/workflows 2>/dev/null \
+              | grep -oE 'version:[[:space:]]*[0-9][0-9.]*' \
+              | sed -n '1s/version:[[:space:]]*//;1p'
+          }
+
+          version=$(declared || true)
           source="packageManager"
           if [ -z "$version" ]; then
-            version=$(grep -rhA3 'pnpm/action-setup' consumer/.github/workflows 2>/dev/null \
-                      | grep -oE 'version:[[:space:]]*[0-9][0-9.]*' | head -1 \
-                      | sed 's/version:[[:space:]]*//')
+            version=$(from_ci || true)
             source="its own CI"
           fi
           if [ -z "$version" ]; then
             version=9
             source="fallback"
           fi
+
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "::notice::${{ matrix.repo }} uses pnpm $version (from $source)"
 


### PR DESCRIPTION
The pnpm probe added yesterday cannot survive a consumer that declares no
`packageManager` — which is 7 of the 12 consumers.

`grep` exits 1 on no match, `xargs` reports that as **123**, and `head -1` can
SIGPIPE its producer into 141. Under `set -euo pipefail` any of those takes the
whole step down, so both fallbacks below it — the `"its own CI"` probe and the
`version=9` floor — were unreachable dead code.

That is not hypothetical. On the mero-js 13.2.4 release
([run 32819654033](https://github.com/calimero-network/mero-js/actions/runs/32819654033))
the step failed at exit 123 for **mero-calendar, mero-blocks, mero-design,
mero-chat-pwa, merraria, mero-pixart and mero-meet**, and none of them got a
bump PR. The correlation is exact: the only 4 consumers that succeeded
(tauri-app, mero-stream, mero-issue-tracker, app-registry) are the only 4 that
declare `packageManager`.

Each probe is now a function whose result may be empty, called with `|| true`,
so absence is an answer rather than a fatal error. `xargs -0 --no-run-if-empty`
also stops a path with a space in it from splitting, and `sed -n '1p'` replaces
`head -1` so the producer is never SIGPIPEd.

Verified against four fixtures, running the step body extracted from this file:

| fixture | old | new |
| --- | --- | --- |
| no `packageManager`, CI pins `version: 9` (the 7 that died) | **dies** | `9` — from its own CI |
| declares `pnpm@11.20.0` (the 4 that survived) | `11.20.0` | `11.20.0` |
| nothing at all | **dies** | `9` — from fallback |
| root declares 9.6.0, `app/` declares 10.14.0, vendored dep declares 6.0.0 | `9.6.0` | `9.6.0` |

The last row is the pre-existing precedence, re-checked: shallowest wins and
`node_modules` is ignored.
