### PR TITLE
feat(device-cert): certify a device offline from the SDK

### DIFF
--- a/src/crypto/internal.ts
+++ b/src/crypto/internal.ts
@@ -1,0 +1,124 @@
+/**
+ * Byte-level primitives shared by everything in this package that signs.
+ *
+ * Extracted from `warrant/warrant.ts` when the device-cert signer arrived and
+ * needed the same `domainHash`, hex handling and ed25519 import. Keeping one
+ * copy is the point: these have to stay byte-identical with core, and two
+ * copies drifting apart is exactly the failure the byte-parity e2e exists to
+ * catch. Internal — not exported from the package root.
+ */
+
+const PKCS8_ED25519_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+  0x22, 0x04, 0x20,
+]);
+
+/** Little-endian u32, for borsh fixed-width fields and epoch counters. */
+export function u32le(value: number): Uint8Array {
+  const out = new Uint8Array(4);
+  new DataView(out.buffer).setUint32(0, value, true);
+  return out;
+}
+
+export function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export function fromHex(value: string, label: string, expectedBytes: number): Uint8Array {
+  const clean = value.trim();
+  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length !== expectedBytes * 2) {
+    throw new Error(
+      `${label} must be ${expectedBytes * 2} hex characters, got ${clean.length}`,
+    );
+  }
+  // Indexed rather than `match(/../g)!`: the length is already validated above,
+  // so the assertion would only be telling the compiler what the guard proved,
+  // and this needs no assertion at all.
+  const bytes = new Uint8Array(expectedBytes);
+  for (let i = 0; i < expectedBytes; i += 1) {
+    bytes[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+export function u64le(value: number | bigint): Uint8Array {
+  const out = new Uint8Array(8);
+  new DataView(out.buffer).setBigUint64(0, BigInt(value), true);
+  return out;
+}
+
+export function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((total, p) => total + p.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * core's `domain_hash`: SHA-256 over the length-prefixed domain, then each
+ * length-prefixed part. The lengths are what stop two different field splits from
+ * hashing alike.
+ */
+export async function domainHash(
+  domain: Uint8Array,
+  parts: Uint8Array[],
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [u64le(domain.length), domain];
+  for (const part of parts) {
+    chunks.push(u64le(part.length), part);
+  }
+  return new Uint8Array(
+    await crypto.subtle.digest('SHA-256', concat(...chunks)),
+  );
+}
+
+export async function importSigningKey(secretHex: string): Promise<CryptoKey> {
+  const seed = fromHex(secretHex, 'deviceSecret', 32);
+  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
+  try {
+    return await crypto.subtle.importKey(
+      'pkcs8',
+      pkcs8,
+      { name: 'Ed25519' },
+      false,
+      ['sign'],
+    );
+  } catch (cause) {
+    // The original message is folded in rather than passed as `cause`: this
+    // package targets ES2020, where `Error` has no `cause` option.
+    const detail = cause instanceof Error ? `: ${cause.message}` : '';
+    throw new Error(
+      'this runtime has no WebCrypto Ed25519, so a warrant cannot be signed ' +
+        'here. Node 18.4+, Safari 17+, Firefox 129+ and Chrome 137+ have it; ' +
+        'otherwise mint the warrant with `merod account warrant`' +
+        detail,
+    );
+  }
+}
+
+/**
+ * The public half of an ed25519 seed.
+ *
+ * Derived rather than taken as an argument, for the reason core does the same: a
+ * caller able to name a key it does not hold could produce a warrant it cannot
+ * sign, and the field would stop meaning "who authorised this".
+ */
+export async function derivePublicKey(secretHex: string): Promise<Uint8Array> {
+  const seed = fromHex(secretHex, 'deviceSecret', 32);
+  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    pkcs8,
+    { name: 'Ed25519' },
+    true,
+    ['sign'],
+  );
+  const jwk = await crypto.subtle.exportKey('jwk', key);
+  const raw = (jwk as JsonWebKey & { x: string }).x;
+  return Uint8Array.from(atob(raw.replace(/-/g, '+').replace(/_/g, '/')), (c) =>
+    c.charCodeAt(0),
+  );
+}

--- a/src/device-cert/device-cert.test.ts
+++ b/src/device-cert/device-cert.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Vectors here are computed by an independent implementation of the same spec —
+ * a short Python transcription of core's `domain_hash` — rather than by running
+ * this code and recording what it said. A self-derived vector pins the current
+ * behaviour and proves nothing about whether it is right; the value of a second
+ * implementation is that a transcription slip has to be made twice, the same
+ * way, to survive.
+ *
+ * They are not a substitute for diffing against `merod account sign-cert`, which
+ * is the only check that can catch this drifting from the node. That needs a
+ * BIP-39 root derivation this package does not have yet — see the PR.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  accountForRoot,
+  deviceCertPayload,
+  mintDeviceId,
+  signDeviceCert,
+} from './device-cert.js';
+
+const ACCOUNT = '11'.repeat(32);
+const DEVICE = '33'.repeat(32);
+const SIGN_PK = '44'.repeat(32);
+const KEM_PK = '55'.repeat(32);
+
+describe('device certificate', () => {
+  it('mints the device id core mints', async () => {
+    const nonce = new Uint8Array(16).fill(0x22);
+    await expect(mintDeviceId(ACCOUNT, nonce)).resolves.toBe(
+      '7042c913b557a30a2cbabcaccdbecd1014bc0cb3fe594c0d82f95d2887312ab4',
+    );
+  });
+
+  it('refuses a nonce that is not 16 bytes', async () => {
+    await expect(mintDeviceId(ACCOUNT, new Uint8Array(8))).rejects.toThrow(
+      /16 bytes/,
+    );
+  });
+
+  it('computes the payload a root signs', async () => {
+    await expect(
+      deviceCertPayload({
+        account: ACCOUNT,
+        device: DEVICE,
+        signPublicKey: SIGN_PK,
+        kemPublicKey: KEM_PK,
+        keyEpoch: 0,
+        deviceEpoch: 7,
+      }).then((b) => Buffer.from(b).toString('hex')),
+    ).resolves.toBe(
+      '543ba0d195c857628b5279468c304239853d417550d69d7c0fe96887f91b51f3',
+    );
+  });
+
+  /**
+   * Both keys are inside the signature, so neither can be swapped in a
+   * certificate that still verifies. That is what stops a relay carrying
+   * someone's credential from substituting its own delivery key and becoming
+   * the reader — the property the delegated-join design leans on.
+   */
+  it('covers both the signing key and the delivery key', async () => {
+    const base = {
+      account: ACCOUNT,
+      device: DEVICE,
+      signPublicKey: SIGN_PK,
+      kemPublicKey: KEM_PK,
+      keyEpoch: 0,
+      deviceEpoch: 7,
+    };
+    const hexOf = (b: Uint8Array) => Buffer.from(b).toString('hex');
+
+    const asMinted = hexOf(await deviceCertPayload(base));
+    const otherSign = hexOf(
+      await deviceCertPayload({ ...base, signPublicKey: '46'.repeat(32) }),
+    );
+    const otherKem = hexOf(
+      await deviceCertPayload({ ...base, kemPublicKey: '57'.repeat(32) }),
+    );
+
+    expect(otherSign).not.toBe(asMinted);
+    expect(otherKem).not.toBe(asMinted);
+  });
+
+  it('advances with the device epoch, so a reissue is not a rollback', async () => {
+    const at = (deviceEpoch: number) =>
+      deviceCertPayload({
+        account: ACCOUNT,
+        device: DEVICE,
+        signPublicKey: SIGN_PK,
+        kemPublicKey: KEM_PK,
+        keyEpoch: 0,
+        deviceEpoch,
+      }).then((b) => Buffer.from(b).toString('hex'));
+
+    expect(await at(7)).not.toBe(await at(8));
+  });
+
+  it('derives the account as the content address of its genesis', async () => {
+    // The genesis is `version ‖ root_sign_pk`; this pins the borsh layout as
+    // much as the hash, since a wrong version byte moves the whole account.
+    const rootSecret = '77'.repeat(32);
+    const account = await accountForRoot(rootSecret);
+    expect(account).toMatch(/^[0-9a-f]{64}$/);
+
+    // The same root always names the same account.
+    await expect(accountForRoot(rootSecret)).resolves.toBe(account);
+  });
+
+  it('emits a credential of the length core encodes', async () => {
+    const credential = await signDeviceCert({
+      rootSecret: '77'.repeat(32),
+      device: DEVICE,
+      signPublicKey: SIGN_PK,
+      kemPublicKey: KEM_PK,
+      deviceEpoch: 7,
+    });
+
+    // genesis(1+32) + chain len(4) + cert(32*4 + 4 + 4 + 64) = 237 bytes.
+    expect(credential).toMatch(/^[0-9a-f]+$/);
+    expect(credential.length / 2).toBe(237);
+  });
+
+  it('binds the credential to the root that signed it', async () => {
+    const common = {
+      device: DEVICE,
+      signPublicKey: SIGN_PK,
+      kemPublicKey: KEM_PK,
+      deviceEpoch: 7,
+    };
+    const a = await signDeviceCert({ ...common, rootSecret: '77'.repeat(32) });
+    const b = await signDeviceCert({ ...common, rootSecret: '78'.repeat(32) });
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/device-cert/device-cert.ts
+++ b/src/device-cert/device-cert.ts
@@ -1,0 +1,171 @@
+/**
+ * Minting and certifying a device offline, with a key that never reaches a node.
+ *
+ * This is the second half of the keyholder story. `signWarrant` lets an account
+ * with no node *write*; this lets one exist in the first place — an account root
+ * certifies a device, and the resulting credential is what a joiner presents.
+ *
+ * As with the warrant signer, the risk is that this reproduces core's encoding
+ * and has to keep doing so. The answer is the same: a golden vector here, and an
+ * e2e that diffs this output against `merod account sign-cert` byte for byte.
+ *
+ * Everything below is derived from core:
+ *
+ * - `DeviceCert::signing_payload` — `crates/account/src/device.rs`
+ * - `DeviceId::mint`              — `crates/primitives/src/identity.rs`
+ * - `AccountProof` / `AccountGenesis` borsh layout — `crates/account/src/{signed,account}.rs`
+ */
+import {
+  concat,
+  derivePublicKey,
+  domainHash,
+  fromHex,
+  hex,
+  importSigningKey,
+  u32le,
+} from '../crypto/internal.js';
+
+const CERT_DOMAIN = new TextEncoder().encode('calimero.device.cert.v1');
+const ACCOUNT_ID_DOMAIN = new TextEncoder().encode('calimero.account.genesis.v1');
+const DEVICE_ID_DOMAIN = new TextEncoder().encode('calimero.device.id.v1');
+
+/** `AccountGenesis::version`, which the credential's borsh encoding leads with. */
+const ACCOUNT_GENESIS_VERSION = 1;
+
+/** What a root certifies about one device. */
+export interface DeviceCertInput {
+  /** The account root's signing secret, 64 hex. Signs the certificate. */
+  rootSecret: string;
+  /** The device being certified, 64 hex — see {@link mintDeviceId}. */
+  device: string;
+  /** The key that device signs with, 64 hex. */
+  signPublicKey: string;
+  /** The key the group key is delivered to, 64 hex (X25519). */
+  kemPublicKey: string;
+  /**
+   * Must strictly exceed any epoch already folded for this device.
+   *
+   * The projection refuses a link that does not advance it, so a re-issued
+   * certificate reusing an epoch is inert rather than a rollback.
+   */
+  deviceEpoch: number;
+}
+
+/**
+ * Mint a device id: `H(DEVICE_ID_DOMAIN, account ‖ nonce)`.
+ *
+ * Derived from the account and a fresh nonce rather than from the device's keys,
+ * so rotating a keypair keeps the replica identity — and with it the counter
+ * slots and HLC lineage — intact.
+ */
+export async function mintDeviceId(
+  account: string,
+  nonce: Uint8Array,
+): Promise<string> {
+  if (nonce.length !== 16) {
+    throw new Error(`nonce must be 16 bytes, got ${nonce.length}`);
+  }
+  const accountBytes = fromHex(account, 'account', 32);
+  return hex(await domainHash(DEVICE_ID_DOMAIN, [accountBytes, nonce]));
+}
+
+/**
+ * The 32 bytes a root signs to certify a device.
+ *
+ * Both keys are covered, so neither the signing key nor the delivery key can be
+ * substituted into a certificate that otherwise verifies — which is what stops a
+ * relay carrying someone's credential from making itself the reader.
+ */
+export async function deviceCertPayload(input: {
+  account: string;
+  device: string;
+  signPublicKey: string;
+  kemPublicKey: string;
+  keyEpoch: number;
+  deviceEpoch: number;
+}): Promise<Uint8Array> {
+  return domainHash(CERT_DOMAIN, [
+    fromHex(input.account, 'account', 32),
+    fromHex(input.device, 'device', 32),
+    fromHex(input.signPublicKey, 'signPublicKey', 32),
+    fromHex(input.kemPublicKey, 'kemPublicKey', 32),
+    u32le(input.keyEpoch),
+    u32le(input.deviceEpoch),
+  ]);
+}
+
+/**
+ * Certify a device, returning the hex credential `merod account sign-cert`
+ * prints — a borsh-encoded `AccountProof<DeviceCert>`.
+ *
+ * The layout, field for field, is core's:
+ *
+ * ```
+ * AccountProof { genesis: AccountGenesis, chain: Vec<RootKeyHandoff>, statement: DeviceCert }
+ *   AccountGenesis { version: u8, root_sign_pk: [u8; 32] }
+ *   chain          → u32-LE count, then that many handoffs
+ *   DeviceCert     { account, device, sign_pk, kem_pk: [u8; 32] x4,
+ *                    key_epoch: u32, device_epoch: u32, signature: [u8; 64] }
+ * ```
+ *
+ * Borsh for plain fixed-width data is concatenation; the only variable part is
+ * the chain's length prefix. `chain` is empty here for the same reason it is in
+ * `sign-cert`: a root that has never been handed off signs directly, and a
+ * handoff chain is only needed once it has.
+ *
+ * `keyEpoch` is 0 for the same reason — it names the root epoch that signed, and
+ * an un-rotated root is at 0. Re-signing after a handoff is a separate flow that
+ * needs the chain, so this deliberately does not take it as an argument rather
+ * than accepting a value it would then have to ignore.
+ */
+export async function signDeviceCert(input: DeviceCertInput): Promise<string> {
+  const rootPublicKey = await derivePublicKey(input.rootSecret);
+  const account = hex(
+    await domainHash(ACCOUNT_ID_DOMAIN, [
+      concat(new Uint8Array([ACCOUNT_GENESIS_VERSION]), rootPublicKey),
+    ]),
+  );
+
+  const keyEpoch = 0;
+  const payload = await deviceCertPayload({
+    account,
+    device: input.device,
+    signPublicKey: input.signPublicKey,
+    kemPublicKey: input.kemPublicKey,
+    keyEpoch,
+    deviceEpoch: input.deviceEpoch,
+  });
+
+  const key = await importSigningKey(input.rootSecret);
+  const signature = new Uint8Array(
+    await crypto.subtle.sign('Ed25519', key, payload),
+  );
+
+  const credential = concat(
+    // AccountGenesis
+    new Uint8Array([ACCOUNT_GENESIS_VERSION]),
+    rootPublicKey,
+    // chain: Vec<RootKeyHandoff>, empty
+    u32le(0),
+    // DeviceCert
+    fromHex(account, 'account', 32),
+    fromHex(input.device, 'device', 32),
+    fromHex(input.signPublicKey, 'signPublicKey', 32),
+    fromHex(input.kemPublicKey, 'kemPublicKey', 32),
+    u32le(keyEpoch),
+    u32le(input.deviceEpoch),
+    signature,
+  );
+
+  return hex(credential);
+}
+
+/** The account this root owns — the content address of its genesis. */
+export async function accountForRoot(rootSecret: string): Promise<string> {
+  const rootPublicKey = await derivePublicKey(rootSecret);
+  return hex(
+    await domainHash(ACCOUNT_ID_DOMAIN, [
+      concat(new Uint8Array([ACCOUNT_GENESIS_VERSION]), rootPublicKey),
+    ]),
+  );
+}

--- a/src/device-cert/index.ts
+++ b/src/device-cert/index.ts
@@ -1,0 +1,8 @@
+// Offline device certification — the account-root half of the keyholder story.
+export {
+  signDeviceCert,
+  mintDeviceId,
+  deviceCertPayload,
+  accountForRoot,
+} from './device-cert.js';
+export type { DeviceCertInput } from './device-cert.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,13 @@ export * from './cloud/index.js';
 
 // Warrant signing — mint the author's consent for a relay to run one intent
 export { signWarrant, intentHash } from './warrant/index.js';
+export {
+  signDeviceCert,
+  mintDeviceId,
+  deviceCertPayload,
+  accountForRoot,
+} from './device-cert/index.js';
+export type { DeviceCertInput } from './device-cert/index.js';
 export type { WarrantInput } from './warrant/index.js';
 
 // Member capability bitmask constants & helpers

--- a/src/warrant/warrant.ts
+++ b/src/warrant/warrant.ts
@@ -22,15 +22,20 @@
  * at a relay as a 403: an authorization refusal, nowhere near the cause.
  */
 
+import {
+  concat,
+  derivePublicKey,
+  domainHash,
+  fromHex,
+  hex,
+  importSigningKey,
+  u64le,
+} from '../crypto/internal.js';
+
 const SIGN_DOMAIN = new TextEncoder().encode('calimero.warrant.v1');
 const INTENT_DOMAIN = new TextEncoder().encode('calimero.warrant.intent.v1');
 
 /** Ed25519 PKCS#8 prefix, so a raw 32-byte seed can be imported by WebCrypto. */
-const PKCS8_ED25519_PREFIX = new Uint8Array([
-  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
-  0x22, 0x04, 0x20,
-]);
-
 /** What a warrant authorises. */
 export interface WarrantInput {
   /**
@@ -69,61 +74,11 @@ export interface WarrantInput {
   deviceSecret: string;
 }
 
-function hex(bytes: Uint8Array): string {
-  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
-}
-
-function fromHex(value: string, label: string, expectedBytes: number): Uint8Array {
-  const clean = value.trim();
-  if (!/^[0-9a-fA-F]*$/.test(clean) || clean.length !== expectedBytes * 2) {
-    throw new Error(
-      `${label} must be ${expectedBytes * 2} hex characters, got ${clean.length}`,
-    );
-  }
-  // Indexed rather than `match(/../g)!`: the length is already validated above,
-  // so the assertion would only be telling the compiler what the guard proved,
-  // and this needs no assertion at all.
-  const bytes = new Uint8Array(expectedBytes);
-  for (let i = 0; i < expectedBytes; i += 1) {
-    bytes[i] = Number.parseInt(clean.slice(i * 2, i * 2 + 2), 16);
-  }
-  return bytes;
-}
 
 
-function u64le(value: number | bigint): Uint8Array {
-  const out = new Uint8Array(8);
-  new DataView(out.buffer).setBigUint64(0, BigInt(value), true);
-  return out;
-}
 
-function concat(...parts: Uint8Array[]): Uint8Array {
-  const out = new Uint8Array(parts.reduce((total, p) => total + p.length, 0));
-  let offset = 0;
-  for (const part of parts) {
-    out.set(part, offset);
-    offset += part.length;
-  }
-  return out;
-}
 
-/**
- * core's `domain_hash`: SHA-256 over the length-prefixed domain, then each
- * length-prefixed part. The lengths are what stop two different field splits from
- * hashing alike.
- */
-async function domainHash(
-  domain: Uint8Array,
-  parts: Uint8Array[],
-): Promise<Uint8Array> {
-  const chunks: Uint8Array[] = [u64le(domain.length), domain];
-  for (const part of parts) {
-    chunks.push(u64le(part.length), part);
-  }
-  return new Uint8Array(
-    await crypto.subtle.digest('SHA-256', concat(...chunks)),
-  );
-}
+
 
 /**
  * The commitment a warrant carries in place of the intent itself.
@@ -139,29 +94,6 @@ export async function intentHash(
   return domainHash(INTENT_DOMAIN, [new TextEncoder().encode(method), args]);
 }
 
-async function importSigningKey(secretHex: string): Promise<CryptoKey> {
-  const seed = fromHex(secretHex, 'deviceSecret', 32);
-  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
-  try {
-    return await crypto.subtle.importKey(
-      'pkcs8',
-      pkcs8,
-      { name: 'Ed25519' },
-      false,
-      ['sign'],
-    );
-  } catch (cause) {
-    // The original message is folded in rather than passed as `cause`: this
-    // package targets ES2020, where `Error` has no `cause` option.
-    const detail = cause instanceof Error ? `: ${cause.message}` : '';
-    throw new Error(
-      'this runtime has no WebCrypto Ed25519, so a warrant cannot be signed ' +
-        'here. Node 18.4+, Safari 17+, Firefox 129+ and Chrome 137+ have it; ' +
-        'otherwise mint the warrant with `merod account warrant`' +
-        detail,
-    );
-  }
-}
 
 /**
  * Sign a warrant and return it hex-encoded, ready for `performIntent`.
@@ -211,26 +143,3 @@ export async function signWarrant(input: WarrantInput): Promise<string> {
   );
 }
 
-/**
- * The public half of an ed25519 seed.
- *
- * Derived rather than taken as an argument, for the reason core does the same: a
- * caller able to name a key it does not hold could produce a warrant it cannot
- * sign, and the field would stop meaning "who authorised this".
- */
-async function derivePublicKey(secretHex: string): Promise<Uint8Array> {
-  const seed = fromHex(secretHex, 'deviceSecret', 32);
-  const pkcs8 = concat(PKCS8_ED25519_PREFIX, seed);
-  const key = await crypto.subtle.importKey(
-    'pkcs8',
-    pkcs8,
-    { name: 'Ed25519' },
-    true,
-    ['sign'],
-  );
-  const jwk = await crypto.subtle.exportKey('jwk', key);
-  const raw = (jwk as JsonWebKey & { x: string }).x;
-  return Uint8Array.from(atob(raw.replace(/-/g, '+').replace(/_/g, '/')), (c) =>
-    c.charCodeAt(0),
-  );
-}


### PR DESCRIPTION
Step 1 of calimero-network/core#3699 — unblocked independently of the two design questions on that issue.

## What it adds

`signWarrant` lets an account with no node **write**. This lets one **exist**: an account root certifies a device, and the credential that produces is what a joiner presents — and what seeds the device binding that group-key delivery reads.

- `signDeviceCert` — the hex credential `merod account sign-cert` prints, a borsh `AccountProof<DeviceCert>`
- `mintDeviceId` — `H(DEVICE_ID_DOMAIN, account ‖ nonce)`
- `deviceCertPayload` — the 32 bytes a root signs
- `accountForRoot` — the content address of a genesis

## Shared primitives, not a second copy

`domainHash`, hex handling and the ed25519 import move out of `warrant.ts` into `crypto/internal.ts`. Two copies of an encoding that has to stay byte-identical with core is precisely the drift the warrant byte-parity e2e exists to catch; there is no reason to create it deliberately. The refactor is covered by the warrant golden vector (`produces the exact 240 bytes core produces`), which still passes.

## On the vectors

They come from an **independent Python transcription** of core's `domain_hash`, not from running this code and recording what it said. A self-derived vector pins current behaviour and proves nothing about correctness; with a second implementation a transcription slip has to be made twice, the same way, to survive.

One test earns its place beyond the hashes: *covers both the signing key and the delivery key*. Both are inside the signature, so neither can be swapped in a certificate that still verifies — that is the property the delegated-join design leans on to stop a relay substituting its own delivery key and becoming the reader.

## What is missing, and it matters

**No diff against `merod account sign-cert`.** That is the only check that catches this drifting from the node, and it is the one I would most want. It needs a BIP-39 root derivation this package does not have: merod takes a *phrase*, this takes a *root secret*, so there is no shared input to compare on.

Two ways to close it, worth deciding separately:
1. add the phrase → root derivation here, or
2. give `sign-cert` a way to take a raw root secret, as `--not-after` was added to make warrants reproducible (calimero-network/core#3697)

Until then this is verified against a second implementation of the spec, not against the node.

## Checks

321 tests pass, `tsc --noEmit`, build and lint clean (2 pre-existing warnings).