### PR TITLE
feat(admin-api): present a signed join to a designated admitter

### DIFF
--- a/src/admin-api/admin-client.ts
+++ b/src/admin-api/admin-client.ts
@@ -102,6 +102,8 @@ import type {
   TeeVerifyQuoteResponseData,
   PerformIntentRequest,
   PerformIntentResponseData,
+  AdmitJoinRequest,
+  AdmitJoinResponseData,
 } from './admin-types.js';
 
 /**
@@ -737,6 +739,36 @@ export class AdminApiClient {
       await this.httpClient.post<{ data: CreateNamespaceInvitationResponseData | CreateRecursiveInvitationResponseData }>(
         `/admin-api/namespaces/${namespaceId}/invite`,
         request ?? {},
+      ),
+    );
+  }
+
+  /**
+   * Present a join this caller signed to a node the inviter named as an
+   * admitter.
+   *
+   * For a member with no node. `joinNamespace` publishes the membership op from
+   * the node making the call; this hands an already-signed op to somebody else's
+   * node to publish. The distinction matters because a keyholder has nowhere to
+   * publish from.
+   *
+   * The op must be signed by the **device key** in the credential it carries —
+   * every peer checks that when applying a join. So the admitter cannot author
+   * this, only carry it: a hostile one can refuse, and nothing else. It cannot
+   * admit a different account, change the group, or grant a role.
+   *
+   * @param namespaceId the namespace being joined, 64 hex
+   * @param request the invitation and the hex-encoded signed op
+   */
+  async admitJoin(
+    namespaceId: string,
+    request: AdmitJoinRequest,
+  ): Promise<AdmitJoinResponseData> {
+    return unwrap(
+      await this.httpClient.post<{ data: AdmitJoinResponseData }>(
+        `/admin-api/namespaces/${namespaceId}/admit`,
+        request,
+        { timeoutMs: 65000 },
       ),
     );
   }

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -336,7 +336,8 @@ export interface GroupInvitationFromAdmin {
   readonly secret_salt: number[];
   readonly invited_role: number;
   /**
-   * Accounts permitted to admit a claim of this invitation, 32 bytes each.
+   * Accounts permitted to admit a claim of this invitation, 64 hex characters
+   * each — the same spelling every other account-addressing field uses.
    *
    * Empty means admission by broadcast: the joiner announces itself on the
    * namespace topic and any ready peer answers — which publishes the invitation
@@ -345,7 +346,7 @@ export interface GroupInvitationFromAdmin {
    *
    * Inside the inviter's signature, so it cannot be redirected.
    */
-  readonly admitters?: number[][];
+  readonly admitters?: readonly string[];
 }
 
 /**

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -1027,6 +1027,18 @@ export interface CreateGroupInvitationRequest {
   requester?: string;
   expirationTimestamp?: number;
   recursive?: boolean;
+  /**
+   * Accounts permitted to admit a claim of this invitation, 64 hex each.
+   *
+   * Omitted or empty leaves admission open to broadcast, which publishes the
+   * invitation to every subscriber of the namespace topic. Naming admitters
+   * keeps it off the topic: the joiner presents the claim to one of them and
+   * every other peer refuses to answer for it.
+   *
+   * Core signs this list into the invitation, so it cannot be redirected after
+   * the fact.
+   */
+  admitters?: string[];
 }
 
 export interface CreateGroupInvitationResponseData {

--- a/src/admin-api/admin-types.ts
+++ b/src/admin-api/admin-types.ts
@@ -335,6 +335,17 @@ export interface GroupInvitationFromAdmin {
   /** Per-invitation nonce; core keeps the legacy `secret_salt` wire name. */
   readonly secret_salt: number[];
   readonly invited_role: number;
+  /**
+   * Accounts permitted to admit a claim of this invitation, 32 bytes each.
+   *
+   * Empty means admission by broadcast: the joiner announces itself on the
+   * namespace topic and any ready peer answers — which publishes the invitation
+   * to every subscriber of that topic. Naming admitters keeps it off the topic,
+   * and the joiner presents it to one of them directly.
+   *
+   * Inside the inviter's signature, so it cannot be redirected.
+   */
+  readonly admitters?: number[][];
 }
 
 /**
@@ -356,6 +367,20 @@ export interface GroupInvitationFromAdmin {
 export interface SignedGroupOpenInvitation {
   readonly invitation: GroupInvitationFromAdmin;
   readonly inviter_signature: string;
+  /**
+   * Where to reach the accounts in {@link GroupInvitationFromAdmin.admitters}.
+   *
+   * Outside the signature, like the other bootstrap hints: an account is reached
+   * through a peer id, and a joiner that has synced nothing cannot resolve one.
+   * A wrong hint costs a failed connection — the admitting node still has to be
+   * in the signed list for its admission to count.
+   *
+   * `{ multiaddr }` for a joiner that runs a node, `{ url }` for one that holds
+   * only a key and reaches the admin API over HTTPS.
+   */
+  readonly admitter_hints?: ReadonlyArray<
+    { readonly multiaddr: string } | { readonly url: string }
+  >;
   /**
    * The account the inviter acts as, as 64 hex characters — not the
    * `inviter_identity` key inside the signed body is written in. Governance
@@ -1104,4 +1129,29 @@ export interface AdminApiClientConfig {
   baseUrl: string;
   getAuthToken?: () => Promise<string | undefined>;
   timeoutMs?: number;
+}
+
+/** A join signed by its subject, handed to an admitter to publish. */
+export interface AdmitJoinRequest {
+  /** The invitation being claimed. Must name the admitter in `admitters`. */
+  readonly invitation: SignedGroupOpenInvitation;
+  /**
+   * The signed `SignedNamespaceOp`, borsh-encoded and hex.
+   *
+   * Signed by the joiner's device key, which is what stops an admitter
+   * substituting a different member: peers check the op's signer against the
+   * credential the op carries.
+   */
+  readonly signedOp: string;
+}
+
+/** What the admitter did with it. */
+export interface AdmitJoinResponseData {
+  /**
+   * Whether the op reached the namespace topic.
+   *
+   * Not "joined" — membership lands when peers apply the op, which the admitter
+   * neither performs nor waits for.
+   */
+  readonly published: boolean;
 }

--- a/tests/e2e/admit-join.test.ts
+++ b/tests/e2e/admit-join.test.ts
@@ -1,0 +1,100 @@
+/**
+ * E2E for direct admission — naming who may admit a join, and handing a signed
+ * join to one of them.
+ *
+ * Covers `POST /admin-api/namespaces/:namespace_id/admit` and the `admitters`
+ * field on group invitations.
+ *
+ * What is proven here is the endpoint's refusals and the round trip of the
+ * signed `admitters` list. The happy path — a keyholder with no node signing its
+ * own membership op and getting admitted — needs this SDK to borsh-encode and
+ * sign a `SignedNamespaceOp`, which it cannot do yet. That signer is the
+ * follow-up; until it lands, no test here can claim a join succeeded, and none
+ * of them do.
+ *
+ * Run manually:
+ *   NODE_URL=http://localhost:4001 pnpm test:e2e
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { MeroJs } from '../../src/mero-js.js';
+import { resolveBaseUrl, resolveCreds, ensureApplication, runId } from './harness.js';
+
+const NODE_URL = resolveBaseUrl();
+const { username: USERNAME, password: PASSWORD } = resolveCreds();
+const RUN = runId();
+
+let mero: MeroJs;
+let namespaceId: string;
+let groupId: string;
+let selfAccount: string;
+
+describe('Direct admission E2E', () => {
+  beforeAll(async () => {
+    mero = new MeroJs({ baseUrl: NODE_URL });
+    await mero.authenticate({ username: USERNAME, password: PASSWORD });
+    const applicationId = await ensureApplication(mero);
+
+    const ns = await mero.admin.createNamespace({
+      name: `admit-${RUN}`,
+      applicationId,
+    });
+    namespaceId = ns.namespaceId;
+    groupId = ns.groupId;
+
+    selfAccount = (await mero.admin.getNodeIdentity()).accountId;
+    expect(selfAccount).toMatch(/^[0-9a-f]{64}$/);
+  }, 60000);
+
+  afterAll(() => {
+    mero?.destroy?.();
+  });
+
+  it('signs the admitter list into the invitation it returns', async () => {
+    const created = await mero.admin.createGroupInvitation(groupId, {
+      admitters: [selfAccount],
+    });
+    expect('invitation' in created).toBe(true);
+    if (!('invitation' in created)) return;
+
+    // 32 bytes, and the account we named — the list travels inside the
+    // inviter's signature, so a joiner can tell who is allowed to admit it
+    // without trusting whoever handed it the invitation.
+    const admitters = created.invitation.invitation.admitters;
+    expect(admitters).toBeDefined();
+    expect(admitters).toHaveLength(1);
+    expect(admitters?.[0]).toHaveLength(32);
+
+    const asHex = Buffer.from(admitters![0]!).toString('hex');
+    expect(asHex).toBe(selfAccount);
+  }, 30000);
+
+  it('refuses an op it cannot decode, rather than publishing it blind', async () => {
+    const created = await mero.admin.createGroupInvitation(groupId, {
+      admitters: [selfAccount],
+    });
+    if (!('invitation' in created)) throw new Error('expected a single invitation');
+
+    // A designated admitter publishes on its own connection, so relaying opaque
+    // bytes would make it an injector for the namespace topic. It decodes first.
+    await expect(
+      mero.admin.admitJoin(namespaceId, {
+        invitation: created.invitation,
+        signedOp: 'deadbeef',
+      }),
+    ).rejects.toThrow();
+  }, 30000);
+
+  it('refuses an empty op', async () => {
+    const created = await mero.admin.createGroupInvitation(groupId, {
+      admitters: [selfAccount],
+    });
+    if (!('invitation' in created)) throw new Error('expected a single invitation');
+
+    await expect(
+      mero.admin.admitJoin(namespaceId, {
+        invitation: created.invitation,
+        signedOp: '',
+      }),
+    ).rejects.toThrow();
+  }, 30000);
+});

--- a/tests/e2e/admit-join.test.ts
+++ b/tests/e2e/admit-join.test.ts
@@ -35,18 +35,20 @@ describe('Direct admission E2E', () => {
     const applicationId = await ensureApplication(mero);
 
     const ns = await mero.admin.createNamespace({
-      name: `admit-${RUN}`,
       applicationId,
+      name: `admit-${RUN}`,
     });
     namespaceId = ns.namespaceId;
-    groupId = ns.groupId;
+    // The namespace id *is* its root group id; there is no separate group to
+    // create or look up, and invitations are issued against the group.
+    groupId = namespaceId;
 
     selfAccount = (await mero.admin.getNodeIdentity()).accountId;
     expect(selfAccount).toMatch(/^[0-9a-f]{64}$/);
   }, 60000);
 
   afterAll(() => {
-    mero?.destroy?.();
+    mero?.close();
   });
 
   it('signs the admitter list into the invitation it returns', async () => {

--- a/tests/e2e/admit-join.test.ts
+++ b/tests/e2e/admit-join.test.ts
@@ -58,16 +58,14 @@ describe('Direct admission E2E', () => {
     expect('invitation' in created).toBe(true);
     if (!('invitation' in created)) return;
 
-    // 32 bytes, and the account we named — the list travels inside the
-    // inviter's signature, so a joiner can tell who is allowed to admit it
-    // without trusting whoever handed it the invitation.
+    // The account we named, spelled the way every other account field is: 64
+    // hex characters. The list travels inside the inviter's signature, so a
+    // joiner can tell who may admit it without trusting whoever passed it along.
     const admitters = created.invitation.invitation.admitters;
     expect(admitters).toBeDefined();
     expect(admitters).toHaveLength(1);
-    expect(admitters?.[0]).toHaveLength(32);
-
-    const asHex = Buffer.from(admitters![0]!).toString('hex');
-    expect(asHex).toBe(selfAccount);
+    expect(admitters?.[0]).toMatch(/^[0-9a-f]{64}$/);
+    expect(admitters?.[0]).toBe(selfAccount);
   }, 30000);
 
   it('refuses an op it cannot decode, rather than publishing it blind', async () => {


### PR DESCRIPTION
The SDK half of direct admission (calimero-network/core#3700). Pairs with core#3703, which adds the endpoint.

`joinNamespace` publishes the membership op from the node handling the call. A keyholder has no such node — it has an account, a device certificate signed offline, and nowhere to publish from. `admitJoin` hands an already-signed op to a node the inviter named as an admitter, and that node publishes it.

**Why handing over a signed op is safe.** The op is signed by the joiner's device key, and every peer checks `signer == credential.statement.sign_pk` when applying a join. So an admitter carries the claim and cannot author one: it can refuse to publish, and nothing else — not admit a different account, not change the group, not grant a role.

**What's in the types.** `admitters` sits inside the inviter's signature; `admitter_hints` sits outside it. Who may admit cannot be redirected; where to reach them is only a hint, and a wrong one costs a failed connection. The hint has to travel with the invitation at all because an account is addressed by peer id, and a joiner that has synced nothing cannot resolve one.

`published` is not `joined` — the admitter puts the op on the topic and does not wait for peers to apply it.

Verified: `tsc` clean, lint 0 errors, full suite green. The wire shapes were checked against the Rust structs rather than assumed — `signedOp` is camelCase per `rename_all` on the request struct, the nested invitation stays snake_case, and `AdmitterEndpoint` is externally tagged, giving `{ multiaddr }` / `{ url }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)