### PR TITLE
ci: give the two-node e2e its only discovery path back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,20 @@ jobs:
 
       - name: Boot 2 merod nodes (embedded auth)
         run: |
-          ./merod --home ./n1 --node n1 init --server-port 4501 --swarm-port 4601 --auth-mode embedded
-          ./merod --home ./n2 --node n2 init --server-port 4502 --swarm-port 4602 --auth-mode embedded
+          # --mdns is load-bearing, not tidy-up. These two nodes have no
+          # bootstrap peer and no rendezvous, so mDNS is their ONLY discovery
+          # path. merod left it on by default until core#3620 ("leave mDNS off
+          # unless asked for"), which first shipped in 0.11.0-rc.26 — and this
+          # job downloads the LATEST release, so it broke the moment rc.26 was
+          # cut, on a run that changed nothing here.
+          #
+          # The symptom points nowhere near the cause: node-2 finds no mesh
+          # peer, falls back to gossip, KeyDelivery times out after 5s, and the
+          # join refuses with a 500. That refusal is correct — a member that
+          # cannot decrypt anything should not land — so the bug reads as
+          # "namespace join is broken" rather than "the nodes never met".
+          ./merod --home ./n1 --node n1 init --server-port 4501 --swarm-port 4601 --auth-mode embedded --mdns
+          ./merod --home ./n2 --node n2 init --server-port 4502 --swarm-port 4602 --auth-mode embedded --mdns
           ./merod --home ./n1 --node n1 run > n1.log 2>&1 & echo $! > n1.pid
           ./merod --home ./n2 --node n2 run > n2.log 2>&1 & echo $! > n2.pid
           for port in 4501 4502; do


### PR DESCRIPTION
## What broke

`Multi-node E2E (vs released merod)` is failing on **every** PR, including ones that
change nothing near it. Mine is just the one that happened to run next.

The two nodes are booted with **no bootstrap peer and no rendezvous**, so mDNS is their
only way to find each other. merod left it on by default until
[core#3620](https://github.com/calimero-network/core/pull/3620) — *"leave mDNS off unless
asked for"* — which first shipped in **0.11.0-rc.26**. This job downloads the *latest*
release, so it broke the moment rc.26 was cut.

Verified rather than guessed: `#3620` is in rc.26 and **not** in rc.25, and every green
run used rc.25.

## Why the symptom points nowhere near the cause

From the uploaded node logs:

```
WARN  could not open a namespace-join stream to any mesh peer
      (deadline 45000ms, elapsed 44067ms, excluded 0)
WARN  join response contained no group key
ERROR KeyDelivery timed out … join cannot proceed without a usable group key
```

node-2 finds no mesh peer, falls back to gossip, key delivery times out, and the join
returns **500**.

**That refusal is correct** — a member who cannot decrypt anything should not land. So
the failure reads as *"namespace join is broken"*, which is why it cost real time to
trace, and it lands on whoever pushes next.

## Why `--mdns` and not `--boot-nodes`

`--boot-nodes` needs node-1's **PeerId**, so it means booting n1, reading its peer id,
then initialising n2 — three phases and more failure modes than the single flag that
used to be the default. mDNS demonstrably works on these runners: it carried every green
run until rc.26.

Also worth flagging upstream: **`merod config --swarm-addrs`, which core's CLAUDE.md
still documents for exactly this two-node setup, no longer exists** — `config` now takes
generic key-value pairs. That doc is stale.

## No new waits

The existing health poll is a condition check, not a sleep, and the join call retries
internally against a 45s deadline — so discovery has time without anything blind being
added.

## Scope

Deliberately separate from #116 (the warrant signer), which is red only because of this.
This is CI-only, unblocks every mero-js PR rather than one, and can land on its own
merits.