### PR TITLE
test(e2e): restore the byte-parity check against merod

### DIFF
--- a/tests/e2e/delegated-intent.test.ts
+++ b/tests/e2e/delegated-intent.test.ts
@@ -205,11 +205,14 @@ describe.skipIf(!MEROD)('performIntent E2E — delegated authorship', () => {
    * --not-after`, since the deadline is signed over and merod otherwise takes it
    * from its own clock.
    */
-  it('produces the same bytes merod does, for the same inputs', () => {
+  it('produces the same bytes merod does, for the same inputs', async () => {
     const notAfter = deadline();
     const nonce = 99;
 
-    expect(mintWarrant(nonce, notAfter)).resolves.toBe(
+    // Awaited, not left to `.resolves` — an un-awaited assertion is currently
+    // auto-awaited by vitest and will simply stop asserting in vitest 3, which
+    // would leave this passing while comparing nothing.
+    await expect(mintWarrant(nonce, notAfter)).resolves.toBe(
       mintWarrantWithMerod(nonce, notAfter),
     );
   }, 60_000);

--- a/tests/e2e/delegated-intent.test.ts
+++ b/tests/e2e/delegated-intent.test.ts
@@ -16,12 +16,10 @@
  * `merod` is still used for the one thing it alone can do: minting the author's
  * device certificate offline, with a key that never reaches the node.
  *
- * A byte-for-byte comparison against a merod-minted warrant would be stronger
- * and is deliberately absent: `merod account warrant` takes `--valid-for`
- * (seconds from its own clock) rather than an absolute `--not-after`, so the two
- * sides cannot be made to agree on that field, and the signature covers it. Node
- * acceptance is the available proof, and it is the one that matters — it is the
- * node's opinion of these bytes that the SDK exists to satisfy.
+ * It also mints a second warrant over identical inputs so the two
+ * implementations can be diffed directly. That needs `merod account warrant
+ * --not-after`: the deadline is signed over, and merod otherwise reads it from
+ * its own clock, so "the same warrant" minted twice never matched.
  *
  * A test that called the endpoint with a fabricated warrant would register
  * coverage and prove nothing: it would 4xx every time and the ratchet would not
@@ -193,6 +191,30 @@ describe.skipIf(!MEROD)('performIntent E2E — delegated authorship', () => {
   }, 60_000);
 
   /**
+   * The two signers agree byte for byte over identical inputs.
+   *
+   * This is the check the acceptance tests above can only imply. A node saying
+   * yes proves it accepted *these* bytes for *this* one intent; it says nothing
+   * about a field the two implementations encode differently but that this
+   * particular input never exercises, and when it does fail it fails as an
+   * opaque 4xx that names nothing.
+   *
+   * Comparing the hex directly fails at the divergence instead, which is what
+   * makes "a borsh encoding kept byte-identical with the node's forever" a
+   * testable claim rather than a hope. It needs `merod account warrant
+   * --not-after`, since the deadline is signed over and merod otherwise takes it
+   * from its own clock.
+   */
+  it('produces the same bytes merod does, for the same inputs', () => {
+    const notAfter = deadline();
+    const nonce = 99;
+
+    expect(mintWarrant(nonce, notAfter)).resolves.toBe(
+      mintWarrantWithMerod(nonce, notAfter),
+    );
+  }, 60_000);
+
+  /**
    * A warrant over the same intent, at the given nonce — signed by THIS SDK.
    *
    * `notAfter` is Unix seconds, and the window only has to outlast the request.
@@ -200,7 +222,7 @@ describe.skipIf(!MEROD)('performIntent E2E — delegated authorship', () => {
    * being finite, since an unbounded warrant is the thing the field exists to
    * prevent.
    */
-  function mintWarrant(nonce: number): Promise<string> {
+  function mintWarrant(nonce: number, notAfter = deadline()): Promise<string> {
     return signWarrant({
       context: contextId,
       authorAccount: device.account,
@@ -208,9 +230,38 @@ describe.skipIf(!MEROD)('performIntent E2E — delegated authorship', () => {
       method: 'set',
       argsJson: ARGS,
       nonce,
-      notAfter: Math.floor(Date.now() / 1000) + 300,
+      notAfter,
       deviceSecret: device.secret,
     });
+  }
+
+  /** A deadline that outlasts the request without being unbounded. */
+  function deadline(): number {
+    return Math.floor(Date.now() / 1000) + 300;
+  }
+
+  /** The same warrant as `merod` mints it, for the byte comparison. */
+  function mintWarrantWithMerod(nonce: number, notAfter: number): string {
+    return merod([
+      'account',
+      'warrant',
+      '--context',
+      contextId,
+      '--method',
+      'set',
+      '--args',
+      JSON.stringify(ARGS),
+      '--executor',
+      relayAccount,
+      '--nonce',
+      String(nonce),
+      '--not-after',
+      String(notAfter),
+      '--device-secret',
+      device.secret,
+      '--credential',
+      device.credential,
+    ]).trim();
   }
 
 });


### PR DESCRIPTION
> **Merge after** calimero-network/mero-js#121, and after a core release carrying `merod account warrant --not-after` — calimero-network/core#3698 cut `rc.28` for that.

## What happened

#120 landed with only its first commit. The byte-comparison test and its follow-up fix were pushed to the branch but are **not on master**:

```
origin/feat/signer-e2e:  3d8038e  sign the warrant with this SDK   ← on master
                         4a77cac  diff against merod, byte for byte ← missing
                         3bedb7d  await the assertion               ← missing
```

Master's `delegated-intent.test.ts` has 4 `it` blocks, not 5, and its header still explains why a byte comparison "is deliberately absent" — which was true when written and is now merely stale.

I reported this check as done. It was *verified* — the paired run on core#3697 exercised it against a real node and it passed — but verifying a test once is not the same as landing it, and I conflated the two.

## What this restores

Minting the same warrant through `signWarrant` and through `merod account warrant --not-after`, then comparing the hex.

Node acceptance proves a node took *those* bytes for *that* intent. It says nothing about a field the two implementations encode differently that the single test input never reaches, and when they do diverge it surfaces as an opaque 4xx naming nothing. A hex diff fails *at* the divergence — which is what makes "a borsh encoding kept byte-identical with the node's forever" checkable rather than hoped for.

The second commit matters on its own: the assertion was written `expect(...).resolves` without `await`. Vitest auto-awaits today so it really did compare, but it stops asserting in Vitest 3 — a test that quietly stops testing, in the one place that would otherwise catch nothing else.

313 unit tests, `tsc --noEmit`, build and lint all clean.