### PR TITLE
feat(admin): account-level device pairing, relink and listings

### DIFF
--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -811,7 +811,7 @@ describe('AdminApiClient', () => {
 
     it('completeAccountPairing omits applications when the caller grants every one', async () => {
       // Absent is the wire's "all", and the SDK must not turn it into `[]` or
-      // into a guess at the full list — the node resolves it.
+      // into a guess at the full list - the node resolves it.
       mock.setMockResponse('POST', '/admin-api/account/pair-complete', { data: { keyDelivered: false } });
       await client.completeAccountPairing({
         deviceId: PAIR_INIT.deviceId,
@@ -841,8 +841,8 @@ describe('AdminApiClient', () => {
         applications: ['App1BaseFiftyEight'],
       });
       // `linkedIn` and `skipped` are the whole point of the answer: publication
-      // is per-DAG, so which namespaces the device actually reached — and why
-      // the others were left alone — is a state the caller has to be able to see.
+      // is per-DAG, so which namespaces the device actually reached - and why
+      // the others were left alone - is a state the caller has to be able to see.
       expect(result).toEqual(relinked);
     });
 

--- a/src/admin-api/admin-client.test.ts
+++ b/src/admin-api/admin-client.test.ts
@@ -752,6 +752,137 @@ describe('AdminApiClient', () => {
     });
   });
 
+  describe('Account Devices & Pairing', () => {
+    // A pair-init answer as merod emits it: every field hex, including the two
+    // public keys, because this payload is a set of round-trip tokens copied
+    // verbatim into pair-complete rather than keys compared against a listing.
+    const HEX32 = 'a'.repeat(64);
+    const HEX64 = 'b'.repeat(128);
+    const PAIR_INIT = {
+      accountId: '1'.repeat(64),
+      deviceId: '2'.repeat(64),
+      kemPublicKey: HEX32,
+      signPublicKey: '3'.repeat(64),
+      statement: HEX64,
+      confirmationCode: '7BC0-DAAC-CCB4-84A4',
+    };
+
+    it('initAccountPairing posts the namespace set and unwraps data', async () => {
+      mock.setMockResponse('POST', '/admin-api/account/pair-init', { data: PAIR_INIT });
+      const result = await client.initAccountPairing({
+        accountRootPublicKey: '4'.repeat(64),
+        namespaces: ['5'.repeat(64), '6'.repeat(64)],
+      });
+      // Passed through untouched: the caller's hex is what the node parses, and
+      // the answer's hex is what pair-complete has to receive verbatim.
+      expect(mock.getRequestBody('POST', '/admin-api/account/pair-init')).toEqual({
+        accountRootPublicKey: '4'.repeat(64),
+        namespaces: ['5'.repeat(64), '6'.repeat(64)],
+      });
+      expect(result).toEqual(PAIR_INIT);
+    });
+
+    it('completeAccountPairing sends the whole pair-init payload plus the scope', async () => {
+      const completed = {
+        accountId: PAIR_INIT.accountId,
+        deviceId: PAIR_INIT.deviceId,
+        keyDelivered: true,
+        confirmationCode: PAIR_INIT.confirmationCode,
+        credential: 'c'.repeat(200),
+      };
+      mock.setMockResponse('POST', '/admin-api/account/pair-complete', { data: completed });
+      const request = {
+        deviceId: PAIR_INIT.deviceId,
+        kemPublicKey: PAIR_INIT.kemPublicKey,
+        signPublicKey: PAIR_INIT.signPublicKey,
+        statement: PAIR_INIT.statement,
+        confirmationCode: PAIR_INIT.confirmationCode,
+        applications: ['App1BaseFiftyEight'],
+      };
+      const result = await client.completeAccountPairing(request);
+      // Asserted whole rather than field by field: the statement is what turns
+      // the three values above from claims by whoever relayed them into a
+      // statement by the device that minted them, so a client that quietly
+      // dropped one field would be asking the node to certify attacker-supplied
+      // keys. The scope stays base58 while everything beside it is hex.
+      expect(mock.getRequestBody('POST', '/admin-api/account/pair-complete')).toEqual(request);
+      expect(result).toEqual(completed);
+    });
+
+    it('completeAccountPairing omits applications when the caller grants every one', async () => {
+      // Absent is the wire's "all", and the SDK must not turn it into `[]` or
+      // into a guess at the full list — the node resolves it.
+      mock.setMockResponse('POST', '/admin-api/account/pair-complete', { data: { keyDelivered: false } });
+      await client.completeAccountPairing({
+        deviceId: PAIR_INIT.deviceId,
+        kemPublicKey: PAIR_INIT.kemPublicKey,
+        signPublicKey: PAIR_INIT.signPublicKey,
+        statement: PAIR_INIT.statement,
+        confirmationCode: PAIR_INIT.confirmationCode,
+      });
+      expect(
+        mock.getRequestBody('POST', '/admin-api/account/pair-complete'),
+      ).not.toHaveProperty('applications');
+    });
+
+    it('relinkAccountDevice names the device in the path and unwraps data', async () => {
+      const relinked = {
+        accountId: PAIR_INIT.accountId,
+        deviceId: PAIR_INIT.deviceId,
+        applications: ['App1BaseFiftyEight'],
+        linkedIn: [{ namespaceId: '5'.repeat(64), keyDelivered: true }],
+        skipped: [{ namespaceId: '6'.repeat(64), reason: 'outOfScope' }],
+      };
+      mock.setMockResponse('POST', `/admin-api/account/devices/${PAIR_INIT.deviceId}/relink`, { data: relinked });
+      const result = await client.relinkAccountDevice(PAIR_INIT.deviceId, {
+        applications: ['App1BaseFiftyEight'],
+      });
+      expect(mock.getRequestBody('POST', `/admin-api/account/devices/${PAIR_INIT.deviceId}/relink`)).toEqual({
+        applications: ['App1BaseFiftyEight'],
+      });
+      // `linkedIn` and `skipped` are the whole point of the answer: publication
+      // is per-DAG, so which namespaces the device actually reached — and why
+      // the others were left alone — is a state the caller has to be able to see.
+      expect(result).toEqual(relinked);
+    });
+
+    it('relinkAccountDevice sends an empty body for a repair-only relink', async () => {
+      // No argument means "repair against the stored scope", which the wire
+      // spells as an absent list. It must not become the every-application list
+      // an empty `applications` means on pair-complete.
+      mock.setMockResponse('POST', `/admin-api/account/devices/${PAIR_INIT.deviceId}/relink`, {
+        data: { applications: [], linkedIn: [], skipped: [] },
+      });
+      await client.relinkAccountDevice(PAIR_INIT.deviceId);
+      expect(mock.getRequestBody('POST', `/admin-api/account/devices/${PAIR_INIT.deviceId}/relink`)).toEqual({});
+    });
+
+    it('listAccountDevices reads the top-level `devices` wrapper, not `data`', async () => {
+      const devices = [
+        {
+          deviceId: PAIR_INIT.deviceId,
+          signingKey: 'BaseFiftyEightSigningKey',
+          isSelf: true,
+          revoked: false,
+          applications: [],
+          namespaces: ['5'.repeat(64)],
+        },
+      ];
+      mock.setMockResponse('GET', '/admin-api/account/devices', { devices });
+      const result = await client.listAccountDevices();
+      // `applications: []` survives as-is: on a device entry an empty list means
+      // EVERY application, so normalizing it away would invert its meaning.
+      expect(result).toEqual(devices);
+      expect(result[0].applications).toEqual([]);
+    });
+
+    it('listAccountApplications reads the top-level `applications` wrapper, not `data`', async () => {
+      const applications = [{ applicationId: 'App1BaseFiftyEight', namespaces: ['5'.repeat(64)] }];
+      mock.setMockResponse('GET', '/admin-api/account/applications', { applications });
+      expect(await client.listAccountApplications()).toEqual(applications);
+    });
+  });
+
   describe('Group Management', () => {
     it('getGroupInfo unwraps data with all fields', async () => {
       const info = {

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -752,7 +752,7 @@ export class AdminApiClient {
   // ---- Account Devices & Pairing ----
 
   /**
-   * Mint this node a device for an account that already lives somewhere else —
+   * Mint this node a device for an account that already lives somewhere else -
    * the first half of pairing, run on the joining node.
    *
    * Publishes nothing and needs no key: it produces the device id, the two
@@ -764,8 +764,8 @@ export class AdminApiClient {
    * Takes a set of namespaces rather than one, and takes it from the caller
    * because this node cannot discover it: a node that is a member of nothing can
    * neither read the account's namespace set off a DAG nor derive it. One device
-   * covers however many are named — the certificate is over the account, not a
-   * scope — so there is one id and one code to hand over regardless.
+   * covers however many are named - the certificate is over the account, not a
+   * scope - so there is one id and one code to hand over regardless.
    */
   async initAccountPairing(request: AccountPairInitRequest): Promise<AccountPairInitResponseData> {
     return unwrap(
@@ -774,7 +774,7 @@ export class AdminApiClient {
   }
 
   /**
-   * Certify a device another node minted, link it, and deliver its scope keys —
+   * Certify a device another node minted, link it, and deliver its scope keys -
    * the second half of pairing, run on the node that holds the account root.
    *
    * Every field but `applications` is copied verbatim out of that node's
@@ -783,7 +783,7 @@ export class AdminApiClient {
    * holds it.
    *
    * The scope is named in applications, not namespaces, because that is the
-   * question a person can answer — a namespace is an implementation unit they
+   * question a person can answer - a namespace is an implementation unit they
    * never chose. Leave it out to grant every application.
    */
   async completeAccountPairing(
@@ -800,13 +800,13 @@ export class AdminApiClient {
    *
    * Pairing is a snapshot, and this is how it is repeated. A namespace created
    * or joined afterwards holds no binding for a device paired before it, and the
-   * symptom is silence — the device simply never sees that namespace. Nothing
+   * symptom is silence - the device simply never sees that namespace. Nothing
    * but the id is needed to repair it: the certificate is already held here,
    * root-signed and naming no namespace, so a fresh endorsement and a key wrap
    * are all a later namespace is missing. The device does not have to be online.
    *
    * Passing `applications` widens the device's stored scope as well as
-   * repairing. Passing none — or an empty list — repairs against the scope
+   * repairing. Passing none - or an empty list - repairs against the scope
    * already stored, which is deliberately NOT the "every application" that an
    * empty list means on {@link completeAccountPairing}: overloading it here
    * would make the accidental request the widest one.
@@ -824,7 +824,7 @@ export class AdminApiClient {
   }
 
   /**
-   * Every device of this account, as this node sees them — its own included.
+   * Every device of this account, as this node sees them - its own included.
    *
    * Joined from the node-local certificate cache and the live bindings of every
    * namespace this node takes part in, so it is this node's view rather than a
@@ -846,7 +846,7 @@ export class AdminApiClient {
    * What a device-scoping UI lists: {@link completeAccountPairing} and
    * {@link relinkAccountDevice} both take applications, and this is where the
    * ids they take come from. Derived from the namespaces this node takes part
-   * in, so an application installed with no namespace yet is absent — it has
+   * in, so an application installed with no namespace yet is absent - it has
    * nothing to scope a device to until one exists.
    *
    * Wrapped in `applications` on the wire rather than `data`, unwrapped here for

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -59,6 +59,14 @@ import type {
   Namespace,
   NamespaceIdentity,
   NodeIdentity,
+  AccountPairInitRequest,
+  AccountPairInitResponseData,
+  AccountPairCompleteRequest,
+  AccountPairCompleteResponseData,
+  RelinkDeviceRequest,
+  RelinkDeviceResponseData,
+  AccountDeviceEntry,
+  AccountApplicationEntry,
   GroupInfoResponseData,
   DeleteGroupRequest,
   DeleteGroupResponseData,
@@ -739,6 +747,116 @@ export class AdminApiClient {
 
   async listNamespaceGroups(namespaceId: string): Promise<SubgroupEntry[]> {
     return unwrap(await this.httpClient.get<{ data: SubgroupEntry[] }>(`/admin-api/namespaces/${namespaceId}/groups`));
+  }
+
+  // ---- Account Devices & Pairing ----
+
+  /**
+   * Mint this node a device for an account that already lives somewhere else —
+   * the first half of pairing, run on the joining node.
+   *
+   * Publishes nothing and needs no key: it produces the device id, the two
+   * public keys and the signature that the account holder's
+   * {@link completeAccountPairing} certifies, plus a code to read out to them
+   * over a channel the payload does not travel on. Until that second half runs,
+   * the device this mints is inert.
+   *
+   * Takes a set of namespaces rather than one, and takes it from the caller
+   * because this node cannot discover it: a node that is a member of nothing can
+   * neither read the account's namespace set off a DAG nor derive it. One device
+   * covers however many are named — the certificate is over the account, not a
+   * scope — so there is one id and one code to hand over regardless.
+   */
+  async initAccountPairing(request: AccountPairInitRequest): Promise<AccountPairInitResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: AccountPairInitResponseData }>('/admin-api/account/pair-init', request),
+    );
+  }
+
+  /**
+   * Certify a device another node minted, link it, and deliver its scope keys —
+   * the second half of pairing, run on the node that holds the account root.
+   *
+   * Every field but `applications` is copied verbatim out of that node's
+   * {@link initAccountPairing} answer. Only this side can complete it: the
+   * certificate is signed by the account root, which never leaves the node that
+   * holds it.
+   *
+   * The scope is named in applications, not namespaces, because that is the
+   * question a person can answer — a namespace is an implementation unit they
+   * never chose. Leave it out to grant every application.
+   */
+  async completeAccountPairing(
+    request: AccountPairCompleteRequest,
+  ): Promise<AccountPairCompleteResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: AccountPairCompleteResponseData }>('/admin-api/account/pair-complete', request),
+    );
+  }
+
+  /**
+   * Re-run the pairing fan-out for a device this account already certified,
+   * against the namespaces this node takes part in now.
+   *
+   * Pairing is a snapshot, and this is how it is repeated. A namespace created
+   * or joined afterwards holds no binding for a device paired before it, and the
+   * symptom is silence — the device simply never sees that namespace. Nothing
+   * but the id is needed to repair it: the certificate is already held here,
+   * root-signed and naming no namespace, so a fresh endorsement and a key wrap
+   * are all a later namespace is missing. The device does not have to be online.
+   *
+   * Passing `applications` widens the device's stored scope as well as
+   * repairing. Passing none — or an empty list — repairs against the scope
+   * already stored, which is deliberately NOT the "every application" that an
+   * empty list means on {@link completeAccountPairing}: overloading it here
+   * would make the accidental request the widest one.
+   */
+  async relinkAccountDevice(
+    deviceId: string,
+    request?: RelinkDeviceRequest,
+  ): Promise<RelinkDeviceResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: RelinkDeviceResponseData }>(
+        `/admin-api/account/devices/${deviceId}/relink`,
+        request ?? {},
+      ),
+    );
+  }
+
+  /**
+   * Every device of this account, as this node sees them — its own included.
+   *
+   * Joined from the node-local certificate cache and the live bindings of every
+   * namespace this node takes part in, so it is this node's view rather than a
+   * global one: a device certified by another holder appears with an empty
+   * `applications`, because the certificate that would name its scope is not
+   * cached here.
+   *
+   * The wire wraps this in `devices` rather than the usual `data`; the array is
+   * what a caller wants, so that wrapper is not passed on.
+   */
+  async listAccountDevices(): Promise<AccountDeviceEntry[]> {
+    const response = await this.httpClient.get<{ devices: AccountDeviceEntry[] }>('/admin-api/account/devices');
+    return response.devices;
+  }
+
+  /**
+   * Every application this account speaks in, with the namespaces targeting each.
+   *
+   * What a device-scoping UI lists: {@link completeAccountPairing} and
+   * {@link relinkAccountDevice} both take applications, and this is where the
+   * ids they take come from. Derived from the namespaces this node takes part
+   * in, so an application installed with no namespace yet is absent — it has
+   * nothing to scope a device to until one exists.
+   *
+   * Wrapped in `applications` on the wire rather than `data`, unwrapped here for
+   * the same reason {@link listAccountDevices} unwraps `devices`.
+   */
+  async listAccountApplications(): Promise<AccountApplicationEntry[]> {
+    const response = await this.httpClient.get<{ applications: AccountApplicationEntry[] }>(
+      '/admin-api/account/applications',
+    );
+    return response.applications;
   }
 
   // ---- Group Management ----

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -569,15 +569,15 @@ export interface SubgroupEntry {
  * code to read out to them.
  *
  * Account-level, and that is the whole point of it: both credentials pairing
- * mints were always account-wide — the certificate is root-signed and the
- * endorsement node-level, so neither ever named a namespace — while the older
+ * mints were always account-wide - the certificate is root-signed and the
+ * endorsement node-level, so neither ever named a namespace - while the older
  * per-namespace route still made the caller name one, and the device then
  * listened on that one topic while its holder's link fanned out across all of
  * them.
  */
 export interface AccountPairInitRequest {
   /**
-   * The epoch-0 root **public** key of the account to join, 64 hex characters —
+   * The epoch-0 root **public** key of the account to join, 64 hex characters -
    * exactly what {@link NodeIdentity.accountRootPublicKey} reports on the node
    * that already holds the account.
    *
@@ -591,7 +591,7 @@ export interface AccountPairInitRequest {
    * a device certified into nothing listens on no topic.
    *
    * The caller has to supply these, because the joining node cannot discover
-   * them — it is a member of nothing and holds no scope key, so it can neither
+   * them - it is a member of nothing and holds no scope key, so it can neither
    * read the account's namespace set off a DAG nor derive it. The device that
    * already holds the account is the only party that knows it.
    *
@@ -610,7 +610,7 @@ export interface AccountPairInitRequest {
  * the base58 a key is written in elsewhere here. These are round-trip tokens: a
  * caller copies them verbatim into
  * {@link AdminApiClient.completeAccountPairing}, which parses them back as hex,
- * and nothing compares them against a key from anywhere else — the signing key
+ * and nothing compares them against a key from anywhere else - the signing key
  * is the NEW device's, which appears in no member listing yet. So the convention
  * that matters is the one inside the payload, and it is uniform.
  *
@@ -627,7 +627,7 @@ export interface AccountPairInitResponseData {
   /**
    * The Ed25519 key this device signs its ops with, hex.
    *
-   * The account holder cannot derive this — it is minted here — and the
+   * The account holder cannot derive this - it is minted here - and the
    * certificate names it, so it has to travel with the other two.
    */
   signPublicKey: string;
@@ -653,7 +653,7 @@ export interface AccountPairInitResponseData {
 /**
  * Certify a device another node minted, link it, and deliver its scope keys.
  *
- * The second half of pairing, run on the node that holds the account root — the
+ * The second half of pairing, run on the node that holds the account root - the
  * only party that can sign the certificate that makes the device real. Every
  * field but `applications` is copied verbatim from that other node's
  * {@link AccountPairInitResponseData}.
@@ -679,7 +679,7 @@ export interface AccountPairCompleteRequest {
    *
    * Required so the comparison cannot be skipped: this side re-derives the code
    * for the key material that actually arrived and refuses a mismatch. Its value
-   * rests on the code reaching the holder independently of this payload — sent
+   * rests on the code reaching the holder independently of this payload - sent
    * beside the keys, it proves nothing. One code covers the whole pairing,
    * because one device was minted for it.
    */
@@ -689,7 +689,7 @@ export interface AccountPairCompleteRequest {
    * every one of them.
    *
    * Scoped by application rather than by namespace because a person can answer
-   * "which apps may this device use" and cannot answer "which namespaces" — a
+   * "which apps may this device use" and cannot answer "which namespaces" - a
    * namespace is an implementation unit they never named. The node resolves
    * these to namespaces through the same lookup
    * {@link AdminApiClient.listNamespacesForApplication} reads.
@@ -706,13 +706,13 @@ export interface AccountPairCompleteResponseData {
   /**
    * Whether the current scope key was wrapped and published for the device.
    *
-   * `false` does not mean pairing failed — the link is what confers authority,
+   * `false` does not mean pairing failed - the link is what confers authority,
    * and the device's own sync pull re-requests the key. It does mean the device
    * cannot read until that lands.
    */
   keyDelivered: boolean;
   /**
-   * The code for the key material this certified — the same value the request
+   * The code for the key material this certified - the same value the request
    * carried, echoed so the operator can see what the certificate names.
    */
   confirmationCode: string;
@@ -721,7 +721,7 @@ export interface AccountPairCompleteResponseData {
    *
    * The certified device needs this to present itself as a device of the
    * account, and cannot read it off the DAG: doing so means being a member of a
-   * group the account speaks in, which a thin client never is. Not a secret — a
+   * group the account speaks in, which a thin client never is. Not a secret - a
    * certificate is public and proves nothing without the device key it names.
    */
   credential: string;
@@ -734,7 +734,7 @@ export interface AccountPairCompleteResponseData {
  * time, so a namespace created or joined afterwards holds no binding for it and
  * the paired device silently never sees that namespace. This re-runs the fan-out
  * against the namespaces this node takes part in now. The device need not be
- * online, and nothing but its id is required — the certificate is already held
+ * online, and nothing but its id is required - the certificate is already held
  * here, root-signed and naming no namespace, so a fresh endorsement and a key
  * wrap are all a later namespace is missing.
  */
@@ -805,7 +805,7 @@ export interface AccountDeviceEntry {
   /** This device's id, 64 hex characters. */
   deviceId: string;
   /**
-   * The key this device signs its ops with, base58 — not hex, unlike the ids
+   * The key this device signs its ops with, base58 - not hex, unlike the ids
    * around it, and unlike the same key inside a pairing payload.
    */
   signingKey: string;
@@ -814,7 +814,7 @@ export interface AccountDeviceEntry {
   revoked: boolean;
   /**
    * Applications this device may speak for, base58. **Empty means every
-   * application**, the same convention the stored certificate uses — and the
+   * application**, the same convention the stored certificate uses - and the
    * opposite of what an empty {@link RelinkDeviceRequest.applications} asks for.
    * Empty also for a device this node holds no cached certificate for: one bound
    * before the cache existed, or certified by another holder.

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -557,6 +557,291 @@ export interface SubgroupEntry {
   name?: string;
 }
 
+// ---- Account devices & pairing ----
+
+/**
+ * Adopt an account that already lives on another device, and mint this node a
+ * device of its own for it.
+ *
+ * The first half of pairing, run on the joining node. It publishes nothing and
+ * needs no key: it produces the values the account holder's
+ * {@link AdminApiClient.completeAccountPairing} certifies, plus a confirmation
+ * code to read out to them.
+ *
+ * Account-level, and that is the whole point of it: both credentials pairing
+ * mints were always account-wide — the certificate is root-signed and the
+ * endorsement node-level, so neither ever named a namespace — while the older
+ * per-namespace route still made the caller name one, and the device then
+ * listened on that one topic while its holder's link fanned out across all of
+ * them.
+ */
+export interface AccountPairInitRequest {
+  /**
+   * The epoch-0 root **public** key of the account to join, 64 hex characters —
+   * exactly what {@link NodeIdentity.accountRootPublicKey} reports on the node
+   * that already holds the account.
+   *
+   * Named for the half it carries. An ed25519 private and public key are both 32
+   * bytes and both hex, so nothing but the name tells them apart; the private
+   * root never crosses this boundary at all.
+   */
+  accountRootPublicKey: string;
+  /**
+   * Ids of the namespaces to enroll into, 64 hex characters each. At least one:
+   * a device certified into nothing listens on no topic.
+   *
+   * The caller has to supply these, because the joining node cannot discover
+   * them — it is a member of nothing and holds no scope key, so it can neither
+   * read the account's namespace set off a DAG nor derive it. The device that
+   * already holds the account is the only party that knows it.
+   *
+   * This decides what the new device *listens* on, and it does not have to agree
+   * with the applications the holder scopes `pair-complete` to: a binding
+   * published where the device is not listening is picked up whenever it does
+   * subscribe, and a subscription the holder never reaches costs nothing.
+   */
+  namespaces: string[];
+}
+
+/**
+ * What the joining device minted, for the account holder to certify.
+ *
+ * Every field is hex, including the two public keys, and deliberately so against
+ * the base58 a key is written in elsewhere here. These are round-trip tokens: a
+ * caller copies them verbatim into
+ * {@link AdminApiClient.completeAccountPairing}, which parses them back as hex,
+ * and nothing compares them against a key from anywhere else — the signing key
+ * is the NEW device's, which appears in no member listing yet. So the convention
+ * that matters is the one inside the payload, and it is uniform.
+ *
+ * One device is minted however many namespaces were named, so there is one of
+ * each of these to hand over, not one per namespace.
+ */
+export interface AccountPairInitResponseData {
+  /** The account this device will speak for once linked, 64 hex characters. */
+  accountId: string;
+  /** The device that was minted, 64 hex characters. */
+  deviceId: string;
+  /** X25519 agreement key a scope key must be wrapped under to reach this device, hex. */
+  kemPublicKey: string;
+  /**
+   * The Ed25519 key this device signs its ops with, hex.
+   *
+   * The account holder cannot derive this — it is minted here — and the
+   * certificate names it, so it has to travel with the other two.
+   */
+  signPublicKey: string;
+  /**
+   * Ed25519 signature over the account, the device id and both keys above, hex.
+   *
+   * Carried so the three values arrive as a statement by the device that minted
+   * them rather than as assertions by whoever relayed them; `pair-complete`
+   * refuses without it.
+   */
+  statement: string;
+  /**
+   * The value to read out to the account holder, who compares it against what
+   * their `pair-complete` reports.
+   *
+   * The part a substituting attacker cannot fake: it can re-sign its own
+   * statement, but it would have to make its own keys derive the code the other
+   * side is already reading.
+   */
+  confirmationCode: string;
+}
+
+/**
+ * Certify a device another node minted, link it, and deliver its scope keys.
+ *
+ * The second half of pairing, run on the node that holds the account root — the
+ * only party that can sign the certificate that makes the device real. Every
+ * field but `applications` is copied verbatim from that other node's
+ * {@link AccountPairInitResponseData}.
+ */
+export interface AccountPairCompleteRequest {
+  /** The `deviceId` the other node minted, 64 hex characters. */
+  deviceId: string;
+  /** That device's X25519 agreement key, 64 hex characters. */
+  kemPublicKey: string;
+  /** That device's Ed25519 signing key, 64 hex characters. */
+  signPublicKey: string;
+  /**
+   * The signature from that node's pair-init, 128 hex characters (64 bytes).
+   *
+   * Not optional: without it the three values above are only claims by whoever
+   * sent them, and certifying those would make attacker-supplied keys a trusted
+   * device of this account.
+   */
+  statement: string;
+  /**
+   * The code the account holder read off the pairing device, e.g.
+   * `7BC0-DAAC-CCB4-84A4`. Grouping and case are ignored.
+   *
+   * Required so the comparison cannot be skipped: this side re-derives the code
+   * for the key material that actually arrived and refuses a mismatch. Its value
+   * rests on the code reaching the holder independently of this payload — sent
+   * beside the keys, it proves nothing. One code covers the whole pairing,
+   * because one device was minted for it.
+   */
+  confirmationCode: string;
+  /**
+   * Which applications this device may speak for, base58. Omitted or empty means
+   * every one of them.
+   *
+   * Scoped by application rather than by namespace because a person can answer
+   * "which apps may this device use" and cannot answer "which namespaces" — a
+   * namespace is an implementation unit they never named. The node resolves
+   * these to namespaces through the same lookup
+   * {@link AdminApiClient.listNamespacesForApplication} reads.
+   */
+  applications?: string[];
+}
+
+/** What pairing established. */
+export interface AccountPairCompleteResponseData {
+  /** The account the device now speaks for, 64 hex characters. */
+  accountId: string;
+  /** The device that was linked, 64 hex characters. */
+  deviceId: string;
+  /**
+   * Whether the current scope key was wrapped and published for the device.
+   *
+   * `false` does not mean pairing failed — the link is what confers authority,
+   * and the device's own sync pull re-requests the key. It does mean the device
+   * cannot read until that lands.
+   */
+  keyDelivered: boolean;
+  /**
+   * The code for the key material this certified — the same value the request
+   * carried, echoed so the operator can see what the certificate names.
+   */
+  confirmationCode: string;
+  /**
+   * The `AccountProof<DeviceCert>` this pairing minted, hex-encoded borsh.
+   *
+   * The certified device needs this to present itself as a device of the
+   * account, and cannot read it off the DAG: doing so means being a member of a
+   * group the account speaks in, which a thin client never is. Not a secret — a
+   * certificate is public and proves nothing without the device key it names.
+   */
+  credential: string;
+}
+
+/**
+ * Repair or widen the reach of a device this account already certified.
+ *
+ * Pairing is a snapshot: it bound the device wherever this node took part at the
+ * time, so a namespace created or joined afterwards holds no binding for it and
+ * the paired device silently never sees that namespace. This re-runs the fan-out
+ * against the namespaces this node takes part in now. The device need not be
+ * online, and nothing but its id is required — the certificate is already held
+ * here, root-signed and naming no namespace, so a fresh endorsement and a key
+ * wrap are all a later namespace is missing.
+ */
+export interface RelinkDeviceRequest {
+  /**
+   * Applications to add to the device's stored scope, base58.
+   *
+   * **Omitted or empty changes nothing** and repairs against the scope already
+   * stored, which is the request an operator makes to heal drift. Note that this
+   * is the one place an empty list does not mean "all": widening a narrow scope
+   * to every application is deliberately not expressible here, because
+   * overloading the empty list would make the accidental request the widest one.
+   */
+  applications?: string[];
+}
+
+/** One namespace the relink published the device's link into. */
+export interface RelinkOutcomeEntry {
+  /** The namespace id, 64 hex characters. */
+  namespaceId: string;
+  /**
+   * Whether the scope key was wrapped and published for the device here.
+   *
+   * `false` means the link landed and the delivery did not; the link is what
+   * confers authority, and the device's own sync pull re-requests the key.
+   */
+  keyDelivered: boolean;
+}
+
+/** One namespace the relink published nothing into, and why. */
+export interface RelinkSkipEntry {
+  /** The namespace id, 64 hex characters. */
+  namespaceId: string;
+  /**
+   * Why nothing was published there. Currently one of `outOfScope`,
+   * `alreadyBound`, `noScopeKey`, `revoked`, `ownDevice`, `failed`; left as a
+   * string because a node may report a reason newer than this SDK.
+   */
+  reason: string;
+}
+
+/** What the relink repaired, and what it left alone. */
+export interface RelinkDeviceResponseData {
+  /** The account the device speaks for, 64 hex characters. */
+  accountId: string;
+  /** The device that was repaired, 64 hex characters. */
+  deviceId: string;
+  /**
+   * The device's scope after the request, base58. Empty means every
+   * application, which is what a pairing that named none asked for.
+   */
+  applications: string[];
+  /**
+   * Namespaces the link was published into by this call. Reported per namespace
+   * because publication is per-DAG, so which namespaces a device actually
+   * reached is a state the caller has to be able to see.
+   */
+  linkedIn: RelinkOutcomeEntry[];
+  /** Namespaces nothing was published into. */
+  skipped: RelinkSkipEntry[];
+}
+
+/**
+ * One device of this account, joined from the node-local certificate cache and
+ * the live bindings of every namespace this node takes part in.
+ */
+export interface AccountDeviceEntry {
+  /** This device's id, 64 hex characters. */
+  deviceId: string;
+  /**
+   * The key this device signs its ops with, base58 — not hex, unlike the ids
+   * around it, and unlike the same key inside a pairing payload.
+   */
+  signingKey: string;
+  /** Set only on the device this node itself presents. */
+  isSelf: boolean;
+  revoked: boolean;
+  /**
+   * Applications this device may speak for, base58. **Empty means every
+   * application**, the same convention the stored certificate uses — and the
+   * opposite of what an empty {@link RelinkDeviceRequest.applications} asks for.
+   * Empty also for a device this node holds no cached certificate for: one bound
+   * before the cache existed, or certified by another holder.
+   */
+  applications: string[];
+  /**
+   * Ids of the namespaces currently holding a live binding for this device, 64
+   * hex characters each. Empty for a certified device not yet bound anywhere.
+   */
+  namespaces: string[];
+}
+
+/**
+ * One application this account speaks in, derived from the namespaces this node
+ * takes part in that target it.
+ *
+ * An application installed with no namespace yet is absent here: it has no
+ * cross-device meaning until a namespace exists, so there is nothing to scope a
+ * device to.
+ */
+export interface AccountApplicationEntry {
+  /** The application id, base58. */
+  applicationId: string;
+  /** Ids of the namespaces targeting it, 64 hex characters each. */
+  namespaces: string[];
+}
+
 // ---- Groups ----
 
 export interface CreateGroupRequest {

--- a/tests/e2e/account-pairing.test.ts
+++ b/tests/e2e/account-pairing.test.ts
@@ -1,0 +1,177 @@
+/**
+ * E2E for the account-level device pairing surface.
+ *
+ * Requires a running merod node with embedded auth. The CI workflow starts it
+ * before running these tests.
+ *
+ * Run manually:
+ *   NODE_URL=http://localhost:4001 pnpm test:e2e -- account-pairing
+ *
+ * ONE NODE, so the pairing ceremony itself cannot be driven here: pair-init runs
+ * on the joining device and pair-complete on the account holder, and the whole
+ * point of the exchange is that those are different machines. What a single node
+ * can settle is everything around it - the two listings, the half that mints
+ * (which needs no second party), and the refusals, which are asserted by status
+ * because a typed status is the thing this surface added: a client used to get a
+ * 500 for every one of them. The two-node happy path lives in core's own
+ * scenarios, which build merod from the branch.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication } from './harness.js';
+import type { AccountPairInitResponseData, NodeIdentity } from '../../src/admin-api/admin-types.js';
+
+const NODE_URL = resolveBaseUrl();
+const { username: USERNAME, password: PASSWORD } = resolveCreds();
+
+/** Ids on this surface are 64 hex characters; keys beside them are base58. */
+const HEX_32_BYTES = /^[0-9a-f]{64}$/;
+const HEX_64_BYTES = /^[0-9a-f]{128}$/;
+
+let mero: MeroJs;
+let applicationId: string;
+let namespaceId: string;
+let identity: NodeIdentity;
+/** Set when the node under test predates these routes; every test then skips. */
+let routesMissing = false;
+/** Carried from the pair-init test into the refusal that needs a real payload. */
+let offer: AccountPairInitResponseData | undefined;
+
+describe('Account devices & pairing E2E', () => {
+  beforeAll(async () => {
+    mero = new MeroJs({ baseUrl: NODE_URL });
+    await mero.authenticate({ username: USERNAME, password: PASSWORD });
+    applicationId = await ensureApplication(mero);
+    // Taking part in a namespace is what mints this node's account root, and it
+    // has to happen before the probe below: the listing answers 404 both for a
+    // node that holds no account and for a node too old to serve the route, and
+    // only the second is a reason to skip. With an account in hand, a 404 can
+    // only mean the route is absent.
+    namespaceId = (await mero.admin.createNamespace({ applicationId })).namespaceId;
+    identity = await mero.admin.getNodeIdentity();
+
+    try {
+      await mero.admin.listAccountDevices();
+    } catch (e) {
+      if ((e as { status?: number }).status !== 404) throw e;
+      routesMissing = true;
+      console.log('(skip) account routes absent - this merod predates them');
+    }
+  }, 60000);
+
+  afterAll(async () => {
+    if (namespaceId) await mero.admin.deleteNamespace(namespaceId).catch(() => {});
+    mero.close();
+  }, 60000);
+
+  it('lists the account devices this node can see, in the encodings it documents', async (ctx) => {
+    if (routesMissing) return ctx.skip();
+
+    const devices = await mero.admin.listAccountDevices();
+    const participating = (await mero.admin.listNamespaces()).map((ns) => ns.namespaceId);
+
+    // Which devices are here depends on what this node has certified and what is
+    // bound where, and a fresh single node may legitimately have none. What does
+    // not depend on that is the shape, and the shape is what a caller writes
+    // against - an id it reads as base58 because it was rendered hex is a bug
+    // that surfaces as "no such device" far from here.
+    for (const device of devices) {
+      expect(device.deviceId).toMatch(HEX_32_BYTES);
+      expect(typeof device.signingKey).toBe('string');
+      // The one field on this entry that is NOT hex. It is a key, and a key is
+      // base58 here - unlike the same key inside a pairing payload, which is hex
+      // because that payload is round-tripped rather than compared.
+      expect(device.signingKey).not.toMatch(HEX_32_BYTES);
+      expect(typeof device.isSelf).toBe('boolean');
+      expect(typeof device.revoked).toBe('boolean');
+      expect(Array.isArray(device.applications)).toBe(true);
+      for (const ns of device.namespaces) {
+        expect(ns).toMatch(HEX_32_BYTES);
+        // The listing is built from the namespaces this node takes part in, so
+        // one it does not is a namespace the join leaked in from somewhere.
+        expect(participating).toContain(ns);
+      }
+    }
+
+    // At most one device can be this one, and if the listing names it at all it
+    // has to be the device the identity endpoint reports. Two sources for one
+    // fact, and they are allowed to disagree only by omission: the identity
+    // route reads the held device directly while this one reads live bindings,
+    // so a device with no binding yet is absent here and present there.
+    const selves = devices.filter((d) => d.isSelf);
+    expect(selves.length).toBeLessThanOrEqual(1);
+    if (selves.length === 1) expect(selves[0].deviceId).toBe(identity.deviceId);
+  });
+
+  it('names the application this account speaks in, against the namespace targeting it', async (ctx) => {
+    if (routesMissing) return ctx.skip();
+
+    const applications = await mero.admin.listAccountApplications();
+    // Deterministic, unlike the device listing: `beforeAll` created a namespace
+    // targeting this application and this node takes part in it, which is
+    // exactly the derivation behind this route.
+    const entry = applications.find((a) => a.applicationId === applicationId);
+    expect(entry).toBeTruthy();
+    expect(entry!.namespaces).toContain(namespaceId);
+    // Base58, matching every other application id on the admin API, while the
+    // namespaces beside it are hex. The mixture is the contract.
+    expect(entry!.applicationId).not.toMatch(HEX_32_BYTES);
+  });
+
+  it('mints a pairing device for the account root it is handed', async (ctx) => {
+    if (routesMissing) return ctx.skip();
+    // Absent on a node at or below `0.11.0-rc.22`. A node serving these routes
+    // is newer than that, so this should not fire - but reading the root off the
+    // node is what keeps this test from carrying a hardcoded account, and a
+    // missing root is a reason to skip rather than to invent one.
+    if (!identity.accountRootPublicKey) return ctx.skip();
+
+    offer = await mero.admin.initAccountPairing({
+      accountRootPublicKey: identity.accountRootPublicKey,
+      namespaces: [namespaceId],
+    });
+
+    // Every field hex, including the two public keys, and that is the whole
+    // claim being checked: these are round-trip tokens copied verbatim into
+    // pair-complete, so a field rendered base58 to match keys elsewhere would
+    // fail to parse at the other end of a ceremony that has already asked a
+    // human to read a code aloud.
+    expect(offer.accountId).toMatch(HEX_32_BYTES);
+    expect(offer.deviceId).toMatch(HEX_32_BYTES);
+    expect(offer.kemPublicKey).toMatch(HEX_32_BYTES);
+    expect(offer.signPublicKey).toMatch(HEX_32_BYTES);
+    expect(offer.statement).toMatch(HEX_64_BYTES);
+    expect(offer.confirmationCode.trim()).not.toBe('');
+    // One device however many namespaces were named, so the id is not derived
+    // from the namespace it was asked about.
+    expect(offer.deviceId).not.toBe(namespaceId);
+  });
+
+  it('refuses a completion whose confirmation code does not match, as a 400', async (ctx) => {
+    if (routesMissing || !offer) return ctx.skip();
+
+    // A real offer with the one value a substituting attacker cannot forge
+    // replaced. The status is the assertion: this refusal, and the invalid
+    // statement beside it, are the two the API types as "fix the payload", and
+    // both used to reach a client as an untyped 500.
+    await expect(
+      mero.admin.completeAccountPairing({
+        deviceId: offer.deviceId,
+        kemPublicKey: offer.kemPublicKey,
+        signPublicKey: offer.signPublicKey,
+        statement: offer.statement,
+        confirmationCode: 'AAAA-BBBB-CCCC-DDDD',
+      }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+
+  it('refuses a relink of a device it never certified, as a 404', async (ctx) => {
+    if (routesMissing) return ctx.skip();
+
+    // Well-formed and certainly unknown: relink repairs a device this node holds
+    // a certificate for, and it holds none for an id of zeros. A 404 here is
+    // that refusal and not a missing route - `beforeAll` already established the
+    // routes are served.
+    await expect(mero.admin.relinkAccountDevice('0'.repeat(64))).rejects.toMatchObject({ status: 404 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds SDK coverage for core's account-level device pairing surface (calimero-network/core#3657): five `AdminApiClient` methods with fully documented types.

- `initAccountPairing(request)` - `POST /admin-api/account/pair-init`.
  Runs on the device being added; takes the account root public key and the namespace set, returns the minted identity, statement, and confirmation code.
- `completeAccountPairing(request)` - `POST /admin-api/account/pair-complete`.
  Runs on the account holder; optional `applications` scope, absent or empty meaning every application.
- `relinkAccountDevice(deviceId, applications?)` - `POST /admin-api/account/devices/:id/relink`.
  Repairs a device's missing bindings, or widens its scope when `applications` is present - an empty array deliberately means "no change", not "all", matching the server.
- `listAccountDevices()` - `GET /admin-api/account/devices`, returning each device's scope, live bindings, revocation state, and an `isSelf` marker.
- `listAccountApplications()` - `GET /admin-api/account/applications`.

Types document the wire encodings the way the server does: device ids and namespaces are 64-hex, signing keys and application ids are base58, the pairing payload's key material is hex, and an empty `applications` on a device entry means every application.

No runtime dependencies added; the package stays dependency-free.

## Test plan

- 7 unit tests over a mocked transport: each method hits the right path and method, sends the documented body (including keeping `applications` off the wire when omitted), and unwraps the right envelope - `{data}` for the pairing and relink responses, top-level for the two listings.
  15 deliberate mutations of the client (wrong path, dropped field, wrong envelope) were each observed to turn a test red before the suite was trusted.
- 5 e2e specs following the suite's runtime-gating convention: a `beforeAll` first creates a namespace (so the node holds an account root), after which a 404 can only mean the routes are absent and the suite skips.
  Verified both ways against a local stub: all five pass and are recorded by the coverage recorder when the routes are served, and the suite skips cleanly when they are not.
  Their first run against a real node needs a merod containing calimero-network/core#3657.
- `pnpm build`, all typecheck configs, and lint are clean; full unit suite: 314 passed, 1 skipped.
