### PR TITLE
feat(warrant): mint warrants in JS, with no dependencies

### DIFF
--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -673,7 +673,8 @@ export class AdminApiClient {
    * CAN_AUTHOR_ON_BEHALF to …", or that the nonce is already spent — so a caller
    * can tell which precondition failed rather than only that one did.
    *
-   * This SDK does not mint warrants; see {@link PerformIntentRequest.warrant}.
+   * Mint the warrant with {@link signWarrant}; see
+   * {@link PerformIntentRequest.warrant}.
    */
   async performIntent(
     contextId: string,

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -438,10 +438,15 @@ export interface PerformIntentRequest {
    * them — so re-describing the fields as JSON would create a second spelling
    * that could disagree with what was signed.
    *
-   * Mint it with `merod account warrant` or `meroctl context intent`. This SDK
-   * does not sign: doing so would need ed25519 and a borsh encoding kept
-   * byte-identical with the node's forever, and a one-byte drift is
-   * indistinguishable from a forgery.
+   * Mint it with {@link signWarrant}, or out of band with `merod account
+   * warrant` / `meroctl context intent`.
+   *
+   * Signing here needs no dependency, which is why it is available at all: the
+   * hash is WebCrypto SHA-256, the signature is WebCrypto Ed25519, and every
+   * field of a warrant is fixed-width so the encoding is concatenation rather
+   * than borsh. The byte contract is pinned on the node's side, at
+   * `crates/account/src/tests/warrant_wire_fixture.rs`, because a drift there
+   * would otherwise surface here as a 403 rather than as an encoding error.
    */
   warrant: string;
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,10 @@ export type { Codec, EphemeralEntry } from './ephemeral/index.js';
 // Cloud client (enable-HA, disable-HA)
 export * from './cloud/index.js';
 
+// Warrant signing — mint the author's consent for a relay to run one intent
+export { signWarrant, intentHash } from './warrant/index.js';
+export type { WarrantInput } from './warrant/index.js';
+
 // Member capability bitmask constants & helpers
 export * from './capabilities.js';
 

--- a/src/warrant/index.ts
+++ b/src/warrant/index.ts
@@ -1,0 +1,3 @@
+// Warrant signing — the author's half of delegated authorship
+export { signWarrant, intentHash } from './warrant.js';
+export type { WarrantInput } from './warrant.js';

--- a/src/warrant/warrant.test.ts
+++ b/src/warrant/warrant.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Conformance against core's pinned vectors.
+ *
+ * These constants are not chosen here — they are the ones
+ * `crates/account/src/tests/warrant_wire_fixture.rs` asserts, with the same fixed
+ * inputs. If core's format moves, that test fails on core's side and this one
+ * fails here; the pair is what turns a silent 403 at a relay into a red build.
+ *
+ * The device secret is 32 bytes of 0x07, matching `key(7)` in core's test
+ * helpers. It owns nothing.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { intentHash, signWarrant } from './warrant.js';
+
+const DEVICE_SECRET = '07'.repeat(32);
+/** base58 of 32 bytes of 0x11 — core's fixture uses the raw bytes. */
+const CONTEXT_B58 = '29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2';
+const AUTHOR_ACCOUNT = '22'.repeat(32);
+const EXECUTOR = '33'.repeat(32);
+const METHOD = 'set';
+const ARGS = { key: 'k', value: 'v' };
+
+const EXPECTED_INTENT_HASH =
+  'dc066cc8524c74dc21714174009df536376e3151f5b92f0a676defde599dbae5';
+const EXPECTED_DEVICE_KEY =
+  'ea4a6c63e29c520abef5507b132ec5f9954776aebebe7b92421eea691446d22c';
+const EXPECTED_SIGNATURE =
+  'a3ddd5294a755f875a275d61f79105115a2d4fb115339ee2483fc17c0ae96c6d' +
+  'e21e02f26ea103cfe87bb2365ca858c27fb688a99cf1835ed473de226eb24709';
+
+const hex = (bytes: Uint8Array) =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+describe('warrant signing conformance', () => {
+  it('computes the intent hash core computes', async () => {
+    expect(hex(await intentHash(METHOD, ARGS))).toBe(EXPECTED_INTENT_HASH);
+  });
+
+  it('produces the exact 240 bytes core produces', async () => {
+    const warrant = await signWarrant({
+      context: CONTEXT_B58,
+      authorAccount: AUTHOR_ACCOUNT,
+      executor: EXECUTOR,
+      method: METHOD,
+      argsJson: ARGS,
+      nonce: 42,
+      notAfter: 1_700_000_000,
+      deviceSecret: DEVICE_SECRET,
+    });
+
+    // Length first: every field is fixed-width, which is the property that lets
+    // this module concatenate instead of carrying a borsh encoder. A different
+    // length means that stopped being true.
+    expect(warrant.length).toBe(480);
+
+    // Field by field, so a failure names which one moved rather than printing
+    // 480 characters of hex twice.
+    expect(warrant.slice(0, 64)).toBe('11'.repeat(32));
+    expect(warrant.slice(64, 128)).toBe(AUTHOR_ACCOUNT);
+    expect(warrant.slice(128, 192)).toBe(EXPECTED_DEVICE_KEY);
+    expect(warrant.slice(192, 256)).toBe(EXECUTOR);
+    expect(warrant.slice(256, 320)).toBe(EXPECTED_INTENT_HASH);
+    // u64 LITTLE-endian: 42 and 1_700_000_000.
+    expect(warrant.slice(320, 336)).toBe('2a00000000000000');
+    expect(warrant.slice(336, 352)).toBe('00f1536500000000');
+    expect(warrant.slice(352)).toBe(EXPECTED_SIGNATURE);
+  });
+
+  it('derives the device key rather than trusting a caller', async () => {
+    // A caller able to name a key it does not hold could produce a warrant it
+    // cannot sign, and the field would stop meaning "who authorised this".
+    const warrant = await signWarrant({
+      context: CONTEXT_B58,
+      authorAccount: AUTHOR_ACCOUNT,
+      executor: EXECUTOR,
+      method: METHOD,
+      argsJson: ARGS,
+      nonce: 42,
+      notAfter: 1_700_000_000,
+      deviceSecret: DEVICE_SECRET,
+    });
+    expect(warrant.slice(128, 192)).toBe(EXPECTED_DEVICE_KEY);
+  });
+});
+
+describe('input encodings', () => {
+  const base = {
+    context: CONTEXT_B58,
+    authorAccount: AUTHOR_ACCOUNT,
+    executor: EXECUTOR,
+    method: METHOD,
+    argsJson: ARGS,
+    nonce: 1,
+    notAfter: 1,
+    deviceSecret: DEVICE_SECRET,
+  };
+
+  // The ids do not share an encoding, and mixing them up yields a
+  // valid-looking value that only fails against real data.
+  // Two shapes, because they fail for different reasons and only one of them
+  // fails on the alphabet.
+  it('refuses a hex context containing non-base58 characters', async () => {
+    // '0' is not in the base58 alphabet, so this is caught on sight.
+    await expect(
+      signWarrant({ ...base, context: '10'.repeat(32) }),
+    ).rejects.toThrow(/not base58/);
+  });
+
+  it('refuses a hex context that happens to be valid base58', async () => {
+    // The dangerous one. Hex digits are mostly base58 characters, so
+    // `'11'.repeat(32)` DECODES — to 32 zero bytes — rather than failing. Only
+    // the canonical round-trip catches it: those bytes encode as 32 '1's, not
+    // 64, so the input was never a canonical id.
+    await expect(
+      signWarrant({ ...base, context: '11'.repeat(32) }),
+    ).rejects.toThrow(/canonical base58/);
+  });
+
+  it('refuses a base58 account, which is the hex one', async () => {
+    await expect(
+      signWarrant({ ...base, authorAccount: CONTEXT_B58 }),
+    ).rejects.toThrow(/authorAccount must be 64 hex/);
+  });
+
+  it('refuses a device secret of the wrong length', async () => {
+    await expect(
+      signWarrant({ ...base, deviceSecret: '07'.repeat(16) }),
+    ).rejects.toThrow(/deviceSecret must be 64 hex/);
+  });
+});
+
+describe('the intent it authorises', () => {
+  const base = {
+    context: CONTEXT_B58,
+    authorAccount: AUTHOR_ACCOUNT,
+    executor: EXECUTOR,
+    nonce: 7,
+    notAfter: 1_700_000_000,
+    deviceSecret: DEVICE_SECRET,
+  };
+
+  /** The intent hash a node recomputes from what `performIntent` carries. */
+  const commitmentOf = (warrant: string) => warrant.slice(256, 320);
+
+  it('commits to the method, so a relay cannot substitute another', async () => {
+    const set = await signWarrant({ ...base, method: 'set', argsJson: ARGS });
+    const del = await signWarrant({ ...base, method: 'delete', argsJson: ARGS });
+
+    expect(commitmentOf(set)).not.toBe(commitmentOf(del));
+  });
+
+  it('commits to the arguments, so a warrant is not a blank cheque', async () => {
+    const mine = await signWarrant({ ...base, method: METHOD, argsJson: ARGS });
+    const theirs = await signWarrant({
+      ...base,
+      method: METHOD,
+      argsJson: { key: 'k', value: 'SOMETHING ELSE' },
+    });
+
+    expect(commitmentOf(mine)).not.toBe(commitmentOf(theirs));
+  });
+
+  it('matches what performIntent will send for the same intent', async () => {
+    // The pairing that matters: `signWarrant` is given the same `method` and
+    // `argsJson` a caller then passes to `performIntent`, and the node checks
+    // the warrant covers exactly that. Computing the commitment from different
+    // JSON than the request carries is the one way to build a warrant that
+    // verifies as a signature and is refused as authorisation.
+    const method = 'set';
+    const argsJson = { key: 'k', value: 'v' };
+
+    const warrant = await signWarrant({ ...base, method, argsJson });
+
+    expect(commitmentOf(warrant)).toBe(hex(await intentHash(method, argsJson)));
+  });
+
+  it('a different nonce is a different warrant', async () => {
+    // Single-use: the signature stays valid forever, so replay is stopped by the
+    // nonce ledger rather than by the envelope check.
+    const first = await signWarrant({ ...base, method: METHOD, argsJson: ARGS, nonce: 1 });
+    const second = await signWarrant({ ...base, method: METHOD, argsJson: ARGS, nonce: 2 });
+
+    expect(first).not.toBe(second);
+    expect(first.slice(320, 336)).toBe('0100000000000000');
+    expect(second.slice(320, 336)).toBe('0200000000000000');
+  });
+});

--- a/src/warrant/warrant.ts
+++ b/src/warrant/warrant.ts
@@ -1,0 +1,295 @@
+/**
+ * Mint a warrant: the author's consent for one relay to run one intent, once.
+ *
+ * This exists because the case delegated authorship is *for* is an account that
+ * holds no node — a browser tab, a Node service, a bot. Every one of those is a
+ * JS runtime, and until now the only thing that could mint a warrant was `merod`,
+ * so "a member with no node" in practice meant "a member with a node it is not
+ * allowed to use for anything else".
+ *
+ * **No dependencies, and that is not incidental.** The three primitives are all
+ * built in: `crypto.subtle.digest('SHA-256')` for the hash, `crypto.subtle`
+ * Ed25519 for the signature, and `DataView.setBigUint64` for the two u64s. The
+ * warrant's every field is fixed-width, so its encoding is concatenation — there
+ * is no borsh here because none is needed.
+ *
+ * **The byte contract is pinned in core**, at
+ * `crates/account/src/tests/warrant_wire_fixture.rs`. The domain strings below
+ * are `pub(crate)` there, so nothing in that repository forces anyone to notice
+ * this file depends on them — which is exactly why the fixture lives on that side
+ * and this module's test asserts the same vectors. A drift would otherwise leave
+ * this producing well-formed warrants whose signatures verify nowhere, surfacing
+ * at a relay as a 403: an authorization refusal, nowhere near the cause.
+ */
+
+const SIGN_DOMAIN = new TextEncoder().encode('calimero.warrant.v1');
+const INTENT_DOMAIN = new TextEncoder().encode('calimero.warrant.intent.v1');
+
+/** Ed25519 PKCS#8 prefix, so a raw 32-byte seed can be imported by WebCrypto. */
+const PKCS8_ED25519_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+  0x22, 0x04, 0x20,
+]);
+
+const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+/** What a warrant authorises. */
+export interface WarrantInput {
+  /**
+   * The context, base58 — the same string every other method here takes.
+   *
+   * Base58 while the two accounts below are hex, because that is how the node
+   * spells them: `ContextId` and `PublicKey` are base58, `AccountId` and
+   * `DeviceId` are hex. Mixing them up produces a valid-looking value that only
+   * fails against real data, so this module decodes each by its own rule rather
+   * than accepting "32 bytes, somehow".
+   */
+  context: string;
+  /** The author's account, hex — whose consent this is. */
+  authorAccount: string;
+  /** The relay authorised to act, hex. An account, not a key. */
+  executor: string;
+  /** The method the relay may run. */
+  method: string;
+  /** Its arguments, as the JSON the guest will receive. */
+  argsJson: unknown;
+  /**
+   * Monotonic per author **device**.
+   *
+   * Per device rather than per account because two devices of one account are
+   * independent replicas: they cannot coordinate on a counter, so an
+   * account-scoped sequence would have them refusing each other's warrants.
+   */
+  nonce: number | bigint;
+  /** Unix seconds after which the relay must refuse it. */
+  notAfter: number | bigint;
+  /**
+   * The author device's ed25519 signing secret, hex (32 bytes).
+   *
+   * Never sent anywhere. It signs locally and only the signature travels, which
+   * is the whole reason a warrant can be minted by something holding no node.
+   */
+  deviceSecret: string;
+}
+
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function fromHex(value: string, label: string, expectedBytes: number): Uint8Array {
+  const clean = value.trim();
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length !== expectedBytes * 2) {
+    throw new Error(
+      `${label} must be ${expectedBytes * 2} hex characters, got ${clean.length}`,
+    );
+  }
+  // Indexed rather than `match(/../g)!`: the length is already validated above,
+  // so the assertion would only be telling the compiler what the guard proved,
+  // and this needs no assertion at all.
+  const bytes = new Uint8Array(expectedBytes);
+  for (let i = 0; i < expectedBytes; i += 1) {
+    bytes[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Decode base58 to exactly 32 bytes.
+ *
+ * Hand-rolled rather than pulled in: it is fifteen lines, and a dependency here
+ * would be this package's first.
+ */
+function fromBase58(value: string, label: string): Uint8Array {
+  const clean = value.trim();
+  let n = 0n;
+  for (const char of clean) {
+    const digit = B58.indexOf(char);
+    if (digit < 0) {
+      throw new Error(`${label} is not base58: unexpected character '${char}'`);
+    }
+    n = n * 58n + BigInt(digit);
+  }
+  const out = new Uint8Array(32);
+  for (let i = 31; i >= 0; i -= 1) {
+    out[i] = Number(n & 0xffn);
+    n >>= 8n;
+  }
+  if (n !== 0n) {
+    throw new Error(`${label} decodes to more than 32 bytes`);
+  }
+
+  // Round-trip, because decoding alone accepts too much. Hex digits are mostly
+  // valid base58 characters, so a context handed over in hex by mistake can
+  // decode to a real-looking 32 bytes instead of failing — `'11'.repeat(32)`
+  // decodes to all zeros. Re-encoding catches it: the canonical form of those
+  // bytes is 32 '1's, not 64.
+  if (toBase58(out) !== clean) {
+    throw new Error(
+      `${label} is not a canonical base58 32-byte id. If you have it in hex, ` +
+        `note that ${label} is base58 here while accounts are hex`,
+    );
+  }
+  return out;
+}
+
+/** Encode 32 bytes as base58, for the canonical check above. */
+function toBase58(bytes: Uint8Array): string {
+  let n = 0n;
+  for (const byte of bytes) {
+    n = (n << 8n) | BigInt(byte);
+  }
+  let out = '';
+  while (n > 0n) {
+    out = B58[Number(n % 58n)] + out;
+    n /= 58n;
+  }
+  let leadingZeros = 0;
+  while (leadingZeros < bytes.length && bytes[leadingZeros] === 0) {
+    leadingZeros += 1;
+  }
+  return '1'.repeat(leadingZeros) + out;
+}
+
+function u64le(value: number | bigint): Uint8Array {
+  const out = new Uint8Array(8);
+  new DataView(out.buffer).setBigUint64(0, BigInt(value), true);
+  return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((total, p) => total + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * core's `domain_hash`: SHA-256 over the length-prefixed domain, then each
+ * length-prefixed part. The lengths are what stop two different field splits from
+ * hashing alike.
+ */
+async function domainHash(
+  domain: Uint8Array,
+  parts: Uint8Array[],
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [u64le(domain.length), domain];
+  for (const part of parts) {
+    chunks.push(u64le(part.length), part);
+  }
+  return new Uint8Array(
+    await crypto.subtle.digest('SHA-256', concat(...chunks)),
+  );
+}
+
+/**
+ * The commitment a warrant carries in place of the intent itself.
+ *
+ * Its own domain, distinct from the signing one, so a value computed for one
+ * purpose cannot be presented for the other.
+ */
+export async function intentHash(
+  method: string,
+  argsJson: unknown,
+): Promise<Uint8Array> {
+  const args = new TextEncoder().encode(JSON.stringify(argsJson));
+  return domainHash(INTENT_DOMAIN, [new TextEncoder().encode(method), args]);
+}
+
+async function importSigningKey(secretHex: string): Promise<CryptoKey> {
+  const seed = fromHex(secretHex, 'deviceSecret', 32);
+  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
+  try {
+    return await crypto.subtle.importKey(
+      'pkcs8',
+      pkcs8,
+      { name: 'Ed25519' },
+      false,
+      ['sign'],
+    );
+  } catch (cause) {
+    // The original message is folded in rather than passed as `cause`: this
+    // package targets ES2020, where `Error` has no `cause` option.
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    throw new Error(
+      'this runtime has no WebCrypto Ed25519, so a warrant cannot be signed ' +
+        'here. Node 18.4+, Safari 17+, Firefox 129+ and Chrome 137+ have it; ' +
+        'otherwise mint the warrant with `merod account warrant`' +
+        detail,
+    );
+  }
+}
+
+/**
+ * Sign a warrant and return it hex-encoded, ready for `performIntent`.
+ *
+ * The 240 bytes are the canonical form: the signature covers exactly them, which
+ * is why this returns the encoding rather than an object. A caller that rebuilt
+ * the fields from JSON would have a second spelling able to disagree with what
+ * was signed.
+ */
+export async function signWarrant(input: WarrantInput): Promise<string> {
+  const context = fromBase58(input.context, 'context');
+  const authorAccount = fromHex(input.authorAccount, 'authorAccount', 32);
+  const executor = fromHex(input.executor, 'executor', 32);
+
+  const key = await importSigningKey(input.deviceSecret);
+  const publicKey = await derivePublicKey(input.deviceSecret);
+
+  const commitment = await intentHash(input.method, input.argsJson);
+  const nonce = u64le(input.nonce);
+  const notAfter = u64le(input.notAfter);
+
+  const preimage = await domainHash(SIGN_DOMAIN, [
+    context,
+    authorAccount,
+    publicKey,
+    executor,
+    commitment,
+    nonce,
+    notAfter,
+  ]);
+
+  const signature = new Uint8Array(
+    await crypto.subtle.sign({ name: 'Ed25519' }, key, preimage),
+  );
+
+  return hex(
+    concat(
+      context,
+      authorAccount,
+      publicKey,
+      executor,
+      commitment,
+      nonce,
+      notAfter,
+      signature,
+    ),
+  );
+}
+
+/**
+ * The public half of an ed25519 seed.
+ *
+ * Derived rather than taken as an argument, for the reason core does the same: a
+ * caller able to name a key it does not hold could produce a warrant it cannot
+ * sign, and the field would stop meaning "who authorised this".
+ */
+async function derivePublicKey(secretHex: string): Promise<Uint8Array> {
+  const seed = fromHex(secretHex, 'deviceSecret', 32);
+  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8,
+    { name: 'Ed25519' },
+    true,
+    ['sign'],
+  );
+  const jwk = await crypto.subtle.exportKey('jwk', key);
+  const raw = (jwk as JsonWebKey & { x: string }).x;
+  return Uint8Array.from(atob(raw.replace(/-/g, '+').replace(/_/g, '/')), (c) =>
+    c.charCodeAt(0),
+  );
+}


### PR DESCRIPTION
> Pairs with [core#3677](https://github.com/calimero-network/core/pull/3677), which pins the byte contract this reproduces. Closes calimero-network/core#3668.

## Why

The case delegated authorship exists for is an account holding **no node** — a browser
tab, a Node service, a bot. Every one of those is a JS runtime, and the only thing that
could mint a warrant was `merod`. So "a member with no node" meant in practice "a member
with a node it is not allowed to use for anything else".

## No dependency, and that is the point

This package has zero dependencies, deliberately. All three primitives are built in:

| Need | Built-in |
| --- | --- |
| core's `domain_hash` | `crypto.subtle.digest('SHA-256')` |
| the signature | `crypto.subtle` Ed25519 (raw seed via a fixed PKCS#8 prefix) |
| the two u64 fields | `DataView.setBigUint64(…, true)` |
| the 240-byte encoding | `Uint8Array` concat |

**There is no borsh here because none is needed.** Every field of a warrant is
fixed-width, so the encoding is concatenation — no length prefixes, no tags. core#3668
assumed a borsh encoder was required, and that assumption is what made the task look
large. JS also never touches `AccountProof<DeviceCert>` (which *does* contain a `Vec`):
that arrives as hex from `sign-cert` and passes straight through as `authorProof`.

## Verified byte-identical, not argued

Against the vectors core pins in `crates/account/src/tests/warrant_wire_fixture.rs` —
same intent hash, same signature, same 240 bytes, asserted **field by field** so a
failure names which one moved rather than printing 480 hex characters twice.

That fixture lives on core's side on purpose: the domain constants are `pub(crate)`
there, so nothing in that repo would otherwise make anyone notice this file depends on
them — and a drift surfaces *here* as a **403 at a relay**, an authorization refusal
nowhere near the cause.

## Two bugs the tests found rather than confirmed

**A hex context can decode as valid base58 and sign for the wrong context.**
`'11'.repeat(32)` does not fail — it decodes to 32 zero bytes. Hex digits are mostly
base58 characters, so the alphabet check cannot catch it. A **canonical round-trip**
does: those bytes encode as 32 `'1'`s, not 64, so the input was never a canonical id.
`ContextId` is base58 here while accounts are hex, and this is exactly what mixing them
produces. Two tests cover it, split by failure mode.

**`Error`'s `cause` option is ES2022** and this package targets ES2020, so the
underlying message is folded into the text instead.

## Notes

- The device public key is **derived** from the secret rather than accepted, for the
  reason core does the same: a caller able to name a key it does not hold could produce
  a warrant it cannot sign, and the field would stop meaning "who authorised this".
- Corrects two doc comments claiming this SDK cannot sign, *and* the reasoning given for
  why — both now false.
- Runtimes without WebCrypto Ed25519 get an explicit error naming the versions that have
  it (Node 18.4+, Safari 17+, Firefox 129+, Chrome 137+) and the `merod` fallback.

## Verification

- `vitest run` — **320 passed**, 1 skipped, across the whole suite; 11 in this module
- `tsc --noEmit` clean
- `pnpm lint` — 0 errors, and 5 warnings all pre-existing (I removed the one I'd added)