### PR TITLE
fix(warrant)!: the context is hex, and base58 is gone from this package

### DIFF
--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -1,23 +1,23 @@
 /**
  * Account id encoding.
  *
- * Core names the same account in two encodings, and the split is deliberate:
- * the admin API serves and requires **64 hex characters**, while contract data
- * (`sender`, `get_profiles`, anything stamped by `env::account_id()`) carries
- * **base58**. They are rendered differently on purpose, so that handing one
- * where the other is expected fails loudly instead of resolving to the wrong
- * principal.
+ * **Core is hex everywhere now** — the admin API and every other id it spells.
+ * This module used to describe a deliberate split, hex on the admin API against
+ * base58 in contract data, and the core half of that is gone.
  *
- * The cost is that any client reading a member from the admin API and
- * comparing it against a message sender is comparing two spellings of the same
- * value. A raw `===` silently never matches, and passing a contract-sourced id
- * to an admin route answers `400 Invalid account format: expected 64 hex
- * characters (32 bytes)`. Both failure modes are quiet enough to ship.
+ * The app half can remain. `env::account_id()` hands a guest 32 **raw bytes**,
+ * not a string, so whatever an app stores in `sender` or keys `get_profiles` by
+ * is the app's own rendering. An app that base58-encodes those bytes still
+ * produces contract data that a hex admin id will not `===` — and for that app,
+ * these helpers are still the boundary.
  *
- * These helpers canonicalise at that boundary. They convert accounts and
- * nothing else: a device key, an alias or any other value is returned
- * unchanged, because converting is this module's job and destroying what it
- * cannot convert is not.
+ * So they stay, with their reason corrected: the mismatch they bridge is an
+ * application convention, not something core imposes. An app that hex-encodes
+ * needs none of this, and `toAccountHex` is a no-op on what it already holds.
+ *
+ * They convert accounts and nothing else: a device key, an alias or any other
+ * value is returned unchanged, because converting is this module's job and
+ * destroying what it cannot convert is not.
  */
 
 const BASE58_ALPHABET =

--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -844,7 +844,8 @@ export class AdminApiClient {
 
   /**
    * `identity` is the member's ACCOUNT (64 hex), as returned by
-   * {@link listGroupMembers} — not the bs58 signing key that added them.
+   * {@link listGroupMembers} — not the signing key that added them. Both are
+   * 64 hex, so nothing but the source tells them apart.
    */
   async updateMemberRole(
     groupId: string,
@@ -856,7 +857,8 @@ export class AdminApiClient {
 
   /**
    * `identity` is the member's ACCOUNT (64 hex), as returned by
-   * {@link listGroupMembers} — not the bs58 signing key that added them.
+   * {@link listGroupMembers} — not the signing key that added them. Both are
+   * 64 hex, so nothing but the source tells them apart.
    */
   async getMemberCapabilities(groupId: string, identity: string): Promise<MemberCapabilities> {
     return unwrap(
@@ -868,7 +870,8 @@ export class AdminApiClient {
 
   /**
    * `identity` is the member's ACCOUNT (64 hex), as returned by
-   * {@link listGroupMembers} — not the bs58 signing key that added them.
+   * {@link listGroupMembers} — not the signing key that added them. Both are
+   * 64 hex, so nothing but the source tells them apart.
    */
   async setMemberCapabilities(
     groupId: string,
@@ -935,7 +938,8 @@ export class AdminApiClient {
 
   /**
    * `identity` is the member's ACCOUNT (64 hex), as returned by
-   * {@link listGroupMembers} — not the bs58 signing key that added them.
+   * {@link listGroupMembers} — not the signing key that added them. Both are
+   * 64 hex, so nothing but the source tells them apart.
    */
   async getMemberMetadata(groupId: string, identity: string): Promise<MetadataRecord | null> {
     // Single-enveloped record; see getGroupMetadata.
@@ -1147,7 +1151,8 @@ export class AdminApiClient {
    * /admin-api/groups/:group_id/members/:identity/auto-follow).
    *
    * `identity` is the member's ACCOUNT (64 hex), as returned by
-   * {@link listGroupMembers} — not the bs58 signing key that added them.
+   * {@link listGroupMembers} — not the signing key that added them. Both are
+   * 64 hex, so nothing but the source tells them apart.
    */
   async setMemberAutoFollow(
     groupId: string,

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -357,7 +357,7 @@ export interface SignedGroupOpenInvitation {
   readonly invitation: GroupInvitationFromAdmin;
   readonly inviter_signature: string;
   /**
-   * The account the inviter acts as, as 64 hex characters — not the bs58 the
+   * The account the inviter acts as, as 64 hex characters — not the
    * `inviter_identity` key inside the signed body is written in. Governance
    * rows name accounts, and a joiner cannot derive this one: an account is a
    * hash of a root it has never seen.
@@ -492,7 +492,7 @@ export interface NodeIdentity {
    */
   deviceId: string | null;
   /**
-   * The key this node signs ops with, base58.
+   * The key this node signs ops with, 64 hex.
    *
    * The device's signing key, not the account root: the root signs
    * certificates and never an op, so a signature on the wire verifies against
@@ -520,7 +520,7 @@ export interface NodeIdentity {
 export interface NamespaceIdentity {
   /** Echoed back from the argument; it does not describe the identity. */
   namespaceId: string;
-  /** The key this node signs with, base58. */
+  /** The key this node signs with, 64 hex. */
   publicKey: string;
   /**
    * The account this node writes as, 64 hex characters. This — not
@@ -590,7 +590,7 @@ export interface JoinNamespaceResponseData {
    * which is always set.
    */
   groupId?: string;
-  /** The key the joiner signs with, base58. */
+  /** The key the joiner signs with, 64 hex. */
   memberIdentity: string;
   /**
    * The account that key joined as, 64 hex characters. This — not
@@ -748,7 +748,7 @@ export interface GroupMember {
   /**
    * The member's ACCOUNT: 64 hex characters.
    *
-   * Not a signing key, which renders as bs58 — a person may hold several keys
+   * Not a signing key — a person may hold several keys
    * and governance rows name the person. Both are 32 bytes, so nothing here or
    * on the server will object if you pass the wrong one; it will simply name a
    * principal that exists nowhere. Feed this value to
@@ -790,7 +790,8 @@ export interface DeleteGroupResponseData {
 
 export interface GroupMemberInput {
   /**
-   * The invitee's signing KEY, in bs58 — NOT an account.
+   * The invitee's signing KEY, 64 hex — NOT an account. It is spelled exactly
+   * like one, so only the field name says which this is.
    *
    * Adding is the one member-facing call that names a key: the node binds the
    * key to an account as it admits it, so before that there is no account to
@@ -1019,7 +1020,7 @@ export interface JoinGroupRequest {
 
 export interface JoinGroupResponseData {
   groupId: string;
-  /** The key the joiner signs with, base58. */
+  /** The key the joiner signs with, 64 hex. */
   memberIdentity: string;
   /**
    * The account that key joined as, 64 hex characters. This — not

--- a/src/events/group.ts
+++ b/src/events/group.ts
@@ -4,7 +4,7 @@ export interface GroupMembershipEventData {
   type: 'MemberJoined' | 'MemberAdded' | 'MemberRemoved';
   data: {
     /** The member's ACCOUNT, hex-encoded 32 bytes (64 chars) - the principal the
-     * governance rows name. Not a bs58 signing key: the field this replaced
+     * governance rows name. Not a signing key: the field this replaced
      * carried one, and both are strings, so the rename is what makes a stale
      * consumer fail loudly instead of comparing accounts against keys forever. */
     memberAccount: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export * from './admin-api/index.js';
 export { parseAuthCallback, buildAuthLoginUrl } from './auth/index.js';
 export type { AuthCallbackResult, AuthLoginOptions } from './auth/index.js';
 
-// Account id encoding (hex on the admin API, base58 in contract data)
+// Account id encoding (hex everywhere core spells one; an app may re-encode)
 export {
   toAccountHex,
   toAccountBase58,

--- a/src/warrant/warrant.test.ts
+++ b/src/warrant/warrant.test.ts
@@ -14,7 +14,9 @@ import { describe, expect, it } from 'vitest';
 import { intentHash, signWarrant } from './warrant.js';
 
 const DEVICE_SECRET = '07'.repeat(32);
-/** base58 of 32 bytes of 0x11 — core's fixture uses the raw bytes. */
+/** 32 bytes of 0x11 — the same bytes core's fixture uses, now spelled in hex. */
+const CONTEXT = '11'.repeat(32);
+/** The same bytes in base58, which this module no longer accepts anywhere. */
 const CONTEXT_B58 = '29d2S7vB453rNYFdR5Ycwt7y9haRT5fwVwL9zTmBhfV2';
 const AUTHOR_ACCOUNT = '22'.repeat(32);
 const EXECUTOR = '33'.repeat(32);
@@ -39,7 +41,7 @@ describe('warrant signing conformance', () => {
 
   it('produces the exact 240 bytes core produces', async () => {
     const warrant = await signWarrant({
-      context: CONTEXT_B58,
+      context: CONTEXT,
       authorAccount: AUTHOR_ACCOUNT,
       executor: EXECUTOR,
       method: METHOD,
@@ -71,7 +73,7 @@ describe('warrant signing conformance', () => {
     // A caller able to name a key it does not hold could produce a warrant it
     // cannot sign, and the field would stop meaning "who authorised this".
     const warrant = await signWarrant({
-      context: CONTEXT_B58,
+      context: CONTEXT,
       authorAccount: AUTHOR_ACCOUNT,
       executor: EXECUTOR,
       method: METHOD,
@@ -86,7 +88,7 @@ describe('warrant signing conformance', () => {
 
 describe('input encodings', () => {
   const base = {
-    context: CONTEXT_B58,
+    context: CONTEXT,
     authorAccount: AUTHOR_ACCOUNT,
     executor: EXECUTOR,
     method: METHOD,
@@ -96,28 +98,27 @@ describe('input encodings', () => {
     deviceSecret: DEVICE_SECRET,
   };
 
-  // The ids do not share an encoding, and mixing them up yields a
-  // valid-looking value that only fails against real data.
-  // Two shapes, because they fail for different reasons and only one of them
-  // fails on the alphabet.
-  it('refuses a hex context containing non-base58 characters', async () => {
-    // '0' is not in the base58 alphabet, so this is caught on sight.
+  // Every id on this interface is hex now, so there is one rule and base58 is
+  // simply not it. This inverts two tests that pinned the opposite — that a hex
+  // context was refused, once on the alphabet and once by a canonical
+  // round-trip, because `context` was base58 while the accounts were hex.
+  it('refuses a base58 context', async () => {
     await expect(
-      signWarrant({ ...base, context: '10'.repeat(32) }),
-    ).rejects.toThrow(/not base58/);
+      signWarrant({ ...base, context: CONTEXT_B58 }),
+    ).rejects.toThrow(/context must be 64 hex/);
   });
 
-  it('refuses a hex context that happens to be valid base58', async () => {
-    // The dangerous one. Hex digits are mostly base58 characters, so
-    // `'11'.repeat(32)` DECODES — to 32 zero bytes — rather than failing. Only
-    // the canonical round-trip catches it: those bytes encode as 32 '1's, not
-    // 64, so the input was never a canonical id.
+  it('accepts the hex that used to be refused as non-canonical base58', async () => {
+    // This exact string was the dangerous case: hex digits are mostly base58
+    // characters, so `'11'.repeat(32)` decoded to 32 zero bytes rather than
+    // failing, and only a canonical round-trip caught it. With one alphabet
+    // there is nothing to confuse it with — it is the context, and it signs.
     await expect(
       signWarrant({ ...base, context: '11'.repeat(32) }),
-    ).rejects.toThrow(/canonical base58/);
+    ).resolves.toMatch(/^[0-9a-f]+$/);
   });
 
-  it('refuses a base58 account, which is the hex one', async () => {
+  it('refuses a base58 account', async () => {
     await expect(
       signWarrant({ ...base, authorAccount: CONTEXT_B58 }),
     ).rejects.toThrow(/authorAccount must be 64 hex/);
@@ -132,7 +133,7 @@ describe('input encodings', () => {
 
 describe('the intent it authorises', () => {
   const base = {
-    context: CONTEXT_B58,
+    context: CONTEXT,
     authorAccount: AUTHOR_ACCOUNT,
     executor: EXECUTOR,
     nonce: 7,

--- a/src/warrant/warrant.ts
+++ b/src/warrant/warrant.ts
@@ -31,18 +31,15 @@ const PKCS8_ED25519_PREFIX = new Uint8Array([
   0x22, 0x04, 0x20,
 ]);
 
-const B58 = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-
 /** What a warrant authorises. */
 export interface WarrantInput {
   /**
-   * The context, base58 — the same string every other method here takes.
+   * The context, hex — the same string every other method here takes.
    *
-   * Base58 while the two accounts below are hex, because that is how the node
-   * spells them: `ContextId` and `PublicKey` are base58, `AccountId` and
-   * `DeviceId` are hex. Mixing them up produces a valid-looking value that only
-   * fails against real data, so this module decodes each by its own rule rather
-   * than accepting "32 bytes, somehow".
+   * Hex like everything else on this interface. It was base58 while the node
+   * spelled `ContextId` and `PublicKey` that way and `AccountId` and `DeviceId`
+   * in hex; that split is gone, so this module no longer needs a rule per field
+   * and no longer needs a base58 decoder to enforce one.
    */
   context: string;
   /** The author's account, hex — whose consent this is. */
@@ -93,62 +90,6 @@ function fromHex(value: string, label: string, expectedBytes: number): Uint8Arra
   return bytes;
 }
 
-/**
- * Decode base58 to exactly 32 bytes.
- *
- * Hand-rolled rather than pulled in: it is fifteen lines, and a dependency here
- * would be this package's first.
- */
-function fromBase58(value: string, label: string): Uint8Array {
-  const clean = value.trim();
-  let n = 0n;
-  for (const char of clean) {
-    const digit = B58.indexOf(char);
-    if (digit < 0) {
-      throw new Error(`${label} is not base58: unexpected character '${char}'`);
-    }
-    n = n * 58n + BigInt(digit);
-  }
-  const out = new Uint8Array(32);
-  for (let i = 31; i >= 0; i -= 1) {
-    out[i] = Number(n & 0xffn);
-    n >>= 8n;
-  }
-  if (n !== 0n) {
-    throw new Error(`${label} decodes to more than 32 bytes`);
-  }
-
-  // Round-trip, because decoding alone accepts too much. Hex digits are mostly
-  // valid base58 characters, so a context handed over in hex by mistake can
-  // decode to a real-looking 32 bytes instead of failing — `'11'.repeat(32)`
-  // decodes to all zeros. Re-encoding catches it: the canonical form of those
-  // bytes is 32 '1's, not 64.
-  if (toBase58(out) !== clean) {
-    throw new Error(
-      `${label} is not a canonical base58 32-byte id. If you have it in hex, ` +
-        `note that ${label} is base58 here while accounts are hex`,
-    );
-  }
-  return out;
-}
-
-/** Encode 32 bytes as base58, for the canonical check above. */
-function toBase58(bytes: Uint8Array): string {
-  let n = 0n;
-  for (const byte of bytes) {
-    n = (n << 8n) | BigInt(byte);
-  }
-  let out = '';
-  while (n > 0n) {
-    out = B58[Number(n % 58n)] + out;
-    n /= 58n;
-  }
-  let leadingZeros = 0;
-  while (leadingZeros < bytes.length && bytes[leadingZeros] === 0) {
-    leadingZeros += 1;
-  }
-  return '1'.repeat(leadingZeros) + out;
-}
 
 function u64le(value: number | bigint): Uint8Array {
   const out = new Uint8Array(8);
@@ -231,7 +172,7 @@ async function importSigningKey(secretHex: string): Promise<CryptoKey> {
  * was signed.
  */
 export async function signWarrant(input: WarrantInput): Promise<string> {
-  const context = fromBase58(input.context, 'context');
+  const context = fromHex(input.context, 'context', 32);
   const authorAccount = fromHex(input.authorAccount, 'authorAccount', 32);
   const executor = fromHex(input.executor, 'executor', 32);
 

--- a/tests/e2e/ephemeral.test.ts
+++ b/tests/e2e/ephemeral.test.ts
@@ -173,7 +173,11 @@ describe('E2E — ephemeral presence (single node)', () => {
 
     // The default JSON codec round-trips the slice through the node's byte array.
     expect(entry.state).toEqual({ nonce, cursor: { line: 42, col: 7 } });
-    expect(entry.author).toMatch(/^[1-9A-HJ-NP-Za-km-z]+$/); // bs58 identity key
+    // 64 hex. This asserted the bs58 alphabet until core made every id hex, and
+    // the two character classes overlap enough that the old regex kept passing on
+    // most hex strings — it only failed once an id happened to contain a `0`.
+    // Pinning the length as well as the alphabet is what makes it a real check.
+    expect(entry.author).toMatch(/^[0-9a-f]{64}$/); // hex identity key
     // `subscribe` hands callers a real boolean even though the wire omits the field.
     expect(entry.removed).toBe(false);
     // A live delta is fresh at receipt: `ageMs` must be genuinely ABSENT, not 0


### PR DESCRIPTION
Pairs with **calimero-network/core#3691**, which removes base58 from every id.
Merge that first.

## The break

`signWarrant` took `context` in base58 and **explicitly refused hex**, with an
error telling the caller "`context` is base58 here while accounts are hex". That
was right: the node spelled `ContextId` and `PublicKey` in base58 and
`AccountId`/`DeviceId` in hex, so this module decoded each field by its own rule
rather than accepting "32 bytes, somehow".

Core has one rule now, so this has one rule. `context` is 64 hex, and a base58
context is **refused** rather than mis-decoded — the loud failure, which is the
point of not accepting both.

The bytes are unchanged, so a given context produces a byte-identical warrant and
the golden vector needed no edit.

## What that deletes

The hand-rolled base58 decoder, its encoder, and the canonical round-trip check
between them. The round-trip is worth a note, because it is exactly the hazard
this whole migration is about: hex digits are mostly valid base58 characters, so
a hex context **decoded** to real-looking bytes rather than failing —
`'11'.repeat(32)` came out as 32 zero bytes. Only re-encoding and comparing
caught it. With a single alphabet there is nothing to confuse it with.

Two tests inverted accordingly. The one that pinned that dangerous case —
`'11'.repeat(32)` rejected as non-canonical base58 — now asserts the same string
signs, because it is simply the context.

## `src/account` stays

It bridges hex admin ids against base58 in contract data, and only the **core**
half of that split is gone. `env::account_id()` hands a guest 32 raw bytes, not a
string, so whatever an app writes into `sender` is the app's own rendering. An app
that base58-encodes still needs this boundary; one that hex-encodes finds
`toAccountHex` a no-op.

Its docstring claimed core imposed the two encodings. Corrected to attribute the
convention to the application, which is where it actually lives.

## Everything else

Comment-only. Roughly a dozen doc comments described ids as bs58 — including
several saying a member's account is "not the bs58 signing key". Both are 64 hex
now, so nothing but the source distinguishes them, and the comments say that
instead.

## Tests

320 pass, 1 skipped. Build and lint clean; the 5 remaining lint warnings in
`src/account/index.ts` and `docs/` are pre-existing (verified by re-running lint
with this branch's changes stashed).
