### PR TITLE
ci: actually run the delegated-intent suite, and fail if it does not

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,32 @@ jobs:
           MERO_E2E_USER: dev
           MERO_E2E_PASS: dev-password
           NO_COLOR: '1'
+          # The delegated-intent suite mints an author certificate and a warrant
+          # offline, which only merod can do, so it is `describe.skipIf(!MEROD)`.
+          # The binary is already downloaded above; without this it skipped here
+          # and ran ONLY in core's sdk-e2e.yml — so this repo reported green on a
+          # suite it had never executed.
+          MEROD_BINARY: ${{ github.workspace }}/merod
         run: |
           set -o pipefail
           pnpm test:e2e 2>&1 | tee e2e.log
           # Guard against a vacuous/all-skipped green: require at least one passing test.
           grep -qE "[1-9][0-9]* passed" e2e.log \
             || { echo "::error::e2e produced no passing tests — refusing a vacuous pass"; exit 1; }
+          # And specifically that the delegated suite RAN. The guard above is
+          # satisfied by any other file passing, so a silently skipped
+          # delegated-intent would have gone unnoticed indefinitely — which is
+          # exactly what happened until now. `skipIf` reports the file with no
+          # test count, so requiring the count is what distinguishes ran from
+          # skipped.
+          #
+          # Deliberately strict: it matches `(N tests)` but not
+          # `(N tests | M skipped)`, so adding a conditionally-skipped test to
+          # that file trips it. That is the right way round — a skip in this
+          # suite is precisely what is being guarded against, and a loud failure
+          # naming the file beats the silence it replaces.
+          grep -qE "delegated-intent\.test\.ts.*\([0-9]+ tests?\)" e2e.log \
+            || { echo "::error::delegated-intent suite did not run — MEROD_BINARY unset or merod unusable"; exit 1; }
 
       - name: Upload e2e logs
         if: always()


### PR DESCRIPTION
> **Merge after** a core release carrying `merod account warrant --not-after` — calimero-network/core#3698 cuts `rc.28` for exactly this. Until then the byte-comparison test invokes a flag no released merod has, and this job runs the latest release.

## The gap

`delegated-intent.test.ts` is `describe.skipIf(!MEROD)`, and `MEROD_BINARY` is set **only** in core's `sdk-e2e.yml`. So this repo has been skipping it and reporting green on a suite it never ran — the signer's only end-to-end coverage lived in another repo's CI, by accident of which workflow happened to export the variable.

Nothing structurally prevented that continuing indefinitely.

## Two changes

**Run it.** The merod binary is already downloaded for this job, so this is one `env:` line.

**Notice if it stops running.** The existing vacuous-pass guard requires one passing test *anywhere*, which any other file satisfies — it could never have caught this. The new guard requires this file to report a test count, which `skipIf` does not produce:

```
✓ tests/e2e/delegated-intent.test.ts (5 tests) 703ms      → matches
↓ tests/e2e/delegated-intent.test.ts (5 tests | 5 skipped) → does not
```

Both forms checked against real vitest output from the paired run on core#3697.

Strict on purpose: it matches `(N tests)` and not `(N tests | M skipped)`, so a conditionally-skipped test added to this file later trips it. That is the right way round — a skip here is the thing being guarded against, and a loud failure naming the file beats the silence it replaces.